### PR TITLE
Fix for search on types that implement a non-standard comparison method.

### DIFF
--- a/core/src/main/scala/spire/math/Searching.scala
+++ b/core/src/main/scala/spire/math/Searching.scala
@@ -15,11 +15,11 @@ object Searching {
     var last = upper
     while (first <= last) {
       val middle = (first + last) >>> 1
-      as(middle).compare(item) match {
-        case -1 => first = middle + 1
-        case 1 => last = middle - 1
-        case 0 => return middle
-      }
+
+      val compare = as(middle).compare(item)
+      if (compare < 0) first = middle + 1
+      else if (compare > 0) last = middle - 1
+      else return middle
     }
     -first - 1
   }
@@ -32,11 +32,11 @@ object Searching {
     var last = upper
     while (first <= last) {
       val middle = (first + last) >>> 1
-      as(middle).compare(item) match {
-        case -1 => first = middle + 1
-        case 1 => last = middle - 1
-        case 0 => return middle
-      }
+
+      val compare = as(middle).compare(item)
+      if (compare < 0) first = middle + 1
+      else if (compare > 0) last = middle - 1
+      else return middle
     }
     -first - 1
   }

--- a/core/src/test/scala/spire/math/SearchTest.scala
+++ b/core/src/test/scala/spire/math/SearchTest.scala
@@ -1,0 +1,21 @@
+package spire.math
+
+import spire.implicits._
+import spire.syntax.order._
+import spire.algebra._
+
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
+
+class SearchTest extends FunSuite {
+  test("search when type provides a traditional comparison method") {
+    assert(Searching.search(Array(1, 2, 3), 0) == -1)
+    assert(Searching.search(Array(1, 2, 3), 2) == 1)
+  }
+
+  test("search when comparison can be a value not in {-1, 0, 1}") {
+    assert(Searching.search(Array("a", "b", "c"), "aaa") < 0)
+    assert(Searching.search(Array("a", "b", "c"), "b") == 1)
+  }
+}
+


### PR DESCRIPTION
Spire search was throwing a match error on types where the result of compare could be an integer outside of the set {-1, 0, 1} such as String.
