### PR TITLE
Easy constructor for additive/multiplicative groups.

### DIFF
--- a/core/src/main/scala/spire/algebra/Group.scala
+++ b/core/src/main/scala/spire/algebra/Group.scala
@@ -13,6 +13,10 @@ trait Group[@spec(Int,Long,Float,Double) A] extends Monoid[A] {
 
 object Group extends Group1 {
   @inline final def apply[A](implicit ev: Group[A]) = ev
+
+  @inline final def additive[A](implicit A: AdditiveGroup[A]) =  A.additive
+
+  @inline final def multiplicative[A](implicit A: MultiplicativeGroup[A]) = A.multiplicative
 }
 
 /**
@@ -22,6 +26,10 @@ trait AbGroup[@spec(Int,Long,Float,Double) A] extends Group[A]
 
 object AbGroup extends AbGroupProductImplicits {
   @inline final def apply[A](implicit ev: AbGroup[A]) = ev
+
+  @inline final def additive[A](implicit A: AdditiveAbGroup[A]) =  A.additive
+
+  @inline final def multiplicative[A](implicit A: MultiplicativeAbGroup[A]) = A.multiplicative
 }
 
 final class GroupOps[A](lhs:A)(implicit ev:Group[A]) {

--- a/core/src/main/scala/spire/algebra/Monoid.scala
+++ b/core/src/main/scala/spire/algebra/Monoid.scala
@@ -15,6 +15,10 @@ trait Monoid[@spec(Int,Long,Float,Double) A] extends Semigroup[A] {
 object Monoid extends Monoid1 {
   @inline final def apply[A](implicit m: Monoid[A]): Monoid[A] = m
 
+  @inline final def additive[A](implicit A: AdditiveMonoid[A]) = A.additive
+
+  @inline final def multiplicative[A](implicit A: MultiplicativeMonoid[A]) = A.multiplicative
+
   implicit def group[A: Group]: Monoid[A] = Group[A]
 }
 

--- a/core/src/main/scala/spire/algebra/Semigroup.scala
+++ b/core/src/main/scala/spire/algebra/Semigroup.scala
@@ -13,6 +13,10 @@ trait Semigroup[@spec(Int,Long,Float,Double) A] {
 
 object Semigroup extends Semigroup0 {
   @inline final def apply[A](implicit s: Semigroup[A]) = s
+
+  @inline final def additive[A](implicit A: AdditiveSemigroup[A]) =  A.additive
+
+  @inline final def multiplicative[A](implicit A: MultiplicativeSemigroup[A]) = A.multiplicative
 }
 
 trait Semigroup0 extends SemigroupProductImplicits {


### PR DESCRIPTION
This let's us easily grab the additive/multiplicative groups (and
monoids, semigroups) using, eg, Group.additive[Long]. It is nice because
we do not need to worry about the structure it comes from. For example,
Group.additive[Vector[Long]] works and you don't need to worry about
Module[Vector[Long], Long].
