### PR TITLE
Remove 30% performance impact from Well19937a/c, Well44497a/b through index caching

### DIFF
--- a/core/src/main/scala/spire/random/mutable/Well19937a.scala
+++ b/core/src/main/scala/spire/random/mutable/Well19937a.scala
@@ -38,19 +38,7 @@ import java.util
  */
 final class Well19937a protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well19937a.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos}
-
-  /*
-    @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
-    @inline private final val vm1     = new Utils.IntArrayWrapper(i => (i + M1) % R, state)
-    @inline private final val vm2     = new Utils.IntArrayWrapper(i => (i + M2) % R, state)
-    @inline private final val vm3     = new Utils.IntArrayWrapper(i => (i + M3) % R, state)
-    @inline private final val vrm1    = new Utils.IntArrayWrapper(i => (i + R_1) % R, state)
-    @inline private final val vrm2    = new Utils.IntArrayWrapper(i => (i + R_2) % R, state)
-    @inline private final val newV0   = vrm1
-    @inline private final val newV1   = v0
-    @inline private final val newVrm1 = vrm2
-  */
+  import Well19937a.{UpperMask, LowerMask, R, BYTES, mat0pos, mat0neg, mat1, mat3pos}
 
   private var i : Int = i0
 
@@ -78,30 +66,15 @@ final class Well19937a protected[random](state: Array[Int], i0: Int) extends Int
    */
   def nextInt(): Int = {
 
-    @inline def map(r: Int) = {
-      val n = i + r
-      if (n >= R) n - R
-      else if (n < 0) n + R
-      else n
-    }
+    import Well19937acIndexCache._
 
-    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)
-    val z1: Int = mat0neg(-25, state(i)) ^ mat0pos(27, state(map(M1)))
-    val z2: Int = mat3pos(9, state(map(M2))) ^ mat0pos(1, state(map(M3)))
+    val z0: Int = (state(vrm1(i)) & LowerMask) | (state(vrm2(i)) & UpperMask)
+    val z1: Int = mat0neg(-25, state(i)) ^ mat0pos(27, state(vm1(i)))
+    val z2: Int = mat3pos(9, state(vm2(i))) ^ mat0pos(1, state(vm3(i)))
 
     state(i) = z1 ^ z2
-    state(map(R_1)) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, state(i))
-    i = map(R_1)
-
-    /*
-      val z0: Int = (vrm1(i) & LowerMask) | (vrm2(i) & UpperMask)
-      val z1: Int = mat0neg(-25, v0(i)) ^ mat0pos(27, vm1(i))
-      val z2: Int = mat3pos(9, vm2(i)) ^ mat0pos(1, vm3(i))
-
-      newV1(i) = z1 ^ z2
-      newV0(i) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, newV1(i))
-      i = (i + R_1) & R_1
-    */
+    state(vrm1(i)) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, state(i))
+    i = vrm1(i)
 
     state(i)
   }
@@ -119,22 +92,22 @@ object Well19937a extends GeneratorCompanion[Well19937a, (Array[Int], Int)] {
   @inline private final val R : Int = (K + 31) / 32
 
   /** Length of the pool in ints -1. */
-  @inline private final val R_1 : Int = R - 1
+  // @inline private final val R_1 : Int = R - 1
 
   /** Length of the pool in ints -2. */
-  @inline private final val R_2 : Int = R - 2
+  // @inline private final val R_2 : Int = R - 2
 
   /** Length of the pool and index in bytes */
   @inline private final val BYTES = R * 4 + 4
 
   /** First parameter of the algorithm. */
-  @inline private final val M1 : Int = 70
+  // @inline private final val M1 : Int = 70
 
   /** Second parameter of the algorithm. */
-  @inline private final val M2 : Int = 179
+  // @inline private final val M2 : Int = 179
 
   /** Third parameter of the algorithm. */
-  @inline private final val M3 : Int = 449
+  // @inline private final val M3 : Int = 449
 
   @inline private final def mat0pos(t: Int, v: Int) = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int) = v ^ (v << -t)

--- a/core/src/main/scala/spire/random/mutable/Well19937acIndexCache.scala
+++ b/core/src/main/scala/spire/random/mutable/Well19937acIndexCache.scala
@@ -1,0 +1,62 @@
+/************************************************************************\
+** Project                                                              **
+**       ______  ______   __    ______    ____                          **
+**      / ____/ / __  /  / /   / __  /   / __/     (c) 2011-2014        **
+**     / /__   / /_/ /  / /   / /_/ /   / /_                            **
+**    /___  / / ____/  / /   / __  /   / __/   Erik Osheim, Tom Switzer **
+**   ____/ / / /      / /   / / | |   / /__                             **
+**  /_____/ /_/      /_/   /_/  |_|  /____/     All rights reserved.    **
+**                                                                      **
+**      Redistribution and use permitted under the MIT license.         **
+**                                                                      **
+\************************************************************************/
+
+
+package spire
+package random
+package mutable
+
+/**
+ * This is an Index Cache for the Well19937a and Well19937c implementations.
+ *
+ * <p>The acronym WELL stands for Well Equidistributed Long-period Linear.
+ *
+ * <p><b>Reference: </b>
+ * Fran&ccedil;ois Panneton, Pierre L'Ecuyer and Makoto Matsumoto:
+ * "Improved Long-Period Generators Based on Linear Recurrences Modulo 2",
+ * <i>ACM Transactions on Mathematical Software,</i> Vol. 32, No. 1, January 2006, pp 1--16.
+ *
+ * @see <a href="http://www.iro.umontreal.ca/~panneton/well/WELL19937a.c">WELL19937a.c</a>
+ * @see <a href="http://www.iro.umontreal.ca/~panneton/WELLRNG.html">Well PRNG Home Page</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Well_Equidistributed_Long-period_Linear">WELL @ Wikipedia</a>
+ * @author <a href="mailto:dusan.kysel@gmail.com">Du&#x0161;an Kysel</a>
+ */
+private[random] object Well19937acIndexCache {
+
+  /** Number of bits in the pool. */
+  @inline private final val K : Int = 19937
+
+  /** Length of the pool in ints. */
+  @inline private final val R : Int = (K + 31) / 32
+
+  /** Length of the pool in ints -1. */
+  @inline private final val R_1 : Int = R - 1
+
+  /** Length of the pool in ints -2. */
+  @inline private final val R_2 : Int = R - 2
+
+  /** First parameter of the algorithm. */
+  @inline private final val M1 : Int = 70
+
+  /** Second parameter of the algorithm. */
+  @inline private final val M2 : Int = 179
+
+  /** Third parameter of the algorithm. */
+  @inline private final val M3 : Int = 449
+
+  val vm1  = Array.tabulate(R)(i => (i + M1) % R)
+  val vm2  = Array.tabulate(R)(i => (i + M2) % R)
+  val vm3  = Array.tabulate(R)(i => (i + M3) % R)
+  val vrm1 = Array.tabulate(R)(i => (i + R_1) % R)
+  val vrm2 = Array.tabulate(R)(i => (i + R_2) % R)
+}

--- a/core/src/main/scala/spire/random/mutable/Well19937c.scala
+++ b/core/src/main/scala/spire/random/mutable/Well19937c.scala
@@ -38,19 +38,7 @@ import java.util
  */
 final class Well19937c protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well19937c.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3pos, TemperB, TemperC}
-
-  /*
-    @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
-    @inline private final val vm1     = new Utils.IntArrayWrapper(i => (i + M1) % R, state)
-    @inline private final val vm2     = new Utils.IntArrayWrapper(i => (i + M2) % R, state)
-    @inline private final val vm3     = new Utils.IntArrayWrapper(i => (i + M3) % R, state)
-    @inline private final val vrm1    = new Utils.IntArrayWrapper(i => (i + R_1) % R, state)
-    @inline private final val vrm2    = new Utils.IntArrayWrapper(i => (i + R_2) % R, state)
-    @inline private final val newV0   = vrm1
-    @inline private final val newV1   = v0
-    @inline private final val newVrm1 = vrm2
-  */
+  import Well19937c.{UpperMask, LowerMask, R, BYTES, mat0pos, mat0neg, mat1, mat3pos, TemperB, TemperC}
 
   private var i : Int = i0
 
@@ -78,30 +66,15 @@ final class Well19937c protected[random](state: Array[Int], i0: Int) extends Int
    */
   def nextInt(): Int = {
 
-    @inline def map(r: Int) = {
-      val n = i + r
-      if (n >= R) n - R
-      else if (n < 0) n + R
-      else n
-    }
+    import Well19937acIndexCache._
 
-    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)
-    val z1: Int = mat0neg(-25, state(i)) ^ mat0pos(27, state(map(M1)))
-    val z2: Int = mat3pos(9, state(map(M2))) ^ mat0pos(1, state(map(M3)))
+    val z0: Int = (state(vrm1(i)) & LowerMask) | (state(vrm2(i)) & UpperMask)
+    val z1: Int = mat0neg(-25, state(i)) ^ mat0pos(27, state(vm1(i)))
+    val z2: Int = mat3pos(9, state(vm2(i))) ^ mat0pos(1, state(vm3(i)))
 
     state(i) = z1 ^ z2
-    state(map(R_1)) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, state(i))
-    i = map(R_1)
-
-    /*
-      val z0: Int = (vrm1(i) & LowerMask) | (vrm2(i) & UpperMask)
-      val z1: Int = mat0neg(-25, v0(i)) ^ mat0pos(27, vm1(i))
-      val z2: Int = mat3pos(9, vm2(i)) ^ mat0pos(1, vm3(i))
-
-      newV1(i) = z1 ^ z2
-      newV0(i) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, newV1(i))
-      i = (i + R_1) & R_1
-    */
+    state(vrm1(i)) = mat1(z0) ^ mat0neg(-9, z1) ^ mat0neg(-21, z2) ^ mat0pos(21, state(i))
+    i = vrm1(i)
 
     // Matsumoto-Kurita tempering to get a ME (maximally equidistributed) generator
     val t0 = state(i)
@@ -127,22 +100,22 @@ object Well19937c extends GeneratorCompanion[Well19937c, (Array[Int], Int)] {
   @inline private final val R : Int = (K + 31) / 32
 
   /** Length of the pool in ints -1. */
-  @inline private final val R_1 : Int = R - 1
+  // @inline private final val R_1 : Int = R - 1
 
   /** Length of the pool in ints -2. */
-  @inline private final val R_2 : Int = R - 2
+  // @inline private final val R_2 : Int = R - 2
 
   /** Length of the pool and index in bytes */
   @inline private final val BYTES = R * 4 + 4
 
   /** First parameter of the algorithm. */
-  @inline private final val M1 : Int = 70
+  // @inline private final val M1 : Int = 70
 
   /** Second parameter of the algorithm. */
-  @inline private final val M2 : Int = 179
+  // @inline private final val M2 : Int = 179
 
   /** Third parameter of the algorithm. */
-  @inline private final val M3 : Int = 449
+  // @inline private final val M3 : Int = 449
 
   @inline private final def mat0pos(t: Int, v: Int) = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int) = v ^ (v << -t)

--- a/core/src/main/scala/spire/random/mutable/Well44497a.scala
+++ b/core/src/main/scala/spire/random/mutable/Well44497a.scala
@@ -38,19 +38,7 @@ import java.util
  */
 final class Well44497a protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well44497a.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3neg, mat5}
-
-  /*
-    @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
-    @inline private final val vm1     = new Utils.IntArrayWrapper(i => (i + M1) % R, state)
-    @inline private final val vm2     = new Utils.IntArrayWrapper(i => (i + M2) % R, state)
-    @inline private final val vm3     = new Utils.IntArrayWrapper(i => (i + M3) % R, state)
-    @inline private final val vrm1    = new Utils.IntArrayWrapper(i => (i + R_1) % R, state)
-    @inline private final val vrm2    = new Utils.IntArrayWrapper(i => (i + R_2) % R, state)
-    @inline private final val newV0   = vrm1
-    @inline private final val newV1   = v0
-    @inline private final val newVrm1 = vrm2
-  */
+  import Well44497a.{UpperMask, LowerMask, R, BYTES, mat0pos, mat0neg, mat1, mat3neg, mat5}
 
   private var i : Int = i0
 
@@ -78,30 +66,15 @@ final class Well44497a protected[random](state: Array[Int], i0: Int) extends Int
    */
   def nextInt(): Int = {
 
-    @inline def map(r: Int) = {
-      val n = i + r
-      if (n >= R) n - R
-      else if (n < 0) n + R
-      else n
-    }
+    import Well44497abIndexCache._
 
-    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)
-    val z1: Int = mat0neg(-24, state(i)) ^ mat0pos(30, state(map(M1)))
-    val z2: Int = mat0neg(-10, state(map(M2))) ^ mat3neg(-26, state(map(M3)))
+    val z0: Int = (state(vrm1(i)) & LowerMask) | (state(vrm2(i)) & UpperMask)
+    val z1: Int = mat0neg(-24, state(i)) ^ mat0pos(30, state(vm1(i)))
+    val z2: Int = mat0neg(-10, state(vm2(i))) ^ mat3neg(-26, state(vm3(i)))
 
     state(i) = z1 ^ z2
-    state(map(R_1)) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(state(i))
-    i = map(R_1)
-
-    /*
-      val z0: Int = (vrm1(i) & LowerMask) | (vrm2(i) & UpperMask)
-      val z1: Int = mat0neg(-24, v0(i)) ^ mat0pos(30, vm1(i))
-      val z2: Int = mat0neg(-10, vm2(i)) ^ mat3neg(-26, vm3(i))
-
-      newV1(i) = z1 ^ z2
-      newV0(i) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(newV1(i))
-      i = (i + R_1) & R_1
-    */
+    state(vrm1(i)) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(state(i))
+    i = vrm1(i)
 
     state(i)
   }
@@ -119,22 +92,22 @@ object Well44497a extends GeneratorCompanion[Well44497a, (Array[Int], Int)] {
   @inline private final val R : Int = (K + 31) / 32
 
   /** Length of the pool in ints -1. */
-  @inline private final val R_1 : Int = R - 1
+  // @inline private final val R_1 : Int = R - 1
 
   /** Length of the pool in ints -2. */
-  @inline private final val R_2 : Int = R - 2
+  // @inline private final val R_2 : Int = R - 2
 
   /** Length of the pool and index in bytes */
   @inline private final val BYTES = R * 4 + 4
 
   /** First parameter of the algorithm. */
-  @inline private final val M1 : Int = 23
+  // @inline private final val M1 : Int = 23
 
   /** Second parameter of the algorithm. */
-  @inline private final val M2 : Int = 481
+  // @inline private final val M2 : Int = 481
 
   /** Third parameter of the algorithm. */
-  @inline private final val M3 : Int = 229
+  // @inline private final val M3 : Int = 229
 
   @inline private final def mat0pos(t: Int, v: Int)         = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int)         = v ^ (v << -t)

--- a/core/src/main/scala/spire/random/mutable/Well44497abIndexCache.scala
+++ b/core/src/main/scala/spire/random/mutable/Well44497abIndexCache.scala
@@ -1,0 +1,62 @@
+/************************************************************************\
+** Project                                                              **
+**       ______  ______   __    ______    ____                          **
+**      / ____/ / __  /  / /   / __  /   / __/     (c) 2011-2014        **
+**     / /__   / /_/ /  / /   / /_/ /   / /_                            **
+**    /___  / / ____/  / /   / __  /   / __/   Erik Osheim, Tom Switzer **
+**   ____/ / / /      / /   / / | |   / /__                             **
+**  /_____/ /_/      /_/   /_/  |_|  /____/     All rights reserved.    **
+**                                                                      **
+**      Redistribution and use permitted under the MIT license.         **
+**                                                                      **
+\************************************************************************/
+
+
+package spire
+package random
+package mutable
+
+/**
+ * This is an Index Cache for the Well44497a and Well44497b implementations.
+ *
+ * <p>The acronym WELL stands for Well Equidistributed Long-period Linear.
+ *
+ * <p><b>Reference: </b>
+ * Fran&ccedil;ois Panneton, Pierre L'Ecuyer and Makoto Matsumoto:
+ * "Improved Long-Period Generators Based on Linear Recurrences Modulo 2",
+ * <i>ACM Transactions on Mathematical Software,</i> Vol. 32, No. 1, January 2006, pp 1--16.
+ *
+ * @see <a href="http://www.iro.umontreal.ca/~panneton/well/WELL44497a.c">WELL44497a.c</a>
+ * @see <a href="http://www.iro.umontreal.ca/~panneton/WELLRNG.html">Well PRNG Home Page</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Well_Equidistributed_Long-period_Linear">WELL @ Wikipedia</a>
+ * @author <a href="mailto:dusan.kysel@gmail.com">Du&#x0161;an Kysel</a>
+ */
+private[random] object Well44497abIndexCache {
+
+  /** Number of bits in the pool. */
+  @inline private final val K : Int = 44497
+
+  /** Length of the pool in ints. */
+  @inline private final val R : Int = (K + 31) / 32
+
+  /** Length of the pool in ints -1. */
+  @inline private final val R_1 : Int = R - 1
+
+  /** Length of the pool in ints -2. */
+  @inline private final val R_2 : Int = R - 2
+
+  /** First parameter of the algorithm. */
+  @inline private final val M1 : Int = 23
+
+  /** Second parameter of the algorithm. */
+  @inline private final val M2 : Int = 481
+
+  /** Third parameter of the algorithm. */
+  @inline private final val M3 : Int = 229
+
+  val vm1  = Array.tabulate(R)(i => (i + M1) % R)
+  val vm2  = Array.tabulate(R)(i => (i + M2) % R)
+  val vm3  = Array.tabulate(R)(i => (i + M3) % R)
+  val vrm1 = Array.tabulate(R)(i => (i + R_1) % R)
+  val vrm2 = Array.tabulate(R)(i => (i + R_2) % R)
+}

--- a/core/src/main/scala/spire/random/mutable/Well44497b.scala
+++ b/core/src/main/scala/spire/random/mutable/Well44497b.scala
@@ -38,19 +38,7 @@ import java.util
  */
 final class Well44497b protected[random](state: Array[Int], i0: Int) extends IntBasedGenerator {
 
-  import Well44497b.{UpperMask, LowerMask, R, R_1, R_2, BYTES, M1, M2, M3, mat0pos, mat0neg, mat1, mat3neg, mat5, TemperB, TemperC}
-
-  /*
-    @inline private final val v0      = new Utils.IntArrayWrapper(i => i, state)
-    @inline private final val vm1     = new Utils.IntArrayWrapper(i => (i + M1) % R, state)
-    @inline private final val vm2     = new Utils.IntArrayWrapper(i => (i + M2) % R, state)
-    @inline private final val vm3     = new Utils.IntArrayWrapper(i => (i + M3) % R, state)
-    @inline private final val vrm1    = new Utils.IntArrayWrapper(i => (i + R_1) % R, state)
-    @inline private final val vrm2    = new Utils.IntArrayWrapper(i => (i + R_2) % R, state)
-    @inline private final val newV0   = vrm1
-    @inline private final val newV1   = v0
-    @inline private final val newVrm1 = vrm2
-  */
+  import Well44497b.{UpperMask, LowerMask, R, BYTES, mat0pos, mat0neg, mat1, mat3neg, mat5, TemperB, TemperC}
 
   private var i : Int = i0
 
@@ -78,30 +66,15 @@ final class Well44497b protected[random](state: Array[Int], i0: Int) extends Int
    */
   def nextInt(): Int = {
 
-    @inline def map(r: Int) = {
-      val n = i + r
-      if (n >= R) n - R
-      else if (n < 0) n + R
-      else n
-    }
+    import Well44497abIndexCache._
 
-    val z0: Int = (state(map(R_1)) & LowerMask) | (state(map(R_2)) & UpperMask)
-    val z1: Int = mat0neg(-24, state(i)) ^ mat0pos(30, state(map(M1)))
-    val z2: Int = mat0neg(-10, state(map(M2))) ^ mat3neg(-26, state(map(M3)))
+    val z0: Int = (state(vrm1(i)) & LowerMask) | (state(vrm2(i)) & UpperMask)
+    val z1: Int = mat0neg(-24, state(i)) ^ mat0pos(30, state(vm1(i)))
+    val z2: Int = mat0neg(-10, state(vm2(i))) ^ mat3neg(-26, state(vm3(i)))
 
     state(i) = z1 ^ z2
-    state(map(R_1)) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(state(i))
-    i = map(R_1)
-
-    /*
-      val z0: Int = (vrm1(i) & LowerMask) | (vrm2(i) & UpperMask)
-      val z1: Int = mat0neg(-24, v0(i)) ^ mat0pos(30, vm1(i))
-      val z2: Int = mat0neg(-10, vm2(i)) ^ mat3neg(-26, vm3(i))
-
-      newV1(i) = z1 ^ z2
-      newV0(i) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(newV1(i))
-      i = (i + R_1) & R_1
-    */
+    state(vrm1(i)) = mat1(z0) ^ mat0pos(20, z1) ^ mat5(9, 0xb729fcec, 0xfbffffff, 0x00020000, z2) ^ mat1(state(i))
+    i = vrm1(i)
 
     // Matsumoto-Kurita tempering to get a ME (maximally equidistributed) generator
     val t0 = state(i)
@@ -127,22 +100,22 @@ object Well44497b extends GeneratorCompanion[Well44497b, (Array[Int], Int)] {
   @inline private final val R : Int = (K + 31) / 32
 
   /** Length of the pool in ints -1. */
-  @inline private final val R_1 : Int = R - 1
+  // @inline private final val R_1 : Int = R - 1
 
   /** Length of the pool in ints -2. */
-  @inline private final val R_2 : Int = R - 2
+  // @inline private final val R_2 : Int = R - 2
 
   /** Length of the pool and index in bytes */
   @inline private final val BYTES = R * 4 + 4
 
   /** First parameter of the algorithm. */
-  @inline private final val M1 : Int = 23
+  // @inline private final val M1 : Int = 23
 
   /** Second parameter of the algorithm. */
-  @inline private final val M2 : Int = 481
+  // @inline private final val M2 : Int = 481
 
   /** Third parameter of the algorithm. */
-  @inline private final val M3 : Int = 229
+  // @inline private final val M3 : Int = 229
 
   @inline private final def mat0pos(t: Int, v: Int)         = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int)         = v ^ (v << -t)


### PR DESCRIPTION
Also cleans up commented out reference code that is no longer needed.

The implementation is now both more DRY and fully performant at a negligible memory cost. :smiley:
