### PR TITLE
Fix bug in Well44497a, Well44497b and clean up syntax in all Well PRNGs

### DIFF
--- a/core/src/main/scala/spire/random/mutable/Well1024a.scala
+++ b/core/src/main/scala/spire/random/mutable/Well1024a.scala
@@ -18,9 +18,8 @@ package mutable
 
 import spire.syntax.cfor._
 import spire.util.Pack
-import spire.math.max
 import java.nio.ByteBuffer
-import java.util.Arrays
+import java.util
 
 /**
  * This is a Scala implementation of the Well1024a PRNG based on WELL1024a.c.
@@ -39,7 +38,7 @@ import java.util.Arrays
  */
 final class Well1024a protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well1024a.{K, R, R_1, BYTES, M1, M2, M3, mat0pos, mat0neg}
+  import Well1024a.{R, R_1, BYTES, M1, M2, M3, mat0pos, mat0neg}
 
   /*
     @inline private final val v0   = new Utils.IntArrayWrapper(i => i, state)
@@ -53,7 +52,7 @@ final class Well1024a protected[random](state: Array[Int], i0: Int) extends IntB
 
   private var i : Int = i0
 
-  def copyInit: Well1024a = new Well1024a(state.clone, i)
+  def copyInit: Well1024a = new Well1024a(state.clone(), i)
 
   def getSeedBytes(): Array[Byte] = {
     val bytes = new Array[Byte](BYTES)
@@ -65,10 +64,10 @@ final class Well1024a protected[random](state: Array[Int], i0: Int) extends IntB
   }
 
   def setSeedBytes(bytes: Array[Byte]) {
-    val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
+    val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
-    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt() }
+    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt }
     i = bb.getInt
   }
 
@@ -131,14 +130,14 @@ object Well1024a extends GeneratorCompanion[Well1024a, (Array[Int], Int)] {
 
   def fromSeed(seed: (Array[Int], Int)): Well1024a =
     seed match {
-      case (state, statei) =>
+      case (state, stateIndex) =>
         assert(state.length == R)
-        new Well1024a(state, statei)
+        new Well1024a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well1024a = fromSeed((Utils.seedFromArray(R, arr)), 0)
+  def fromArray(arr: Array[Int]): Well1024a = fromSeed(Utils.seedFromArray(R, arr), 0)
 
   def fromBytes(bytes: Array[Byte]): Well1024a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well1024a = fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time))), 0)
+  def fromTime(time: Long = System.nanoTime) : Well1024a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
 }

--- a/core/src/main/scala/spire/random/mutable/Well19937a.scala
+++ b/core/src/main/scala/spire/random/mutable/Well19937a.scala
@@ -18,9 +18,8 @@ package mutable
 
 import spire.syntax.cfor._
 import spire.util.Pack
-import spire.math.max
 import java.nio.ByteBuffer
-import java.util.Arrays
+import java.util
 
 /**
  * This is a Scala implementation of the Well19937a PRNG based on WELL19937a.c.
@@ -39,7 +38,7 @@ import java.util.Arrays
  */
 final class Well19937a protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well19937a.{UpperMask, LowerMask, K, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos}
+  import Well19937a.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos}
 
   /*
     @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
@@ -55,7 +54,7 @@ final class Well19937a protected[random](state: Array[Int], i0: Int) extends Int
 
   private var i : Int = i0
 
-  def copyInit: Well19937a = new Well19937a(state.clone, i)
+  def copyInit: Well19937a = new Well19937a(state.clone(), i)
 
   def getSeedBytes(): Array[Byte] = {
     val bytes = new Array[Byte](BYTES)
@@ -67,10 +66,10 @@ final class Well19937a protected[random](state: Array[Int], i0: Int) extends Int
   }
 
   def setSeedBytes(bytes: Array[Byte]) {
-    val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
+    val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
-    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt() }
+    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt }
     i = bb.getInt
   }
 
@@ -146,14 +145,14 @@ object Well19937a extends GeneratorCompanion[Well19937a, (Array[Int], Int)] {
 
   def fromSeed(seed: (Array[Int], Int)): Well19937a =
     seed match {
-      case (state, statei) =>
+      case (state, stateIndex) =>
         assert(state.length == R)
-        new Well19937a(state, statei)
+        new Well19937a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well19937a = fromSeed((Utils.seedFromArray(R, arr)), 0)
+  def fromArray(arr: Array[Int]): Well19937a = fromSeed(Utils.seedFromArray(R, arr), 0)
 
   def fromBytes(bytes: Array[Byte]): Well19937a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well19937a = fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time))), 0)
+  def fromTime(time: Long = System.nanoTime) : Well19937a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
 }

--- a/core/src/main/scala/spire/random/mutable/Well19937c.scala
+++ b/core/src/main/scala/spire/random/mutable/Well19937c.scala
@@ -18,9 +18,8 @@ package mutable
 
 import spire.syntax.cfor._
 import spire.util.Pack
-import spire.math.max
 import java.nio.ByteBuffer
-import java.util.Arrays
+import java.util
 
 /**
  * This is a Scala implementation of the Well19937c PRNG based on WELL19937a.c.
@@ -39,7 +38,7 @@ import java.util.Arrays
  */
 final class Well19937c protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well19937c.{UpperMask, LowerMask, K, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos, TemperB, TemperC}
+  import Well19937c.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos, TemperB, TemperC}
 
   /*
     @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
@@ -55,7 +54,7 @@ final class Well19937c protected[random](state: Array[Int], i0: Int) extends Int
 
   private var i : Int = i0
 
-  def copyInit: Well19937c = new Well19937c(state.clone, i)
+  def copyInit: Well19937c = new Well19937c(state.clone(), i)
 
   def getSeedBytes(): Array[Byte] = {
     val bytes = new Array[Byte](BYTES)
@@ -67,10 +66,10 @@ final class Well19937c protected[random](state: Array[Int], i0: Int) extends Int
   }
 
   def setSeedBytes(bytes: Array[Byte]) {
-    val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
+    val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
-    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt() }
+    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt }
     i = bb.getInt
   }
 
@@ -154,14 +153,14 @@ object Well19937c extends GeneratorCompanion[Well19937c, (Array[Int], Int)] {
 
   def fromSeed(seed: (Array[Int], Int)): Well19937c =
     seed match {
-      case (state, statei) =>
+      case (state, stateIndex) =>
         assert(state.length == R)
-        new Well19937c(state, statei)
+        new Well19937c(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well19937c = fromSeed((Utils.seedFromArray(R, arr)), 0)
+  def fromArray(arr: Array[Int]): Well19937c = fromSeed(Utils.seedFromArray(R, arr), 0)
 
   def fromBytes(bytes: Array[Byte]): Well19937c = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well19937c = fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time))), 0)
+  def fromTime(time: Long = System.nanoTime) : Well19937c = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
 }

--- a/core/src/main/scala/spire/random/mutable/Well44497b.scala
+++ b/core/src/main/scala/spire/random/mutable/Well44497b.scala
@@ -18,9 +18,8 @@ package mutable
 
 import spire.syntax.cfor._
 import spire.util.Pack
-import spire.math.max
 import java.nio.ByteBuffer
-import java.util.Arrays
+import java.util
 
 /**
  * This is a Scala implementation of the Well44497b PRNG based on WELL44497a.c.
@@ -39,7 +38,7 @@ import java.util.Arrays
  */
 final class Well44497b protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well44497b.{UpperMask, LowerMask, K, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat2, mat3pos, mat3neg, mat4pos, mat4neg, mat5, TemperB, TemperC}
+  import Well44497b.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3neg, mat5, TemperB, TemperC}
 
   /*
     @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
@@ -55,7 +54,7 @@ final class Well44497b protected[random](state: Array[Int], i0: Int) extends Int
 
   private var i : Int = i0
 
-  def copyInit: Well44497b = new Well44497b(state.clone, i)
+  def copyInit: Well44497b = new Well44497b(state.clone(), i)
 
   def getSeedBytes(): Array[Byte] = {
     val bytes = new Array[Byte](BYTES)
@@ -67,10 +66,10 @@ final class Well44497b protected[random](state: Array[Int], i0: Int) extends Int
   }
 
   def setSeedBytes(bytes: Array[Byte]) {
-    val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
+    val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
-    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt() }
+    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt }
     i = bb.getInt
   }
 
@@ -86,7 +85,7 @@ final class Well44497b protected[random](state: Array[Int], i0: Int) extends Int
       else n
     }
 
-    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2) & UpperMask))
+    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)
     val z1: Int = mat0neg(-24, state(i)) ^ mat0pos(30, state(map(M1)))
     val z2: Int = mat0neg(-10, state(map(M2))) ^ mat3neg(-26, state(map(M3)))
 
@@ -148,11 +147,11 @@ object Well44497b extends GeneratorCompanion[Well44497b, (Array[Int], Int)] {
   @inline private final def mat0pos(t: Int, v: Int)         = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int)         = v ^ (v << -t)
   @inline private final def mat1(v: Int)                    = v
-  @inline private final def mat2(a: Int, v: Int)            = if ((v & 1) != 0) (v >>> 1) ^ a else (v >>> 1)
-  @inline private final def mat3pos(t: Int, v: Int)         = v >>> t
+  // @inline private final def mat2(a: Int, v: Int)            = if ((v & 1) != 0) (v >>> 1) ^ a else v >>> 1
+  // @inline private final def mat3pos(t: Int, v: Int)         = v >>> t
   @inline private final def mat3neg(t: Int, v: Int)         = v << -t
-  @inline private final def mat4pos(t: Int, b: Int, v: Int) = v ^ ((v >>> t) & b)
-  @inline private final def mat4neg(t: Int, b: Int, v: Int) = v ^ ((v << -t) & b)
+  // @inline private final def mat4pos(t: Int, b: Int, v: Int) = v ^ ((v >>> t) & b)
+  // @inline private final def mat4neg(t: Int, b: Int, v: Int) = v ^ ((v << -t) & b)
   @inline private final def mat5(r: Int, a: Int, ds: Int, dt: Int, v: Int) = {
     if ((v & dt) != 0) {
       (((v << r) ^ (v >>> (32 - r))) & ds) ^ a
@@ -165,14 +164,14 @@ object Well44497b extends GeneratorCompanion[Well44497b, (Array[Int], Int)] {
 
   def fromSeed(seed: (Array[Int], Int)): Well44497b =
     seed match {
-      case (state, statei) =>
+      case (state, stateIndex) =>
         assert(state.length == R)
-        new Well44497b(state, statei)
+        new Well44497b(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well44497b = fromSeed((Utils.seedFromArray(R, arr)), 0)
+  def fromArray(arr: Array[Int]): Well44497b = fromSeed(Utils.seedFromArray(R, arr), 0)
 
   def fromBytes(bytes: Array[Byte]): Well44497b = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well44497b = fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time))), 0)
+  def fromTime(time: Long = System.nanoTime) : Well44497b = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
 }

--- a/core/src/main/scala/spire/random/mutable/Well512a.scala
+++ b/core/src/main/scala/spire/random/mutable/Well512a.scala
@@ -18,9 +18,8 @@ package mutable
 
 import spire.syntax.cfor._
 import spire.util.Pack
-import spire.math.max
 import java.nio.ByteBuffer
-import java.util.Arrays
+import java.util
 
 /**
  * This is a Scala implementation of the Well512a PRNG based on WELL512a.c.
@@ -39,7 +38,7 @@ import java.util.Arrays
  */
 final class Well512a protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well512a.{K, R, R_1, BYTES, M1, M2, M3, mat0pos, mat0neg, mat3neg, mat4neg}
+  import Well512a.{R, R_1, BYTES, M1, M2, mat0pos, mat0neg, mat3neg, mat4neg}
 
   /*
     @inline private final val v0    = new Utils.IntArrayWrapper(i => i, state)
@@ -52,7 +51,7 @@ final class Well512a protected[random](state: Array[Int], i0: Int) extends IntBa
 
   private var i : Int = i0
 
-  def copyInit: Well512a = new Well512a(state.clone, i)
+  def copyInit: Well512a = new Well512a(state.clone(), i)
 
   def getSeedBytes(): Array[Byte] = {
     val bytes = new Array[Byte](BYTES)
@@ -64,10 +63,10 @@ final class Well512a protected[random](state: Array[Int], i0: Int) extends IntBa
   }
 
   def setSeedBytes(bytes: Array[Byte]) {
-    val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
+    val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
-    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt() }
+    cfor(0)(_ < R, _ + 1) { i => state(i) = bb.getInt }
     i = bb.getInt
   }
 
@@ -121,7 +120,7 @@ object Well512a extends GeneratorCompanion[Well512a, (Array[Int], Int)] {
   @inline private final val M2 : Int = 9
 
   /** Third parameter of the algorithm. */
-  @inline private final val M3 : Int = 5
+  // @inline private final val M3 : Int = 5
 
   @inline private final def mat0pos(t: Int, v: Int)         = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int)         = v ^ (v << -t)
@@ -132,14 +131,14 @@ object Well512a extends GeneratorCompanion[Well512a, (Array[Int], Int)] {
 
   def fromSeed(seed: (Array[Int], Int)): Well512a =
     seed match {
-      case (state, statei) =>
+      case (state, stateIndex) =>
         assert(state.length == R)
-        new Well512a(state, statei)
+        new Well512a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well512a = fromSeed((Utils.seedFromArray(R, arr)), 0)
+  def fromArray(arr: Array[Int]): Well512a = fromSeed(Utils.seedFromArray(R, arr), 0)
 
   def fromBytes(bytes: Array[Byte]): Well512a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well512a = fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time))), 0)
+  def fromTime(time: Long = System.nanoTime) : Well512a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
 }


### PR DESCRIPTION
1. Fixes a bug in Well44497 parenthesing:
   `val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2) & UpperMask))`
   should be
   `val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)`
2. Comments out unused parts of the WELL algorithms (defined yet unused in the original algorithms).
3. Removes unused imports.
4. Cleans code syntax up (makes code pass IntelliJ IDEA inspections).
