### PR TITLE
Upgrade sbt plugins to latest versions.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -128,7 +128,7 @@ object MyBuild extends Build {
   lazy val spireSettings = Seq(
     name := "spire-aggregate"
   ) ++ noPublish ++ unidocSettings ++ Seq(
-    excludedProjects in unidoc in ScalaUnidoc ++= Seq("examples", "benchmark", "tests")
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(examples, benchmark, tests)
   ) ++ releaseSettings ++ Seq(
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.5")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.1")


### PR DESCRIPTION
Unidoc 0.3.0 has changed the way you configure excluded projects so we
updated the build configuration.

The outdated versions of plugins depended on outdated version of dispatch
library and that was causing problems when plugging spire into Scala
community build.
