### PR TITLE
Fix Syntax.cforMacro#isClean (see non/spire#75)

### DIFF
--- a/core/src/main/scala/spire/macros/Syntax.scala
+++ b/core/src/main/scala/spire/macros/Syntax.scala
@@ -14,7 +14,7 @@ object Syntax {
     val c.WeakTypeTag(tpe) = implicitly[c.WeakTypeTag[A]]
 
     def isClean(t: Tree): Boolean = t match {
-      case Ident(_) => true
+      case Ident(_: TermName) if t.symbol.asTerm.isStable => true
       case Function(_, _) => true
       case _ => false
     }

--- a/core/src/test/scala/spire/SyntaxTest.scala
+++ b/core/src/test/scala/spire/SyntaxTest.scala
@@ -48,6 +48,45 @@ class SyntaxTest extends FunSuite {
     assert(v == 111, s"v == $v")
     assert(b.toList === List(0, 1, 2), s"b.toList == ${b.toList}")
   }
+
+  test("functions with side effects function values in cfor") {
+    val b = mutable.ArrayBuffer.empty[Int]
+    var v = 0
+    def test: Int => Boolean = { v += 1; _ < 3 }
+    def incr: Int => Int = { v += 10; _ + 1}
+    def body: Int => Unit = {
+      v += 100
+      x => {
+        b += x
+      }
+    }
+    cfor(0)(test, incr)(body)
+    assert(v == 111, s"v == $v")
+    assert(b.toList === List(0, 1, 2), s"b.toList == ${b.toList}")
+  }
+
+  test("functions with side effects function by-value params in cfor") {
+    val b = mutable.ArrayBuffer.empty[Int]
+    var v = 0
+    def run(
+        test: => (Int => Boolean),
+        incr: => (Int => Int),
+        body: => (Int => Unit)) {
+      cfor(0)(test, incr)(body)
+    }
+    run(
+      { v += 1; _ < 3 },
+      { v += 10; _ + 1},
+      {
+        v += 100
+        x => {
+          b += x
+        }
+      }
+    )
+    assert(v == 111, s"v == $v")
+    assert(b.toList === List(0, 1, 2), s"b.toList == ${b.toList}")
+  }
   
   test("capture value in closure") {
     val b1 = collection.mutable.ArrayBuffer[() => Int]()


### PR DESCRIPTION
This attempts to complete the fix for non/spire#75.
The `isClean` method from 58dd318f41c9dd39d6a8f7c07f73b4c74c74a746 was a bit too optimistic: it can't rely on checking that the Tree is an Ident, it also needs to check that its Symbol is stable (see edge cases in diff of SyntaxTest).
