### PR TITLE
Added nroot (and pow that takes Rational) to Rational.

### DIFF
--- a/src/main/scala/numerics/math/ApproximationContext.scala
+++ b/src/main/scala/numerics/math/ApproximationContext.scala
@@ -1,0 +1,8 @@
+package numerics.math
+
+case class ApproximationContext[A](error: A)
+object ApproximationContext {
+  implicit def rational2error(q: Rational) = ApproximationContext(q)
+}
+
+


### PR DESCRIPTION
They require an implicit ApproximationContext[Rational] to bound the _absolute_ error, so you'll need to create one to use the methods.

The biggest issue right now is that, in the convergence rate proof, I assume the initial approximation is pretty good (within 1/n relative error of the real nroot), but my initial approximation is just Rational(ceil(num nroot k),floor(den nroot k)), which can't really guarantee that bound :-\ Mostly this isn't noticeable, as the real rate seems to be much better anyways.
