### PR TITLE
update dependencies

### DIFF
--- a/macros/src/test/scala/spire/macros/CheckedTest.scala
+++ b/macros/src/test/scala/spire/macros/CheckedTest.scala
@@ -18,7 +18,7 @@ class CheckedTest extends FunSuite with GeneratorDrivenPropertyChecks with Match
     if (value.isValidLong) {
       check should equal (value.toLong)
     } else {
-      evaluating { check } should produce[ArithmeticException]
+      an[ArithmeticException] should be thrownBy { check }
     }
   }
 
@@ -26,13 +26,13 @@ class CheckedTest extends FunSuite with GeneratorDrivenPropertyChecks with Match
     if (value.isValidInt) {
       check should equal (value.toInt)
     } else {
-      evaluating { check } should produce[ArithmeticException]
+      an[ArithmeticException] should be thrownBy { check }
     }
   }
 
   test("Negate of Int.MinValue overflows") {
     val x = Int.MinValue
-    evaluating { checked(-x) } should produce[ArithmeticException]
+    an[ArithmeticException] should be thrownBy { checked(-x) }
   }
 
   test("Int negate overflow throws arithmetic exception") {
@@ -75,7 +75,7 @@ class CheckedTest extends FunSuite with GeneratorDrivenPropertyChecks with Match
 
   test("Negate of Long.MinValue overflows") {
     val x = Long.MinValue
-    evaluating { checked(-x) } should produce[ArithmeticException]
+    an[ArithmeticException] should be thrownBy { checked(-x) }
   }
 
   test("Long negate overflow throws arithmetic exception") {
@@ -127,42 +127,42 @@ class CheckedTest extends FunSuite with GeneratorDrivenPropertyChecks with Match
       y + x
     } should equal(Some(Int.MaxValue.toLong + 2))
 
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Long.MaxValue
       val y = 2
       x * y
-    }) should produce[ArithmeticException]
+    })
 
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Long.MaxValue
       val y = 2
       y * x
-    }) should produce[ArithmeticException]
+    })
   }
 
   test("Byte and Short upgrade to Int when mixed") {
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Int.MaxValue
       val y = (2: Byte)
       x * y
-    }) should produce[ArithmeticException]
+    })
 
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Int.MaxValue
       val y = (2: Byte)
       y * x
-    }) should produce[ArithmeticException]
+    })
 
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Int.MaxValue
       val y = (2: Short)
       x * y
-    }) should produce[ArithmeticException]
+    })
 
-    evaluating(checked {
+    an[ArithmeticException] should be thrownBy (checked {
       val x = Int.MaxValue
       val y = (2: Short)
       y * x
-    }) should produce[ArithmeticException]
+    })
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,8 +18,8 @@ object MyBuild extends Build {
 
   // Dependencies
 
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.0"
-  lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.10.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.1.0"
+  lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.3"
 
   // Release step
 
@@ -52,9 +52,6 @@ object MyBuild extends Build {
 
     scalaVersion := "2.10.2",
 
-    // disable annoying warnings about 2.10.x
-    conflictWarning in ThisBuild := ConflictWarning.disable,
-
     licenses := Seq("BSD-style" -> url("http://opensource.org/licenses/MIT")),
     homepage := Some(url("http://spire-math.org")),
 
@@ -75,6 +72,7 @@ object MyBuild extends Build {
     ),
 
     resolvers += Resolver.sonatypeRepo("snapshots"),
+    resolvers += Resolver.sonatypeRepo("releases"),
     addCompilerPlugin("org.scala-lang.plugins" % "macro-paradise_2.10.2" % "2.0.0-SNAPSHOT"),
 
     publishMavenStyle := true,
@@ -199,7 +197,7 @@ object MyBuild extends Build {
   lazy val scalacheckSettings = Seq(
     name := "spire-scalacheck-binding",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "discipline" % "0.1",
+      "org.typelevel" %% "discipline" % "0.2",
       scalaCheck
     )
   )


### PR DESCRIPTION
Scalacheck to 1.11, hence Scalatest to 2.1.0 and discipline to the just-released 0.2.
