### PR TITLE
Add fib, fact, and choose functions to spire.math.

### DIFF
--- a/core/src/main/scala/spire/math/package.scala
+++ b/core/src/main/scala/spire/math/package.scala
@@ -39,6 +39,53 @@ package object math {
   final def ceil[A](a: A)(implicit ev: IsReal[A]): A = ev.ceil(a)
 
   /**
+   * choose (binomial coefficient)
+   */
+  def choose(n: Long, k: Long): BigInt = {
+    if (n < 0 || k < 0) throw new IllegalArgumentException(s"n=$n, k=$k")
+    if (k == 0L || k == n) return BigInt(1)
+    if (k > n) return BigInt(0)
+    if (n - k > k) return choose(n, n - k)
+
+    @tailrec def loop(lo: Long, hi: Long, prod: BigInt): BigInt =
+      if (lo > hi) prod
+      else loop(lo + 1L, hi - 1L, BigInt(lo) * BigInt(hi) * prod)
+
+    if (((n - k) & 1) == 1)
+      loop(k + 1, n - 1L, BigInt(n)) / fact(n - k)
+    else
+      loop(k + 1, n, BigInt(1)) / fact(n - k)
+  }
+
+  /**
+   * factorial
+   */
+  def fact(n: Long): BigInt = {
+    if (n < 0) throw new IllegalArgumentException(n.toString)
+    @tailrec def loop(lo: Long, hi: Long, prod: BigInt): BigInt =
+      if (lo > hi) prod
+      else loop(lo + 1L, hi - 1L, BigInt(lo) * BigInt(hi) * prod)
+    if ((n & 1) == 1) loop(1L, n - 1L, BigInt(n))
+    else loop(2L, n - 1L, BigInt(n))
+  }
+
+  /**
+   * fibonacci
+   */
+  def fib(n: Long): BigInt = {
+    if (n < 0) throw new IllegalArgumentException(n.toString)
+    var i = 63
+    while (((n >>> i) & 1) == 0 && i >= 0) i -= 1
+    @tailrec def loop(a: BigInt, b: BigInt, i: Int): BigInt = {
+      val c = a + b
+      if (i < 0) b
+      else if (((n >>> i) & 1) == 1) loop((a + c) * b, b * b + c * c, i - 1)
+      else loop(a * a + b * b, (a + c) * b, i - 1)
+    }
+    loop(BigInt(1), BigInt(0), i)
+  }
+
+  /**
    * floor
    */
   final def floor(n: Float): Float = Math.floor(n).toFloat

--- a/core/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/src/main/scala/spire/syntax/std/Ops.scala
@@ -11,24 +11,28 @@ import scala.{specialized => spec}
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 
-final class LiteralIntOps(val lhs:Int) extends AnyVal {
-  def /~(rhs:Int) = lhs / rhs
-  def /%(rhs:Int) = (lhs / rhs, lhs % rhs)
-  def pow(rhs:Int) = Math.pow(lhs, rhs).toInt
-  def **(rhs:Int) = Math.pow(lhs, rhs).toInt
+final class LiteralIntOps(val lhs: Int) extends AnyVal {
+  def /~(rhs: Int) = lhs / rhs
+  def /%(rhs: Int) = (lhs / rhs, lhs % rhs)
+  def pow(rhs: Int) = Math.pow(lhs, rhs).toInt
+  def **(rhs: Int) = Math.pow(lhs, rhs).toInt
+  def !(): BigInt = spire.math.fact(lhs)
 }
 
-final class LiteralLongOps(val lhs:Long) extends AnyVal {
-  def pow(rhs:Long) = spire.math.pow(lhs, rhs)
-  def **(rhs:Long) = spire.math.pow(lhs, rhs)
+final class LiteralLongOps(val lhs: Long) extends AnyVal {
+  def /~(rhs: Long) = lhs / rhs
+  def /%(rhs: Long) = (lhs / rhs, lhs % rhs)
+  def pow(rhs: Long) = spire.math.pow(lhs, rhs)
+  def **(rhs: Long) = spire.math.pow(lhs, rhs)
+  def !(): BigInt = spire.math.fact(lhs)
 }
 
-final class LiteralDoubleOps(val lhs:Double) extends AnyVal {
-  def pow(rhs:Double) = spire.math.pow(lhs, rhs)
-  def **(rhs:Double) = spire.math.pow(lhs, rhs)
+final class LiteralDoubleOps(val lhs: Double) extends AnyVal {
+  def pow(rhs: Double) = spire.math.pow(lhs, rhs)
+  def **(rhs: Double) = spire.math.pow(lhs, rhs)
 }
 
-class LiteralBigIntOps(val lhs:BigInt) extends AnyVal {
+class LiteralBigIntOps(val lhs: BigInt) extends AnyVal {
   def /~(rhs: BigInt) = lhs / rhs
   def pow(rhs: BigInt) = spire.math.pow(lhs, rhs)
   def **(rhs: BigInt) = spire.math.pow(lhs, rhs)
@@ -66,45 +70,45 @@ class LiteralBigIntOps(val lhs:BigInt) extends AnyVal {
   def /%(rhs: Number) = Number(lhs) /% rhs
 }
 
-final class ArrayOps[@spec A](arr:Array[A]) {
-  def qsum(implicit ev:Rig[A]) = {
+final class ArrayOps[@spec A](arr: Array[A]) {
+  def qsum(implicit ev: Rig[A]) = {
     @tailrec
-    def f(i:Int, n:Int, t:A):A = if (i < n) f(i + 1, n, ev.plus(t, arr(i))) else t
+    def f(i: Int, n: Int, t: A): A = if (i < n) f(i + 1, n, ev.plus(t, arr(i))) else t
     f(0, arr.length, ev.zero)
   }
 
-  def qproduct(implicit ev:Rig[A]) = {
+  def qproduct(implicit ev: Rig[A]) = {
     @tailrec
-    def f(i:Int, n:Int, t:A):A = if (i < n) f(i + 1, n, ev.times(t, arr(i))) else t
+    def f(i: Int, n: Int, t: A): A = if (i < n) f(i + 1, n, ev.times(t, arr(i))) else t
     f(0, arr.length, ev.one)
   }
 
-  def qnorm(p:Int)(implicit ev:Field[A], s: Signed[A], nr:NRoot[A]) = {
+  def qnorm(p: Int)(implicit ev: Field[A], s: Signed[A], nr: NRoot[A]) = {
     @tailrec
-    def f(i:Int, n:Int, t:A):A =
+    def f(i: Int, n: Int, t: A): A =
       if (i < n) f(i + 1, n, ev.plus(t, ev.pow(s.abs(arr(i)), p))) else t
     nr.nroot(f(0, arr.length, ev.one), p)
   }
 
-  def qmin(implicit ev:Order[A]) = {
+  def qmin(implicit ev: Order[A]) = {
     if (arr.length == 0) sys.error("empty array")
     @tailrec
-    def f(i:Int, n:Int, t:A):A = if (i < n) f(i + 1, n, ev.min(t, arr(i))) else t
+    def f(i: Int, n: Int, t: A): A = if (i < n) f(i + 1, n, ev.min(t, arr(i))) else t
     f(1, arr.length, arr(0))
   }
 
-  def qmax(implicit ev:Order[A]) = {
+  def qmax(implicit ev: Order[A]) = {
     if (arr.length == 0) sys.error("empty array")
     @tailrec
-    def f(i:Int, n:Int, t:A):A = if (i < n) f(i + 1, n, ev.max(t, arr(i))) else t
+    def f(i: Int, n: Int, t: A): A = if (i < n) f(i + 1, n, ev.max(t, arr(i))) else t
     f(1, arr.length, arr(0))
   }
 
-  def qmean(implicit ev:Field[A]): A = {
+  def qmean(implicit ev: Field[A]): A = {
     if (arr.length == 0) sys.error("empty array")
     var sum = ev.zero
     @tailrec
-    def f(i:Int, j: Int, n:Int):A = if (i < n) {
+    def f(i: Int, j: Int, n: Int): A = if (i < n) {
       val t = ev.div(ev.times(sum, ev.fromInt(i)), ev.fromInt(j))
       val z = ev.div(arr(i), ev.fromInt(j))
       sum = ev.plus(t, z)
@@ -121,45 +125,45 @@ final class ArrayOps[@spec A](arr:Array[A]) {
     Searching.search(arr, a)
   }
 
-  def qsort(implicit ev:Order[A], ct:ClassTag[A]) {
+  def qsort(implicit ev: Order[A], ct: ClassTag[A]) {
     Sorting.sort(arr)
   }
 
-  def qsortBy[@spec B](f:A => B)(implicit ev:Order[B], ct:ClassTag[A]) {
+  def qsortBy[@spec B](f: A => B)(implicit ev: Order[B], ct: ClassTag[A]) {
     implicit val ord: Order[A] = ev.on(f)
     Sorting.sort(arr)
   }
 
-  def qsortWith(f:(A, A) => Int)(implicit ct:ClassTag[A]) {
+  def qsortWith(f: (A, A) => Int)(implicit ct: ClassTag[A]) {
     implicit val ord: Order[A] = Order.from(f)
     Sorting.sort(arr)
   }
 
-  def qsorted(implicit ev:Order[A], ct:ClassTag[A]): Array[A] = {
+  def qsorted(implicit ev: Order[A], ct: ClassTag[A]): Array[A] = {
     val arr2 = arr.clone
     Sorting.sort(arr2)
     arr2
   }
 
-  def qsortedBy[@spec B](f:A => B)(implicit ev:Order[B], ct:ClassTag[A]): Array[A] = {
+  def qsortedBy[@spec B](f: A => B)(implicit ev: Order[B], ct: ClassTag[A]): Array[A] = {
     implicit val ord: Order[A] = ev.on(f)
     val arr2 = arr.clone
     Sorting.sort(arr2)
     arr2
   }
 
-  def qsortedWith(f:(A, A) => Int)(implicit ct:ClassTag[A]): Array[A] = {
+  def qsortedWith(f: (A, A) => Int)(implicit ct: ClassTag[A]): Array[A] = {
     implicit val ord: Order[A] = Order.from(f)
     val arr2 = arr.clone
     Sorting.sort(arr2)
     arr2
   }
 
-  def qselect(k: Int)(implicit ev:Order[A], ct:ClassTag[A]) {
+  def qselect(k: Int)(implicit ev: Order[A], ct: ClassTag[A]) {
     Selection.select(arr, k)
   }
 
-  def qselected(k: Int)(implicit ev:Order[A], ct:ClassTag[A]): Array[A] = {
+  def qselected(k: Int)(implicit ev: Order[A], ct: ClassTag[A]): Array[A] = {
     val arr2 = arr.clone
     Selection.select(arr2, k)
     arr2
@@ -184,8 +188,8 @@ final class IndexedSeqOps[@spec A, CC[A] <: IndexedSeq[A]](as: CC[A]) {
     Searching.search(as, a)
 }
 
-final class SeqOps[@spec A, CC[A] <: Iterable[A]](as:CC[A]) {
-  def qsum(implicit ev:Rig[A]) = {
+final class SeqOps[@spec A, CC[A] <: Iterable[A]](as: CC[A]) {
+  def qsum(implicit ev: Rig[A]) = {
     var sum = ev.zero
     val f: A => Unit = (a: A) => sum = ev.plus(sum, a)
     as.foreach(f)
@@ -193,33 +197,33 @@ final class SeqOps[@spec A, CC[A] <: Iterable[A]](as:CC[A]) {
     sum
   }
 
-  def qproduct(implicit ev:Rig[A]) = {
+  def qproduct(implicit ev: Rig[A]) = {
     var prod = ev.one
     as.foreach(a => prod = ev.times(prod, a))
     prod
   }
 
-  def qnorm(p:Int)(implicit ev:Field[A], s: Signed[A], nr:NRoot[A]) = {
+  def qnorm(p: Int)(implicit ev: Field[A], s: Signed[A], nr: NRoot[A]) = {
     var t = ev.one
     as.foreach(a => t = ev.plus(t, ev.pow(s.abs(a), p)))
     nr.nroot(t, p)
   }
 
-  def qmin(implicit ev:Order[A]) = {
+  def qmin(implicit ev: Order[A]) = {
     if (as.isEmpty) sys.error("empty seq")
     var min = as.head
     as.foreach(a => min = ev.min(min, a))
     min
   }
 
-  def qmax(implicit ev:Order[A]) = {
+  def qmax(implicit ev: Order[A]) = {
     if (as.isEmpty) sys.error("empty seq")
     var max = as.head
     as.foreach(a => max = ev.max(max, a))
     max
   }
 
-  def qmean(implicit ev:Field[A]): A = {
+  def qmean(implicit ev: Field[A]): A = {
     if (as.isEmpty) sys.error("empty seq")
     var mean = ev.zero
     var i = 0
@@ -236,7 +240,7 @@ final class SeqOps[@spec A, CC[A] <: Iterable[A]](as:CC[A]) {
 
   import spire.math.{Sorting, Selection}
 
-  protected[this] def toSizeAndArray(implicit ct:ClassTag[A]) = {
+  protected[this] def toSizeAndArray(implicit ct: ClassTag[A]) = {
     val len = as.size
     val arr = new Array[A](len)
     var i = 0
@@ -247,7 +251,7 @@ final class SeqOps[@spec A, CC[A] <: Iterable[A]](as:CC[A]) {
     (len, arr)
   }
 
-  protected[this] def fromSizeAndArray(len: Int, arr: Array[A])(implicit cbf:CanBuildFrom[CC[A], A, CC[A]]) = {
+  protected[this] def fromSizeAndArray(len: Int, arr: Array[A])(implicit cbf: CanBuildFrom[CC[A], A, CC[A]]) = {
     val b = cbf(as)
     b.sizeHint(len)
     var i = 0
@@ -258,27 +262,27 @@ final class SeqOps[@spec A, CC[A] <: Iterable[A]](as:CC[A]) {
     b.result
   }
 
-  def qsorted(implicit ev:Order[A], ct:ClassTag[A], cbf:CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
+  def qsorted(implicit ev: Order[A], ct: ClassTag[A], cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
     val (len, arr) = toSizeAndArray
     Sorting.sort(arr)
     fromSizeAndArray(len, arr)
   }
   
-  def qsortedBy[@spec B](f:A => B)(implicit ev:Order[B], ct:ClassTag[A], cbf:CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
+  def qsortedBy[@spec B](f: A => B)(implicit ev: Order[B], ct: ClassTag[A], cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
     val (len, arr) = toSizeAndArray
     implicit val ord: Order[A] = ev.on(f)
     Sorting.sort(arr)
     fromSizeAndArray(len, arr)
   }
   
-  def qsortedWith(f:(A, A) => Int)(implicit ct:ClassTag[A], cbf:CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
+  def qsortedWith(f: (A, A) => Int)(implicit ct: ClassTag[A], cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
     val (len, arr) = toSizeAndArray
     implicit val ord: Order[A] = Order.from(f)
     Sorting.sort(arr)
     fromSizeAndArray(len, arr)
   }
   
-  def qselected(k: Int)(implicit ev:Order[A], ct:ClassTag[A], cbf:CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
+  def qselected(k: Int)(implicit ev: Order[A], ct: ClassTag[A], cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
     val (len, arr) = toSizeAndArray
     Selection.select(arr, k)
     fromSizeAndArray(len, arr)

--- a/core/src/test/scala/spire/math/PackageCheck.scala
+++ b/core/src/test/scala/spire/math/PackageCheck.scala
@@ -1,0 +1,32 @@
+package spire.math
+
+import org.scalatest.matchers.ShouldMatchers
+import org.scalacheck.Arbitrary._
+import org.scalatest._
+import prop._
+
+class PackageCheck extends PropSpec with ShouldMatchers with GeneratorDrivenPropertyChecks {
+  property("fib(n + 2) = fib(n + 1) + fib(n)") {
+    forAll { (n0: Byte) =>
+      val n = n0.toLong.abs
+      fib(n + 2) should be === fib(n + 1) + fib(n)
+    }
+  }
+
+  property("(n + 1)! = n! * (n + 1)") {
+    forAll { (n0: Byte) =>
+      val n = n0.toLong.abs + 1
+      fact(n + 1) should be === fact(n) * (n + 1)
+    }
+  }
+
+  property("choose(n, k) = n!/(k! * (n-k)!)") {
+    forAll { (n0: Byte, k0: Byte) =>
+      val k = k0.toLong.abs
+      val n = n0.toLong.abs
+      if (k > n) choose(n, k) should be === 0
+      else if (k == 0 || k == n) choose(n, k) should be === 1
+      else choose(n, k) should be === fact(n) / (fact(k) * fact(n - k))
+    }
+  }
+}


### PR DESCRIPTION
The functions are:

  fib(n): The nth Fibonnaci number (the 0th is 0, the 1st is 1)
  fact(n): The nth factorial (the 0th is 0, the 1st is 1)
  choose(n, k): The binomial coefficient (n k), i.e. n!/k!(n-k)!

These three functions aren't hard to implement, but in Spire we have
an opportunity to create versions that are a bit faster (or more
resilient) than a totally naive approach.

There is still a lot of room to make these methods faster. But
for now they seem to perform well.
