### PR TITLE
Numeric doesn't extend Field anymore.

### DIFF
--- a/core/src/main/scala/spire/math/Fractional.scala
+++ b/core/src/main/scala/spire/math/Fractional.scala
@@ -26,45 +26,49 @@ object Fractional {
 
 private[math] trait FloatIsFractional extends Fractional[Float] with FloatIsField
 with FloatIsNRoot with ConvertableFromFloat with ConvertableToFloat
-with FloatOrder with FloatIsSigned {
+with FloatIsReal {
   override def fromInt(n: Int): Float = n
   override def fromDouble(n: Double): Float = n.toFloat
+  override def toDouble(n: Float): Double = n.toDouble
 }
 
 private[math] trait DoubleIsFractional extends Fractional[Double] with DoubleIsField
 with DoubleIsNRoot with ConvertableFromDouble with ConvertableToDouble
-with DoubleOrder with DoubleIsSigned {
+with DoubleIsReal {
   override def fromInt(n: Int): Double = n
   override def fromDouble(n: Double): Double = n
+  override def toDouble(n: Double): Double = n.toDouble
 }
 
 
 private[math] trait BigDecimalIsFractional extends Fractional[BigDecimal] with BigDecimalIsField
 with BigDecimalIsNRoot with ConvertableFromBigDecimal with ConvertableToBigDecimal
-with BigDecimalOrder with BigDecimalIsSigned {
+with BigDecimalIsReal {
   override def fromInt(n: Int): BigDecimal = BigDecimal(n)
   override def fromDouble(n: Double): BigDecimal = BigDecimal(n)
+  override def toDouble(n: BigDecimal): Double = n.toDouble
 }
 
 private[math] trait RationalIsFractional extends Fractional[Rational] with RationalIsField
 with RationalIsNRoot with ConvertableFromRational with ConvertableToRational
 with RationalIsReal {
-  override def toDouble(n: Rational): Double = n.toDouble
   override def fromInt(n: Int): Rational = Rational(n)
   override def fromDouble(n: Double): Rational = Rational(n)
+  override def toDouble(n: Rational): Double = n.toDouble
 }
-
 
 private[math] trait RealIsFractional extends Fractional[Real] with RealIsField
 with RealIsNRoot with ConvertableFromReal with ConvertableToReal
-with RealOrder with RealIsSigned {
+with RealIsReal {
   override def fromInt(n: Int): Real = Real(n)
   override def fromDouble(n: Double): Real = Real(n)
+  override def toDouble(n: Real): Double = n.toDouble
 }
 
 private[math] trait NumberIsFractional extends Fractional[Number] with NumberIsField
 with NumberIsNRoot with ConvertableFromNumber with ConvertableToNumber
-with NumberOrder with NumberIsSigned {
+with NumberIsReal {
   override def fromInt(n: Int): Number = Number(n)
   override def fromDouble(n: Double): Number = Number(n)
+  override def toDouble(n: Number): Double = n.toDouble
 }

--- a/core/src/main/scala/spire/math/Integral.scala
+++ b/core/src/main/scala/spire/math/Integral.scala
@@ -7,7 +7,7 @@ import spire.macrosk.Ops
 import scala.{specialized => spec}
 
 trait Integral[@spec(Int,Long) A] extends EuclideanRing[A]
-with ConvertableFrom[A] with ConvertableTo[A] with Order[A] with Signed[A] {
+with ConvertableFrom[A] with ConvertableTo[A] with IsReal[A] {
   def isZero(x: A) = eqv(x, zero)
   def isNonzero(x: A) = neqv(x, zero)
   def isPositive(x: A) = gt(x, zero)
@@ -24,21 +24,25 @@ object Integral {
 }
 
 private[math] trait IntIsIntegral extends Integral[Int] with IntIsEuclideanRing
-with ConvertableFromInt with ConvertableToInt with IntOrder with IntIsSigned {
+with ConvertableFromInt with ConvertableToInt with IntIsReal {
   override def fromInt(n: Int): Int = n
+  override def toDouble(n: Int): Double = n.toDouble
 }
 
 private[math] trait LongIsIntegral extends Integral[Long] with LongIsEuclideanRing
-with ConvertableFromLong with ConvertableToLong with LongOrder with LongIsSigned {
+with ConvertableFromLong with ConvertableToLong with LongIsReal {
   override def fromInt(n: Int): Long = n.toLong
+  override def toDouble(n: Long): Double = n.toDouble
 }
 
 private[math] trait BigIntIsIntegral extends Integral[BigInt] with BigIntIsEuclideanRing
-with ConvertableFromBigInt with ConvertableToBigInt with BigIntOrder with BigIntIsSigned {
+with ConvertableFromBigInt with ConvertableToBigInt with BigIntIsReal {
   override def fromInt(n: Int): BigInt = BigInt(n)
+  override def toDouble(n: BigInt): Double = n.toDouble
 }
 
 private[math] trait SafeLongIsIntegral extends Integral[SafeLong] with SafeLongIsEuclideanRing
-with ConvertableFromSafeLong with ConvertableToSafeLong with SafeLongOrder with SafeLongIsSigned {
+with ConvertableFromSafeLong with ConvertableToSafeLong with SafeLongIsReal {
   override def fromInt(n: Int): SafeLong = SafeLong(n)
+  override def toDouble(n: SafeLong): Double = n.toDouble
 }

--- a/core/src/main/scala/spire/math/Numeric.scala
+++ b/core/src/main/scala/spire/math/Numeric.scala
@@ -13,8 +13,9 @@ import scala.{specialized => spec}
  * 6. Start to worry about things like e.g. pow(BigInt, BigInt)
  */
 
-trait Numeric[@spec(Int,Long,Float,Double) A] extends Field[A] with NRoot[A]
-with ConvertableFrom[A] with ConvertableTo[A] with Order[A] with Signed[A]
+trait Numeric[@spec(Int,Long,Float,Double) A] extends Rig[A]
+with AdditiveAbGroup[A] with MultiplicativeGroup[A] with NRoot[A]
+with ConvertableFrom[A] with ConvertableTo[A] with IsReal[A]
 
 object Numeric {
   implicit object IntIsNumeric extends IntIsNumeric
@@ -34,58 +35,52 @@ object Numeric {
 }
 
 private[math] trait IntIsNumeric extends Numeric[Int] with IntIsEuclideanRing with IntIsNRoot
-with ConvertableFromInt with ConvertableToInt with IntOrder with IntIsSigned {
+with ConvertableFromInt with ConvertableToInt with IntIsReal {
   override def fromInt(n: Int): Int = n
   override def fromDouble(n: Double): Int = n.toInt
+  override def toDouble(n: Int): Double = n.toDouble
   def div(a:Int, b:Int) = a / b
-  def ceil(a: Int): Int = a
-  def floor(a: Int): Int = a
-  def round(a: Int): Int = a
-  def isWhole(a:Int) = true
 }
 
 private[math] trait LongIsNumeric extends Numeric[Long] with LongIsEuclideanRing with LongIsNRoot
-with ConvertableFromLong with ConvertableToLong with LongOrder with LongIsSigned {
+with ConvertableFromLong with ConvertableToLong with LongIsReal {
   override def fromInt(n: Int): Long = n
   override def fromDouble(n: Double): Long = n.toLong
+  override def toDouble(n: Long): Double = n.toDouble
   def div(a:Long, b:Long) = a / b
-  def ceil(a: Long): Long = a
-  def floor(a: Long): Long = a
-  def round(a: Long): Long = a
-  def isWhole(a:Long) = true
 }
 
 private[math] trait BigIntIsNumeric extends Numeric[BigInt] with BigIntIsEuclideanRing
 with BigIntIsNRoot with ConvertableFromBigInt with ConvertableToBigInt
-with BigIntOrder with BigIntIsSigned {
+with BigIntIsReal {
   override def fromInt(n: Int): BigInt = BigInt(n)
   override def fromDouble(n: Double): BigInt = BigDecimal(n).toBigInt
+  override def toDouble(n: BigInt): Double = n.toDouble
   def div(a:BigInt, b:BigInt) = a / b
-  def ceil(a: BigInt): BigInt = a
-  def floor(a: BigInt): BigInt = a
-  def round(a: BigInt): BigInt = a
-  def isWhole(a:BigInt) = true
 }
 
 private[math] trait FloatIsNumeric extends Numeric[Float] with FloatIsField
 with FloatIsNRoot with ConvertableFromFloat with ConvertableToFloat
-with FloatOrder with FloatIsSigned {
+with FloatIsReal {
   override def fromInt(n: Int): Float = n.toFloat
   override def fromDouble(n: Double): Float = n.toFloat
+  override def toDouble(n: Float): Double = n.toDouble
 }
 
 private[math] trait DoubleIsNumeric extends Numeric[Double] with DoubleIsField
 with DoubleIsNRoot with ConvertableFromDouble with ConvertableToDouble
-with DoubleOrder with DoubleIsSigned {
+with DoubleIsReal {
   override def fromInt(n: Int): Double = n.toDouble
   override def fromDouble(n: Double): Double = n
+  override def toDouble(n: Double): Double = n.toDouble
 }
 
 private[math] trait BigDecimalIsNumeric extends Numeric[BigDecimal] with BigDecimalIsField
 with BigDecimalIsNRoot with ConvertableFromBigDecimal with ConvertableToBigDecimal
-with BigDecimalOrder with BigDecimalIsSigned {
+with BigDecimalIsReal {
   override def fromInt(n: Int): BigDecimal = BigDecimal(n)
   override def fromDouble(n: Double): BigDecimal = BigDecimal(n)
+  override def toDouble(n: BigDecimal): Double = n.toDouble
 }
 
 private[math] trait RationalIsNumeric extends Numeric[Rational] with RationalIsField
@@ -97,9 +92,10 @@ with RationalIsReal {
 }
 
 private[math] trait RealIsNumeric extends Numeric[Real] with RealIsField with RealIsNRoot
-with ConvertableFromReal with ConvertableToReal with RealOrder with RealIsSigned {
+with ConvertableFromReal with ConvertableToReal with RealIsReal {
   override def fromInt(n: Int): Real = Real(n)
   override def fromDouble(n: Double): Real = Real(n)
+  override def toDouble(n: Real): Double = n.toDouble
 }
 
 

--- a/core/src/main/scala/spire/math/fpf/MaybeDouble.scala
+++ b/core/src/main/scala/spire/math/fpf/MaybeDouble.scala
@@ -186,6 +186,15 @@ final class MaybeDouble(val approx: Double, private val mes: Double, private val
     toLong map { _.toDouble == approx }
   } else None
 
+  private def consensus(f: Double => Double) = if (isValid) {
+    val x = f(approx - error)
+    if (x == f(approx + error)) MaybeDouble(x) else MaybeDouble.Invalid
+  } else MaybeDouble.Invalid
+
+  def ceil: MaybeDouble = consensus(spire.math.ceil)
+  def floor: MaybeDouble = consensus(spire.math.floor)
+  def round: MaybeDouble = consensus(spire.math.round)
+
   override def hashCode: Int = (approx.## + mes.## * 19 + ind * 23)
   override def equals(that: Any): Boolean = that match {
     case that: MaybeDouble =>

--- a/core/src/test/scala/spire/algebra/NRootTest.scala
+++ b/core/src/test/scala/spire/algebra/NRootTest.scala
@@ -10,10 +10,10 @@ class NRootTest extends FunSuite {
   def testIntegralNRoot[A: Numeric: ClassTag] {
     val cls = implicitly[ClassTag[A]].runtimeClass.getSimpleName
     test("Integral NRoot (%s)" format cls) {
-      val one = Ring[A].one
-      assert(NRoot[A].nroot(Ring[A].one, 2) === Ring[A].one)
-      assert(NRoot[A].nroot(Ring[A].fromInt(1234), 2) === Ring[A].fromInt(35))
-      assert(NRoot[A].nroot(Ring[A].fromInt(912384), 3) === Ring[A].fromInt(96))
+      val one = Rig[A].one
+      assert(NRoot[A].nroot(Rig[A].one, 2) === Rig[A].one)
+      assert(NRoot[A].nroot(Numeric[A].fromInt(1234), 2) === Numeric[A].fromInt(35))
+      assert(NRoot[A].nroot(Numeric[A].fromInt(912384), 3) === Numeric[A].fromInt(96))
     }
   }
 

--- a/core/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/core/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -101,11 +101,10 @@ class TypeclassExistenceTest extends FunSuite {
     check[Double]
   }
 
-  test("Numerics have Order, NRoot, are EuclideanRings and are Fields") {
+  test("Numerics have Order, NRoot, and are Rigs") {
     def check[A: Numeric: ClassTag] {
+      hasRig[A]
       hasOrder[A]
-      hasEuclideanRing[A]
-      hasField[A]
       hasNRoot[A]
     }
 


### PR DESCRIPTION
Aside from some other minor fixes/refactors, this also makes Numeric
only extend Rig now, rather than Field. Note that / still exists with
Numeric, but it comes from inheriting just MultiplicativeGroup, rather
than Field.
