### PR TITLE
Fix bug with OrderedRingIsSign and add (again?) ConvertableTo.

### DIFF
--- a/src/main/scala/spire/algebra/Signed.scala
+++ b/src/main/scala/spire/algebra/Signed.scala
@@ -95,7 +95,7 @@ trait FloatIsSigned extends Signed[Float] {
 
 trait DoubleIsSigned extends Signed[Double] {
   // Note that math.signum(-1d) == -1 in 2.9.2.
-  override def signum(a: Double): Int = if (a == 0.0) 0 else mth.signum(a).toInt
+  override def signum(a: Double): Int = mth.signum(a).toInt
   def abs(a: Double): Double = if (a < 0.0) -a else a
 }
 

--- a/src/main/scala/spire/math/Convertable.scala
+++ b/src/main/scala/spire/math/Convertable.scala
@@ -146,6 +146,23 @@ trait ConvertableToReal extends ConvertableTo[Real] {
   def fromRational(a:Rational) = Real(a)
 }
 
+object ConvertableTo {
+  implicit object ConvertableToInt extends ConvertableToInt
+  implicit object ConvertableToLong extends ConvertableToLong
+  implicit object ConvertableToBigInt extends ConvertableToBigInt
+  implicit object ConvertableToFloat extends ConvertableToFloat
+  implicit object ConvertableToDouble extends ConvertableToDouble
+  implicit object ConvertableToBigDecimal extends ConvertableToBigDecimal
+  implicit object ConvertableToRational extends ConvertableToRational
+  implicit object ConvertableToReal extends ConvertableToReal
+
+  implicit def ConvertableToComplex[A]
+  (implicit fr: Fractional[A], tr: Trig[A]) = new ConvertableToComplex[A] {
+    val f = fr
+    val t = tr
+  }
+}
+
 trait ConvertableFrom[@specialized A] {
   def toByte(a:A): Byte
   def toShort(a:A): Short


### PR DESCRIPTION
I think the ConvertableTo companion object got deleted at some point, so I've re-added it. Also fixed a bug due to me not updating an Order[A].eq to Order[A].eqv (but of course, eq is still valid Scala). Switching to eqv was definitely a good idea!
