### PR TITLE
Fix bug in fast-stop condition in selection.

### DIFF
--- a/core/src/main/scala/spire/math/Selection.scala
+++ b/core/src/main/scala/spire/math/Selection.scala
@@ -56,7 +56,7 @@ trait SelectLike extends Select {
 
     } else {
       val c = partition(data, left, right, stride)(approxMedian(data, left, right, stride))
-      val span = equalSpan(data, left, stride)
+      val span = equalSpan(data, c, stride)
 
       if (c <= k && k < (c + span)) {
         // Spin.


### PR DESCRIPTION
An equal span was being found that was intended to speed up the case
where we have many equal elements. However, we weren't using the center,
but the left side, so if several equal elements were on the left, it
could cause a correctness issue.
