### PR TITLE
foundation for type class based means

### DIFF
--- a/core/src/main/scala/spire/stats/FractionalMeans.scala
+++ b/core/src/main/scala/spire/stats/FractionalMeans.scala
@@ -6,6 +6,22 @@ import scala.collection.GenTraversable
 
 import spire.math.Fractional
 
+object fractional {
+  implicit class FractionalMeansMA[M[_],A](val xs: M[A]) extends AnyVal {
+    def arithmeticMean(implicit fmeans: FractionalMeans[M], frac: Fractional[A]): A = fmeans.arithmeticMean(xs)
+    def arithmeticMeanBy[B](f: A ⇒ B)(implicit fmeans: FractionalMeans[M], frac: Fractional[B]): B = fmeans.arithmeticMeanBy(xs)(f)
+
+    def geometricMean(implicit fmeans: FractionalMeans[M], frac: Fractional[A]): A = fmeans.geometricMean(xs)
+    def geometricMeanBy[B](f: A ⇒ B)(implicit fmeans: FractionalMeans[M], frac: Fractional[B]): B = fmeans.geometricMeanBy(xs)(f)
+
+    def harmonicMean(implicit fmeans: FractionalMeans[M], frac: Fractional[A]): A = fmeans.harmonicMean(xs)
+    def harmonicMeanBy[B](f: A ⇒ B)(implicit fmeans: FractionalMeans[M], frac: Fractional[B]): B = fmeans.harmonicMeanBy(xs)(f)
+
+    def quadraticMean(implicit fmeans: FractionalMeans[M], frac: Fractional[A]): A = fmeans.quadraticMean(xs)
+    def quadraticMeanBy[B](f: A ⇒ B)(implicit fmeans: FractionalMeans[M], frac: Fractional[B]): B = fmeans.quadraticMeanBy(xs)(f)
+  }
+}
+
 trait FractionalMeans[M[_]] {
   def arithmeticMean[A:Fractional](xs: M[A]): A
   def arithmeticMeanBy[A,B:Fractional](xs: M[A])(f: A ⇒ B): B

--- a/core/src/main/scala/spire/stats/FractionalMeans.scala
+++ b/core/src/main/scala/spire/stats/FractionalMeans.scala
@@ -31,42 +31,42 @@ object FractionalMeans extends FractionalMeans0 {
 trait ArrayFractionalMeans extends FractionalMeans[Array] {
   def arithmeticMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
     val sum = xs.foldLeft(num.zero)(num.plus)
-    num.div(sum, num.fromInt(xs.size))
+    num.div(sum, num.fromInt(xs.length))
   }
 
   def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
-    num.div(sum, num.fromInt(xs.size))
+    num.div(sum, num.fromInt(xs.length))
   }
 
   def geometricMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
     val prod = xs.foldLeft(num.one)(num.times)
-    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.length)))
   }
 
   def geometricMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
     val prod = xs.foldLeft(num.one)((b,a) ⇒ num.times(b, f(a)))
-    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.length)))
   }
 
   def harmonicMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
     val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)))
-    num.div(num.fromInt(xs.size), sum)
+    num.div(num.fromInt(xs.length), sum)
   }
 
   def harmonicMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))))
-    num.div(num.fromInt(xs.size), sum)
+    num.div(num.fromInt(xs.length), sum)
   }
 
   def quadraticMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
     val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)))
-    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+    num.sqrt(num.div(sum, num.fromInt(xs.length)))
   }
 
   def quadraticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)))
-    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+    num.sqrt(num.div(sum, num.fromInt(xs.length)))
   }
 }
 

--- a/core/src/main/scala/spire/stats/FractionalMeans.scala
+++ b/core/src/main/scala/spire/stats/FractionalMeans.scala
@@ -1,0 +1,113 @@
+package spire.stats
+
+import language.higherKinds
+
+import scala.collection.GenTraversable
+
+import spire.math.Fractional
+
+trait FractionalMeans[M[_]] {
+  def arithmeticMean[A:Fractional](xs: M[A]): A
+  def arithmeticMeanBy[A,B:Fractional](xs: M[A])(f: A ⇒ B): B
+
+  def geometricMean[A:Fractional](xs: M[A]): A
+  def geometricMeanBy[A,B:Fractional](xs: M[A])(f: A ⇒ B): B
+
+  def harmonicMean[A:Fractional](xs: M[A]): A
+  def harmonicMeanBy[A,B:Fractional](xs: M[A])(f: A ⇒ B): B
+
+  def quadraticMean[A:Fractional](xs: M[A]): A
+  def quadraticMeanBy[A,B:Fractional](xs: M[A])(f: A ⇒ B): B
+}
+
+trait FractionalMeans0 {
+  implicit def GenTraversableMeans[CC[X] <: GenTraversable[X]]: FractionalMeans[CC] = new GenTraversableFractionalMeans[CC] {}
+}
+
+object FractionalMeans extends FractionalMeans0 {
+  implicit object ArrayMeans extends ArrayFractionalMeans
+}
+
+trait ArrayFractionalMeans extends FractionalMeans[Array] {
+  def arithmeticMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.foldLeft(num.zero)(num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def geometricMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
+    val prod = xs.foldLeft(num.one)(num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def geometricMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val prod = xs.foldLeft(num.one)((b,a) ⇒ num.times(b, f(a)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def harmonicMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)))
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def harmonicMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))))
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def quadraticMean[A](xs: Array[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)))
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+
+  def quadraticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)))
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+}
+
+trait GenTraversableFractionalMeans[CC[X] <: GenTraversable[X]] extends FractionalMeans[CC] {
+  def arithmeticMean[A](xs: CC[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.aggregate(num.zero)(num.plus, num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, f(a)), num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def geometricMean[A](xs: CC[A])(implicit num: Fractional[A]): A = {
+    val prod = xs.aggregate(num.one)(num.times, num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def geometricMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val prod = xs.aggregate(num.one)((b,a) ⇒ num.times(b, f(a)), num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def harmonicMean[A](xs: CC[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.aggregate(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)), num.plus)
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def harmonicMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))), num.plus)
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def quadraticMean[A](xs: CC[A])(implicit num: Fractional[A]): A = {
+    val sum = xs.aggregate(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)), num.plus)
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+
+  def quadraticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Fractional[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)), num.plus)
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+}

--- a/core/src/main/scala/spire/stats/IntegralMeans.scala
+++ b/core/src/main/scala/spire/stats/IntegralMeans.scala
@@ -1,0 +1,44 @@
+package spire.stats
+
+import language.higherKinds
+
+import scala.collection.GenTraversable
+
+import spire.math.Integral
+
+trait IntegralMeans[M[_]] {
+  def arithmeticMean[A:Integral](xs: M[A]): A
+  def arithmeticMeanBy[A,B:Integral](xs: M[A])(f: A ⇒ B): B
+}
+
+trait IntegralMeans0 {
+  implicit def GenTraversableMeans[CC[X] <: GenTraversable[X]]: IntegralMeans[CC] = new GenTraversableIntegralMeans[CC] {}
+}
+
+object IntegralMeans extends IntegralMeans0 {
+  implicit object ArrayMeans extends ArrayIntegralMeans
+}
+
+trait ArrayIntegralMeans extends IntegralMeans[Array] {
+  def arithmeticMean[A](xs: Array[A])(implicit num: Integral[A]): A = {
+    val sum = xs.foldLeft(num.zero)(num.plus)
+    num.quot(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Integral[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
+    num.quot(sum, num.fromInt(xs.size))
+  }
+}
+
+trait GenTraversableIntegralMeans[CC[X] <: GenTraversable[X]] extends IntegralMeans[CC] {
+  def arithmeticMean[A](xs: CC[A])(implicit num: Integral[A]): A = {
+    val sum = xs.aggregate(num.zero)(num.plus, num.plus)
+    num.quot(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Integral[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, f(a)), num.plus)
+    num.quot(sum, num.fromInt(xs.size))
+  }
+}

--- a/core/src/main/scala/spire/stats/IntegralMeans.scala
+++ b/core/src/main/scala/spire/stats/IntegralMeans.scala
@@ -24,12 +24,12 @@ object IntegralMeans extends IntegralMeans0 {
 trait ArrayIntegralMeans extends IntegralMeans[Array] {
   def arithmeticMean[A](xs: Array[A])(implicit num: Integral[A]): A = {
     val sum = xs.foldLeft(num.zero)(num.plus)
-    num.quot(sum, num.fromInt(xs.size))
+    num.quot(sum, num.fromInt(xs.length))
   }
 
   def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Integral[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
-    num.quot(sum, num.fromInt(xs.size))
+    num.quot(sum, num.fromInt(xs.length))
   }
 }
 

--- a/core/src/main/scala/spire/stats/IntegralMeans.scala
+++ b/core/src/main/scala/spire/stats/IntegralMeans.scala
@@ -7,6 +7,13 @@ import scala.collection.GenTraversableOnce
 
 import spire.math.Integral
 
+object integral {
+  implicit class IntegralMeansMA[M[_],A](val xs: M[A]) extends AnyVal {
+    def arithmeticMean(implicit imeans: IntegralMeans[M], int: Integral[A]): A = imeans.arithmeticMean(xs)
+    def arithmeticMeanBy[B](f: A ⇒ B)(implicit imeans: IntegralMeans[M], int: Integral[B]): B = imeans.arithmeticMeanBy(xs)(f)
+  }
+}
+
 trait IntegralMeans[M[_]] {
   def arithmeticMean[A:Integral](xs: M[A]): A
   def arithmeticMeanBy[A,B:Integral](xs: M[A])(f: A ⇒ B): B

--- a/core/src/main/scala/spire/stats/IntegralMeans.scala
+++ b/core/src/main/scala/spire/stats/IntegralMeans.scala
@@ -3,6 +3,7 @@ package spire.stats
 import language.higherKinds
 
 import scala.collection.GenTraversable
+import scala.collection.GenTraversableOnce
 
 import spire.math.Integral
 
@@ -17,6 +18,7 @@ trait IntegralMeans0 {
 
 object IntegralMeans extends IntegralMeans0 {
   implicit object ArrayMeans extends ArrayIntegralMeans
+  implicit object GenTraversableOnceMeans extends GenTraversableOnceIntegralMeans
 }
 
 trait ArrayIntegralMeans extends IntegralMeans[Array] {
@@ -40,5 +42,21 @@ trait GenTraversableIntegralMeans[CC[X] <: GenTraversable[X]] extends IntegralMe
   def arithmeticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Integral[B]): B = {
     val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, f(a)), num.plus)
     num.quot(sum, num.fromInt(xs.size))
+  }
+}
+
+trait GenTraversableOnceIntegralMeans extends IntegralMeans[GenTraversableOnce] {
+  def arithmeticMean[A](xs: GenTraversableOnce[A])(implicit num: Integral[A]): A = {
+    val seqop = (b: (A,Int), a: A) ⇒ (num.plus(b._1,a), b._2 + 1)
+    val combop = (a: (A,Int), b: (A,Int)) ⇒ (num.plus(a._1,b._1), a._2 + b._2)
+    val (sum,size) = xs.aggregate((num.zero,0))(seqop, combop)
+    num.quot(sum, num.fromInt(size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: GenTraversableOnce[A])(f: A ⇒ B)(implicit num: Integral[B]): B = {
+    val seqop = (b: (B,Int), a: A) ⇒ (num.plus(b._1,f(a)), b._2 + 1)
+    val combop = (a: (B,Int), b: (B,Int)) ⇒ (num.plus(a._1,b._1), a._2 + b._2)
+    val (sum,size) = xs.aggregate((num.zero,0))(seqop, combop)
+    num.quot(sum, num.fromInt(size))
   }
 }

--- a/core/src/main/scala/spire/stats/NumericMeans.scala
+++ b/core/src/main/scala/spire/stats/NumericMeans.scala
@@ -31,42 +31,42 @@ object NumericMeans extends NumericMeans0 {
 trait ArrayNumericMeans extends NumericMeans[Array] {
   def arithmeticMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
     val sum = xs.foldLeft(num.zero)(num.plus)
-    num.div(sum, num.fromInt(xs.size))
+    num.div(sum, num.fromInt(xs.length))
   }
 
   def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
-    num.div(sum, num.fromInt(xs.size))
+    num.div(sum, num.fromInt(xs.length))
   }
 
   def geometricMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
     val prod = xs.foldLeft(num.one)(num.times)
-    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.length)))
   }
 
   def geometricMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
     val prod = xs.foldLeft(num.one)((b,a) ⇒ num.times(b, f(a)))
-    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.length)))
   }
 
   def harmonicMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
     val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)))
-    num.div(num.fromInt(xs.size), sum)
+    num.div(num.fromInt(xs.length), sum)
   }
 
   def harmonicMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))))
-    num.div(num.fromInt(xs.size), sum)
+    num.div(num.fromInt(xs.length), sum)
   }
 
   def quadraticMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
     val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)))
-    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+    num.sqrt(num.div(sum, num.fromInt(xs.length)))
   }
 
   def quadraticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
     val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)))
-    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+    num.sqrt(num.div(sum, num.fromInt(xs.length)))
   }
 }
 

--- a/core/src/main/scala/spire/stats/NumericMeans.scala
+++ b/core/src/main/scala/spire/stats/NumericMeans.scala
@@ -1,0 +1,113 @@
+package spire.stats
+
+import language.higherKinds
+
+import scala.collection.GenTraversable
+
+import spire.math.Numeric
+
+trait NumericMeans[M[_]] {
+  def arithmeticMean[A:Numeric](xs: M[A]): A
+  def arithmeticMeanBy[A,B:Numeric](xs: M[A])(f: A ⇒ B): B
+
+  def geometricMean[A:Numeric](xs: M[A]): A
+  def geometricMeanBy[A,B:Numeric](xs: M[A])(f: A ⇒ B): B
+
+  def harmonicMean[A:Numeric](xs: M[A]): A
+  def harmonicMeanBy[A,B:Numeric](xs: M[A])(f: A ⇒ B): B
+
+  def quadraticMean[A:Numeric](xs: M[A]): A
+  def quadraticMeanBy[A,B:Numeric](xs: M[A])(f: A ⇒ B): B
+}
+
+trait NumericMeans0 {
+  implicit def GenTraversableMeans[CC[X] <: GenTraversable[X]]: NumericMeans[CC] = new GenTraversableNumericMeans[CC] {}
+}
+
+object NumericMeans extends NumericMeans0 {
+  implicit object ArrayMeans extends ArrayNumericMeans
+}
+
+trait ArrayNumericMeans extends NumericMeans[Array] {
+  def arithmeticMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.foldLeft(num.zero)(num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, f(a)))
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def geometricMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
+    val prod = xs.foldLeft(num.one)(num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def geometricMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val prod = xs.foldLeft(num.one)((b,a) ⇒ num.times(b, f(a)))
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def harmonicMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)))
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def harmonicMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))))
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def quadraticMean[A](xs: Array[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.foldLeft(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)))
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+
+  def quadraticMeanBy[A,B](xs: Array[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.foldLeft(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)))
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+}
+
+trait GenTraversableNumericMeans[CC[X] <: GenTraversable[X]] extends NumericMeans[CC] {
+  def arithmeticMean[A](xs: CC[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.aggregate(num.zero)(num.plus, num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def arithmeticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, f(a)), num.plus)
+    num.div(sum, num.fromInt(xs.size))
+  }
+
+  def geometricMean[A](xs: CC[A])(implicit num: Numeric[A]): A = {
+    val prod = xs.aggregate(num.one)(num.times, num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def geometricMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val prod = xs.aggregate(num.one)((b,a) ⇒ num.times(b, f(a)), num.times)
+    num.fpow(prod, num.reciprocal(num.fromInt(xs.size)))
+  }
+
+  def harmonicMean[A](xs: CC[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.aggregate(num.zero)((agg,a) ⇒ num.plus(agg, num.reciprocal(a)), num.plus)
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def harmonicMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, num.reciprocal(f(a))), num.plus)
+    num.div(num.fromInt(xs.size), sum)
+  }
+
+  def quadraticMean[A](xs: CC[A])(implicit num: Numeric[A]): A = {
+    val sum = xs.aggregate(num.zero)((agg,a) ⇒ num.plus(agg, num.times(a,a)), num.plus)
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+
+  def quadraticMeanBy[A,B](xs: CC[A])(f: A ⇒ B)(implicit num: Numeric[B]): B = {
+    val sum = xs.aggregate(num.zero)((b,a) ⇒ num.plus(b, num.pow(f(a),2)), num.plus)
+    num.sqrt(num.div(sum, num.fromInt(xs.size)))
+  }
+}

--- a/core/src/main/scala/spire/stats/NumericMeans.scala
+++ b/core/src/main/scala/spire/stats/NumericMeans.scala
@@ -6,6 +6,22 @@ import scala.collection.GenTraversable
 
 import spire.math.Numeric
 
+object numeric {
+  implicit class NumericMeansMA[M[_],A](val xs: M[A]) extends AnyVal {
+    def arithmeticMean(implicit nmeans: NumericMeans[M], num: Numeric[A]): A = nmeans.arithmeticMean(xs)
+    def arithmeticMeanBy[B](f: A ⇒ B)(implicit nmeans: NumericMeans[M], num: Numeric[B]): B = nmeans.arithmeticMeanBy(xs)(f)
+
+    def geometricMean(implicit nmeans: NumericMeans[M], num: Numeric[A]): A = nmeans.geometricMean(xs)
+    def geometricMeanBy[B](f: A ⇒ B)(implicit nmeans: NumericMeans[M], num: Numeric[B]): B = nmeans.geometricMeanBy(xs)(f)
+
+    def harmonicMean(implicit nmeans: NumericMeans[M], num: Numeric[A]): A = nmeans.harmonicMean(xs)
+    def harmonicMeanBy[B](f: A ⇒ B)(implicit nmeans: NumericMeans[M], num: Numeric[B]): B = nmeans.harmonicMeanBy(xs)(f)
+
+    def quadraticMean(implicit nmeans: NumericMeans[M], num: Numeric[A]): A = nmeans.quadraticMean(xs)
+    def quadraticMeanBy[B](f: A ⇒ B)(implicit nmeans: NumericMeans[M], num: Numeric[B]): B = nmeans.quadraticMeanBy(xs)(f)
+  }
+}
+
 trait NumericMeans[M[_]] {
   def arithmeticMean[A:Numeric](xs: M[A]): A
   def arithmeticMeanBy[A,B:Numeric](xs: M[A])(f: A ⇒ B): B

--- a/core/src/test/scala/spire/stats/IntegralMeansTest.scala
+++ b/core/src/test/scala/spire/stats/IntegralMeansTest.scala
@@ -1,0 +1,28 @@
+package spire.stats
+
+import org.scalatest.FunSuite
+
+import spire.math.Integral
+import spire.stats.integral._
+
+class IntegralMeansTest extends FunSuite {
+  def testArithmeticMean[M[_]: IntegralMeans,A: Integral](xs: M[A])(goal: A) = {
+    assert(goal === xs.arithmeticMean)
+  }
+
+  test("arithmetic mean of empty array") {
+    testArithmeticMean(Array[Int]())(0)
+  }
+
+  test("arithmetic mean singleton") {
+    testArithmeticMean(Array(1))(1)
+  }
+
+  test("arithmetic mean of same values") {
+    testArithmeticMean(Array.fill(5)(42))(42)
+  }
+
+  test("arithmetic mean of 1 to 5 array") {
+    testArithmeticMean(Array.range(1,6))(3)
+  }
+}


### PR DESCRIPTION
- focus currently just on
  - arithmetic mean
  - geometric mean
  - harmonic mean
  - quadratic mean aka root mean square

- where one of the above is supported, there is also a "*By" version which on the fly
  converts elements without the need to map over the container first:
  (1 to 5).map(_.toDouble).arithmeticMean === (1 to 5).arithmeticMeanBy(_.toDouble)

- first dimension based on
  - spire.math.Fractional (arithmetic, geometric, harmonic, quadratic)
  - spire.math.Integral (arithmetic)
  - spire.math.Numeric (arithmetic, geometric, harmonic, quadratic)

- second dimension based on container type, currently
  - concrete Array
  - generic GenTraversable (using aggregate to support parallel collections)