### PR TITLE
Add k-means example using NormedVectorSpaces.

### DIFF
--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -66,7 +66,7 @@ object KMeansExample extends App {
         val counts = new Array[Int](clusters0.length)
         cfor(0)(_ < points.length, _ + 1) { i =>
           val idx = assignments(i)
-          clusters(idx) = clusters(i) + points(i)
+          clusters(idx) = clusters(idx) + points(i)
           counts(idx) += 1
         }
         cfor(0)(_ < clusters.length, _ + 1) { j =>


### PR DESCRIPTION
An illustrative example of why abstracting over vector spaces can make
our code more re-usable.
