### PR TITLE
Add spire.syntax.all._ import for convenience.

### DIFF
--- a/core/src/main/scala/spire/syntax/package.scala
+++ b/core/src/main/scala/spire/syntax/package.scala
@@ -45,4 +45,6 @@ package object syntax {
   object integral extends IntegralSyntax
   object fractional extends FractionalSyntax
   object numeric extends NumericSyntax
+
+  object all extends AllSyntax
 }


### PR DESCRIPTION
Meant to do this earlier today, but here it is: `spire.syntax.all`.
