### PR TITLE
Remove generic Eq from default implicits.

### DIFF
--- a/core/src/main/scala/spire/math/Eq.scala
+++ b/core/src/main/scala/spire/math/Eq.scala
@@ -22,7 +22,7 @@ final class EqOps[A](lhs:A)(implicit ev:Eq[A]) {
   def =!=(rhs:A) = macro Ops.binop[A, Boolean]
 }
 
-object Eq extends Eq2 with EqProductImplicits {
+object Eq extends Eq1 with EqProductImplicits {
   implicit object ByteEq extends ByteEq
   implicit object ShortEq extends ShortEq
   implicit object CharEq extends CharEq
@@ -43,6 +43,7 @@ object Eq extends Eq2 with EqProductImplicits {
   implicit object SafeLongEq extends SafeLongEq
   implicit object NaturalEq extends NaturalEq
   implicit object NumberEq extends NumberEq
+  implicit object StringEq extends StringEq
 
   def apply[A](implicit e:Eq[A]):Eq[A] = e
 
@@ -50,10 +51,6 @@ object Eq extends Eq2 with EqProductImplicits {
 }
 
 trait Eq0 {
-  implicit def generic[@spec A]: Eq[A] = new GenericEq[A]
-}
-
-trait Eq1 extends Eq0 {
   implicit def seq[A, CC[A] <: SeqLike[A, CC[A]]](implicit A0: Eq[A]) = {
     new SeqEq[A, CC[A]] {
       val A = A0
@@ -69,16 +66,12 @@ trait Eq1 extends Eq0 {
   }
 }
 
-trait Eq2 extends Eq1 {
+trait Eq1 extends Eq0 {
   implicit def array[@spec(Int,Long,Float,Double) A](implicit
       A0: Eq[A], ct: ClassTag[A]) = new ArrayEq[A] {
     val A = A0
     val classTag = ct
   }
-}
-
-private[this] class GenericEq[@spec A] extends Eq[A] {
-  def eqv(x:A, y:A): Boolean = x == y
 }
 
 trait ByteEq extends Eq[Byte] {
@@ -168,4 +161,7 @@ trait OptionEq[A] extends Eq[Option[A]] {
     case (None, None) => true
     case _ => false
   }
+}
+trait StringEq extends Eq[String] {
+  def eqv(x: String, y: String): Boolean = x == y
 }

--- a/core/src/main/scala/spire/package.scala
+++ b/core/src/main/scala/spire/package.scala
@@ -527,7 +527,19 @@ package object math {
   final def max[A](x: A, y: A)(implicit ev: Order[A]) = ev.max(x, y)
 }
 
+private[this] class GenericEq[@spec A] extends Eq[A] {
+  def eqv(x:A, y:A): Boolean = x == y
+}
+
 package optional {
+
+  /**
+   * This provides an implicit `Eq[A]` for any type `A` using Scala's (Java's)
+   * `==` (`equals`).
+   */
+  object genericEq {
+    implicit def generic[@spec A]: Eq[A] = new GenericEq[A]
+  }
 
   /**
    * This object provides implicit instances of Eq and Order for Seq-likes

--- a/examples/src/main/scala/spire/example/operators.scala
+++ b/examples/src/main/scala/spire/example/operators.scala
@@ -8,7 +8,7 @@ import spire.implicits._
 
 object Gcd {
   def gcd0[A:Integral](x: A, y: A): A =
-    if ((x % y) === 0) y else gcd0(y, x % y)
+    if ((x % y) === Integral[A].fromInt(0)) y else gcd0(y, x % y)
 
   def gcd1[A:EuclideanRing:Order](x: A, y: A): A =
     if (x % y === EuclideanRing[A].zero) y else gcd1(y, x % y)

--- a/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
+++ b/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
@@ -59,7 +59,7 @@ class LawTests extends LawChecker {
 
   checkAll("List is a Monoid", Laws[List[Int]].monoid)
   checkAll("Vector is a Monoid", Laws[Vector[Int]].monoid)
-  checkAll("Set is a Monoid", Laws[Set[Int]].monoid)
+  checkAll("Set is a Monoid", Laws[Set[Int]](spire.optional.genericEq.generic, implicitly).monoid)
   checkAll("String is a Monoid", Laws[String].monoid)
 }
 


### PR DESCRIPTION
This removes the generic Eq which makes an Eq[A] available for ANY type
A. While the implicit was low priority, it made it easy to make mistakes
like x === 0, where x is some type A. Eq[Any] would be inferred and we'd
use Scala's == rather than what we'd exepct.

The generic eq still lives, but it has been moved to
spire.optional.genericEq, which you must explicitly import to get.
