### PR TITLE
Metricspace laws

### DIFF
--- a/core/src/main/scala/spire/algebra/MetricSpace.scala
+++ b/core/src/main/scala/spire/algebra/MetricSpace.scala
@@ -10,7 +10,7 @@ trait MetricSpace[V, @spec(Int, Long, Float, Double) R] {
   def distance(v: V, w: V): R
 }
 
-object MetricSpace extends MetricSpace1 {
+object MetricSpace extends MetricSpace0 {
   @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: MetricSpace[V, R]) = V
 
   def distance[V, @spec(Int,Long,Float,Double) R](v: V, w: V)(implicit
@@ -28,13 +28,8 @@ object MetricSpace extends MetricSpace1 {
 }
 
 private[algebra] trait MetricSpace0 {
-  implicit def realMetricSpace[V, @spec(Int,Long,Float,Double) R](implicit
-      V: MetricSpace[V, R], R: IsReal[R]) = new MetricSpace[V, Double] {
-    def distance(v: V, w: V): Double = R.toDouble(V.distance(v, w))
+  implicit def realMetricSpace[@spec(Int,Long,Float,Double) R](implicit
+      R0: IsReal[R], R1: Rng[R]) = new MetricSpace[R, R] {
+    def distance(v: R, w: R): R = R0.abs(R1.minus(v, w))
   }
-}
-
-private[algebra] trait MetricSpace1 extends MetricSpace0 {
-  implicit def NormedVectorSpaceIsMetricSpace[V, @spec(Float,Double) R](implicit
-      V: NormedVectorSpace[V, R]): MetricSpace[V, R] = V
 }

--- a/core/src/main/scala/spire/std/array.scala
+++ b/core/src/main/scala/spire/std/array.scala
@@ -203,12 +203,11 @@ trait ArrayInstances1 extends ArrayInstances0 {
 
 trait ArrayInstances2 extends ArrayInstances1 {
   implicit def ArrayInnerProductSpace[@spec(Int,Long,Float,Double) A](implicit
-      scalar0: Field[A], nroot0: NRoot[A],
-      classTag0: ClassTag[A]): InnerProductSpace[Array[A], A] = new ArrayInnerProductSpace[A] {
-    val scalar = scalar0
-    val nroot = nroot0
-    val classTag = classTag0
-  }
+      scalar0: Field[A], classTag0: ClassTag[A]): InnerProductSpace[Array[A], A] =
+    new ArrayInnerProductSpace[A] {
+      val scalar = scalar0
+      val classTag = classTag0
+    }
 
   implicit def ArrayOrder[@spec(Int,Long,Float,Double) A](implicit
       A0: Order[A], ct: ClassTag[A]) = new ArrayOrder[A] {
@@ -217,6 +216,12 @@ trait ArrayInstances2 extends ArrayInstances1 {
   }
 }
 
-trait ArrayInstances extends ArrayInstances2 {
+trait ArrayInstances3 extends ArrayInstances2 {
+  implicit def ArrayNormedVectorSpace[@spec(Int,Long,Float,Double) A](implicit
+      scalar0: Field[A], nroot0: NRoot[A],
+      classTag0: ClassTag[A]): NormedVectorSpace[Array[A], A] = ArrayInnerProductSpace[A].normed
+}
+
+trait ArrayInstances extends ArrayInstances3 {
   implicit def ArrayMonoid[@spec A: ClassTag] = new ArrayMonoid[A]
 }

--- a/core/src/main/scala/spire/std/seq.scala
+++ b/core/src/main/scala/spire/std/seq.scala
@@ -295,4 +295,9 @@ trait SeqInstances2 extends SeqInstances1 {
   }
 }
 
-trait SeqInstances extends SeqInstances2
+trait SeqInstances3 extends SeqInstances2 {
+  implicit def SeqNormedVectorSpace[A, CC[A] <: SeqLike[A, CC[A]]](implicit field0: Field[A],
+      nroot0: NRoot[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]) = SeqInnerProductSpace[A, CC].normed
+}
+
+trait SeqInstances extends SeqInstances3

--- a/core/src/test/scala/spire/SyntaxTest.scala
+++ b/core/src/test/scala/spire/SyntaxTest.scala
@@ -114,8 +114,7 @@ trait BaseSyntaxTest {
     (a.ceil == IsReal[A].ceil(a)) &&
       (a.floor == IsReal[A].floor(a)) &&
       (a.round == IsReal[A].round(a)) &&
-      (a.isWhole == IsReal[A].isWhole(a)) &&
-      (a.toDouble == IsReal[A].toDouble(a))
+      (a.isWhole == IsReal[A].isWhole(a))
   }
 
   def testSemigroupSyntax[A: Semigroup](a: A, b: A) = {

--- a/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
+++ b/scalacheck-binding/src/test/scala/spire/algebra/LawTests.scala
@@ -65,6 +65,8 @@ class LawTests extends LawChecker {
   checkAll("Set[Int]",    GroupLaws[Set[Int]](spire.optional.genericEq.generic, implicitly).monoid)
   checkAll("String[Int]", GroupLaws[String].monoid)
   checkAll("Array[Int]",  GroupLaws[Array[Int]].monoid)
+
+  checkAll("String", VectorSpaceLaws[String, Int].metricSpace)
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
This switches real metric space to be basically the absolute value of the difference of 2 real numbers, but return as that numbers type, not `Double`. It also implements laws for MetricSpace and checks that the edit distance is a metric space.
