### PR TITLE
Use Context.fresh to give unique term names in cfor macro.

### DIFF
--- a/src/main/scala/spire/macros/Syntax.scala
+++ b/src/main/scala/spire/macros/Syntax.scala
@@ -3,9 +3,6 @@ package spire.macrosk
 import scala.reflect.macros.Context
 
 object Syntax {
-  // used to give our labels, vars a somewhat unique identifier
-  var n: Int = 0
-
   def cforMacro[A:c.WeakTypeTag](c:Context)(init:c.Expr[A])
      (test:c.Expr[A => Boolean], next:c.Expr[A => A])
      (body:c.Expr[A => Unit]): c.Expr[Unit] = {
@@ -13,11 +10,8 @@ object Syntax {
 
     val c.WeakTypeTag(tpe) = implicitly[c.WeakTypeTag[A]]
 
-    // it would be good to do something smarter here
-    n = (n + 1) % 100000
-
-    val a = newTermName("a%d" format n)
-    val w = newTermName("w%d" format n)
+    val a = newTermName(c.fresh)
+    val w = newTermName(c.fresh)
 
     val tailrec = newTermName("tailrec")
 

--- a/src/test/scala/spire/SyntaxTest.scala
+++ b/src/test/scala/spire/SyntaxTest.scala
@@ -1,0 +1,28 @@
+package spire
+
+import spire.syntax._
+
+import org.scalatest.FunSuite
+
+import collection.mutable
+
+class SyntaxTest extends FunSuite {
+  test("simple cfor") {
+    val l = mutable.ListBuffer[Int]()    
+    cfor(0)(_ < 5, _ + 1) { x => 
+      l.append(x)
+    }
+
+    assert(l.toSeq === Seq(0,1,2,3,4))
+  }
+
+  test("nested cfor") {
+    val s = mutable.Set[Int]()
+    cfor(0)(_ < 10, _ + 1) { x =>
+      cfor(10)(_ < 100, _ + 10) { y =>
+        s.add(x+y)
+      }
+    }
+    assert(s.toSeq.sorted === (10 to 99))
+  }
+}


### PR DESCRIPTION
- Some simple unit tests for cfor.
- Note: Context.fresh is deprecated in 2.10.1 for Context.freshName
