### PR TITLE
Add scala syntax to vectorspace type classes.

### DIFF
--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -89,11 +89,11 @@ trait NRootSyntax {
   implicit def nrootOps[A: NRoot](a: A) = new NRootOps(a)
 }
 
-trait ModuleSyntax extends AdditiveGroupSyntax {
+trait ModuleSyntax extends RingSyntax {
   implicit def moduleOps[V](v:V) = new ModuleOps[V](v)
 }
 
-trait VectorSpaceSyntax extends ModuleSyntax {
+trait VectorSpaceSyntax extends ModuleSyntax with FieldSyntax {
   implicit def vectorSpaceOps[V](v:V) = new VectorSpaceOps[V](v)
 }
 


### PR DESCRIPTION
Both spire.syntax.module and spire.syntax.ring (for example) bring in AdditiveGroupSyntax, so we need to have the vector space related syntaxes subsume the scalar's syntax as well. I wish Scala would just shadow the 1st one... argh.
