### PR TITLE
Module only requires Rng.

### DIFF
--- a/core/src/main/scala/spire/algebra/Module.scala
+++ b/core/src/main/scala/spire/algebra/Module.scala
@@ -7,7 +7,7 @@ import scala.{ specialized => spec }
  * a ring, rather than a field.
  */
 trait Module[V, @spec(Int,Long,Float,Double) R] extends AdditiveAbGroup[V] {
-  implicit def scalar: Ring[R] // TODO: Can this be Rng[R] instead?
+  implicit def scalar: Rng[R]
 
   def timesl(r: R, v: V): V
   def timesr(v: V, r: R): V = timesl(r, v)

--- a/core/src/main/scala/spire/std/map.scala
+++ b/core/src/main/scala/spire/std/map.scala
@@ -28,7 +28,7 @@ with Group[Map[K, V]] with Serializable {
 }
 
 @SerialVersionUID(0L)
-class MapRng[K, V](implicit val scalar: Ring[V]) extends RingAlgebra[Map[K, V], V]
+class MapRng[K, V](implicit val scalar: Rng[V]) extends RingAlgebra[Map[K, V], V]
 with Serializable { self =>
   def zero: Map[K, V] = Map.empty
 
@@ -118,7 +118,7 @@ class MapVectorEq[K, V](implicit V: Eq[V], scalar: AdditiveMonoid[V]) extends Eq
 trait MapInstances0 {
   implicit def MapMonoid[K, V: Semigroup] = new MapMonoid[K, V]
 
-  implicit def MapRng[K, V: Ring] = new MapRng[K, V]
+  implicit def MapRng[K, V: Rng] = new MapRng[K, V]
 }
 
 trait MapInstances1 extends MapInstances0 {

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -272,8 +272,8 @@ final class ModuleOps[V](x: V) {
   def :*[F](rhs:F)(implicit ev: Module[V, F]): V = macro Ops.binopWithEv[F, Module[V, F], V]
 
   // TODO: Are macros worth it here?
-  def *:[F](lhs:Int)(implicit ev: Module[V, F]): V = ev.timesl(ev.scalar.fromInt(lhs), x)
-  def :*[F](rhs:Int)(implicit ev: Module[V, F]): V = ev.timesr(x, ev.scalar.fromInt(rhs))
+  def *:[F](lhs:Int)(implicit ev: Module[V, F], F: Ring[F]): V = ev.timesl(F.fromInt(lhs), x)
+  def :*[F](rhs:Int)(implicit ev: Module[V, F], F: Ring[F]): V = ev.timesr(x, F.fromInt(rhs))
 }
 
 final class VectorSpaceOps[V](x: V) {

--- a/core/src/test/scala/spire/SyntaxTest.scala
+++ b/core/src/test/scala/spire/SyntaxTest.scala
@@ -278,9 +278,8 @@ trait BaseSyntaxTest {
       ((a ** 0.5) == NRoot[A].fpow(a, half))
   }
 
-  def testModuleSyntax[V, A](v: V, w: V, a: A)(implicit V: Module[V, A]) = {
+  def testModuleSyntax[V, A](v: V, w: V, a: A)(implicit V: Module[V, A], A: Ring[A]) = {
     import spire.syntax.module._
-    implicit def A: Ring[A] = V.scalar
     ((v + w) == V.plus(v, w)) &&
       ((v - w) == V.minus(v, w)) &&
       (-v == V.negate(v)) &&

--- a/scalacheck-binding/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -15,7 +15,7 @@ object VectorSpaceLaws {
 
 trait VectorSpaceLaws[V, A] extends Laws {
 
-  implicit def scalar(implicit V: Module[V, A]): Ring[A] = V.scalar
+  implicit def scalar(implicit V: Module[V, A]): Rng[A] = V.scalar
 
   val scalarLaws: RingLaws[A]
   val vectorLaws: GroupLaws[V]
@@ -26,7 +26,7 @@ trait VectorSpaceLaws[V, A] extends Laws {
 
   def module(implicit V: Module[V, A]) = new SpaceProperties(
     name = "module",
-    sl = _.ring(V.scalar),
+    sl = _.rng(V.scalar),
     vl = _.abGroup(V.additive),
     parents = Seq.empty,
 
@@ -40,10 +40,10 @@ trait VectorSpaceLaws[V, A] extends Laws {
     ),
     "vector distributes over scalar" → forAll((r: A, s: A, v: V) =>
       ((r + s) *: v) === ((r *: v) + (s *: v))
-    ),
+    )/*,
     "scalar identity is identity" → forAll((v: V) =>
       (V.scalar.one *: v) === v
-    )
+    )*/
   )
 
   def vectorSpace(implicit V: VectorSpace[V, A]) = new SpaceProperties(
@@ -53,14 +53,14 @@ trait VectorSpaceLaws[V, A] extends Laws {
     parents = Seq(module)
   )
 
-  def metricSpace(implicit V: MetricSpace[V, A], o: Order[A], A: Ring[A]) = new SpaceProperties(
+  def metricSpace(implicit V: MetricSpace[V, A], o: Order[A], A: Rng[A]) = new SpaceProperties(
     name = "metric space",
     sl = _.emptyProperties,
     vl = _.emptyProperties,
     parents = Seq.empty,
     "identity" → forAll((x: V, y: V) =>
-      if (x === y) V.distance(x, y) === Ring[A].zero
-      else V.distance(x, y) =!= Ring[A].zero
+      if (x === y) V.distance(x, y) === Rng[A].zero
+      else V.distance(x, y) =!= Rng[A].zero
     ),
     "symmetric" → forAll((x: V, y: V) =>
       V.distance(x, y) === V.distance(y, x)
@@ -81,9 +81,9 @@ trait VectorSpaceLaws[V, A] extends Laws {
     ),
     "only 1 zero" → forAll((v: V) => // This is covered by metricSpace...
       if (v === V.zero)
-        v.norm === Ring[A].zero
+        v.norm === Rng[A].zero
       else
-        v.norm > Ring[A].zero
+        v.norm > Rng[A].zero
     )
   )
 


### PR DESCRIPTION
This removes the requirement that Module's scalar lies in a Ring.
Instead, it now only requires a Rng. This makes the use of nested
instances of infinite vectors (like Map's Rng) possible.
