### PR TITLE
Fix merge sort when # of passes is even.

### DIFF
--- a/src/test/scala/spire/math/SortingTest.scala
+++ b/src/test/scala/spire/math/SortingTest.scala
@@ -5,8 +5,7 @@ import spire.math.fun._
 import org.scalatest.FunSuite
 
 class SortingTest extends FunSuite {
-  test("sort()") {
-    val before = Array(23, 1, 52, 64, 234, 623, 124, 421, 421)
+  def testSort(before: Array[Int]) = {
 
     val goal = before.clone()
     scala.util.Sorting.quickSort(goal)
@@ -14,11 +13,35 @@ class SortingTest extends FunSuite {
     val merged = before.clone()
     Sorting.mergeSort(merged)
 
-    val quicked = before.clone()
-    Sorting.mergeSort(quicked)
+    // val quicked = before.clone()
+    // Sorting.quickSort(quicked)
 
     // make sure our result is ok
     for (i <- 0 until before.length) assert(merged(i) === goal(i))
-    for (i <- 0 until before.length) assert(quicked(i) === goal(i))
+    // for (i <- 0 until before.length) assert(quicked(i) === goal(i))
+  }
+
+  test("sort empty array") {
+    testSort(Array[Int]())
+  }
+
+  test("sort singleton") {
+    testSort(Array[Int](1))
+  }
+
+  test("trivial sort") {
+    testSort(Array(2, 1))
+  }
+
+  test("sort 3 decreasing") {
+    testSort(Array(3, 2, 1))
+  }
+
+  test("sort()") {
+    testSort(Array(23, 1, 52, 64, 234, 623, 124, 421, 421))
+  }
+
+  test("sort 5 decreasing") {
+    testSort(Array(5, 4, 3, 2, 1))
   }
 }


### PR DESCRIPTION
This is sort of a different tack, so may or may not be worth merging all of it. The merge pass is slightly different. The main sort loop is in a tailrec. The sort that people call may do an initial in-place merge pass (width of 2) to ensure that the input array ends up with the final sorted list.
