### PR TITLE
Add new approximate-equality operator.

### DIFF
--- a/core/src/main/scala/spire/algebra/Ops.scala
+++ b/core/src/main/scala/spire/algebra/Ops.scala
@@ -193,3 +193,8 @@ final class NormedVectorSpaceOps[V](lhs: V) {
   def normalize[F](implicit ev: NormedVectorSpace[V, F]): V =
     macro Ops.unopWithEv[NormedVectorSpace[V, F], V]
 }
+
+final class MetricSpaceOps[V](lhs: V) {
+  def =~=[R](rhs: V)(implicit ms: MetricSpace[V, R], o: Order[R],
+      e: MetricSpace.Epsilon[V, R]): Boolean = ms.close(lhs, rhs)
+}

--- a/core/src/main/scala/spire/package.scala
+++ b/core/src/main/scala/spire/package.scala
@@ -456,6 +456,8 @@ trait OpsImplicits {
   implicit def innerProductSpaceOps[V](v:V) = new InnerProductSpaceOps[V](v)
   implicit def coordianteSpaceOps[V](v:V) = new CoordinateSpaceOps[V](v)
 
+  implicit def metricSpaceOps[V](v:V) = new MetricSpaceOps[V](v)
+
   implicit def literalIntOps(lhs:Int) = new LiteralIntOps(lhs)
   implicit def literalLongOps(lhs:Long) = new LiteralLongOps(lhs)
   implicit def literalDoubleOps(lhs:Double) = new LiteralDoubleOps(lhs)

--- a/core/src/main/scala/spire/std/array.scala
+++ b/core/src/main/scala/spire/std/array.scala
@@ -202,13 +202,16 @@ trait ArrayInstances1 extends ArrayInstances0 {
 }
 
 trait ArrayInstances2 extends ArrayInstances1 {
-  implicit def ArrayInnerProductSpace[@spec(Int,Long,Float,Double) A](implicit
+  implicit def ArrayNormedVectorSpace[@spec(Int,Long,Float,Double) A](implicit
       scalar0: Field[A], nroot0: NRoot[A],
-      classTag0: ClassTag[A]): InnerProductSpace[Array[A], A] = new ArrayInnerProductSpace[A] {
-    val scalar = scalar0
-    val nroot = nroot0
-    val classTag = classTag0
-  }
+      classTag0: ClassTag[A]): NormedVectorSpace[Array[A], A] = ArrayInnerProductSpace[A].normed
+
+  implicit def ArrayInnerProductSpace[@spec(Int,Long,Float,Double) A](implicit
+      scalar0: Field[A], classTag0: ClassTag[A]): InnerProductSpace[Array[A], A] =
+    new ArrayInnerProductSpace[A] {
+      val scalar = scalar0
+      val classTag = classTag0
+    }
 
   implicit def ArrayOrder[@spec(Int,Long,Float,Double) A](implicit
       A0: Order[A], ct: ClassTag[A]) = new ArrayOrder[A] {

--- a/core/src/main/scala/spire/std/seq.scala
+++ b/core/src/main/scala/spire/std/seq.scala
@@ -282,10 +282,12 @@ trait SeqInstances1 extends SeqInstances0 {
 }
 
 trait SeqInstances2 extends SeqInstances1 {
+  implicit def SeqNormedVectorSpace[A, CC[A] <: SeqLike[A, CC[A]]](implicit field0: Field[A],
+      nroot0: NRoot[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]) = SeqInnerProductSpace[A, CC].normed
+
   implicit def SeqInnerProductSpace[A, CC[A] <: SeqLike[A, CC[A]]](implicit field0: Field[A],
-      nroot0: NRoot[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]) = new SeqInnerProductSpace[A, CC[A]] {
+      cbf0: CanBuildFrom[CC[A], A, CC[A]]) = new SeqInnerProductSpace[A, CC[A]] {
     val scalar = field0
-    val nroot = nroot0
     val cbf = cbf0
   }
 

--- a/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
+++ b/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
@@ -65,6 +65,8 @@ class LawTests extends LawChecker {
   checkAll("Set[Int]",    GroupLaws[Set[Int]](spire.optional.genericEq.generic, implicitly).monoid)
   checkAll("String[Int]", GroupLaws[String].monoid)
   checkAll("Array[Int]",  GroupLaws[Array[Int]].monoid)
+
+  checkAll("String", VectorSpaceLaws[String, Int].metricSpace)
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
This adds a new _approximate_ equality operator, `x =~= y`, that is
based on `MetricSpace`s. To use it, an implicit `MetricSpace.Epsilon` is
required to be in scope. Two points `x` and `y` are considered
approximately equal if the distance between them is less than or equal
to the value of the implicit epsilon.

This also adds explicit implicit NormedVectorSpaces for `seq` and
`array`.
