### PR TITLE
migrates to paradise 2.0.0-M6

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,8 +81,8 @@ object MyBuild extends Build {
         // in Scala 2.10, quasiquotes are provided by macro-paradise
         case Some((2, 10)) =>
           libraryDependencies.value ++ Seq(
-            compilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M3" cross CrossVersion.full),
-            "org.scalamacros" %% "quasiquotes" % "2.0.0-M3" cross CrossVersion.full)
+            compilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M6" cross CrossVersion.full),
+            "org.scalamacros" %% "quasiquotes" % "2.0.0-M6" cross CrossVersion.full)
       }
     },
 


### PR DESCRIPTION
Tested 2.10.2 locally, and everything went fine. 

`++2.11.0-RC3 test` couldn't find an appropriate version of scalatest. Is there an easy way to also run tests for 2.11 in order to make sure that everything works fine there as well?
