### PR TITLE
Fix for Field[Number].zero returning null.

### DIFF
--- a/core/src/main/scala/spire/math/Number.scala
+++ b/core/src/main/scala/spire/math/Number.scala
@@ -569,11 +569,11 @@ trait NumberInstances {
 private[math] trait NumberIsRing extends Ring[Number] {
   override def minus(a:Number, b:Number): Number = a - b
   def negate(a:Number): Number = -a
-  val one: Number = Number.one
+  def one: Number = Number.one
   def plus(a:Number, b:Number): Number = a + b
   override def pow(a:Number, b:Int): Number = a.pow(Number(b))
   override def times(a:Number, b:Number): Number = a * b
-  val zero: Number = Number.zero
+  def zero: Number = Number.zero
   
   override def fromInt(n: Int): Number = Number(n)
 }


### PR DESCRIPTION
So, apparently using vals in type class traits which access final vals in companion objects is a recipe for disaster. Due to some weird initialization bug or something, the type class instance access the field before it is initialized and so the val in the type class instance is populated with `null` instead of `Number(0)`.
