### PR TITLE
Add default implicit for Monoid[Array[A]].

### DIFF
--- a/core/src/main/scala/spire/algebra/Monoid.scala
+++ b/core/src/main/scala/spire/algebra/Monoid.scala
@@ -33,6 +33,7 @@ trait Monoid0 {
 
 trait Monoid1 extends Monoid0 with MonoidProductImplicits {
   implicit object StringMonoid extends StringMonoid
+  implicit def array[@spec A: ClassTag] = new ArrayMonoid[A]
 }
 
 trait OptionMonoid[A] extends Monoid[Option[A]] {

--- a/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
+++ b/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
@@ -61,6 +61,7 @@ class LawTests extends LawChecker {
   checkAll("Vector is a Monoid", Laws[Vector[Int]].monoid)
   checkAll("Set is a Monoid", Laws[Set[Int]](spire.optional.genericEq.generic, implicitly).monoid)
   checkAll("String is a Monoid", Laws[String].monoid)
+  checkAll("Array is a Monoid", Laws[Array[Int]].monoid)
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
Though there was an ArrayMonoid class, the implicit was missing. This
was just an oversight. The ArrayMonoid is now available implicitly.
