### PR TITLE
Corrected bug in GroupAction operator syntax.

### DIFF
--- a/macros/src/main/scala/spire/macros/Ops.scala
+++ b/macros/src/main/scala/spire/macros/Ops.scala
@@ -230,8 +230,8 @@ object Ops extends Ops {
     ("$u22C5", "dot"),
 
     // GroupAction (|+|> <|+| +> <+ *> <*)
-    ("$bar$plus$bar$greater", "gopl"),
-    ("$less$bar$plus$bar", "gopr"),
+    ("$bar$plus$bar$greater", "actl"),
+    ("$less$bar$plus$bar", "actr"),
     ("$plus$greater", "gplusl"),
     ("$less$plus", "gplusr"),
     ("$times$greater", "gtimesl"),


### PR DESCRIPTION
Small typo in the macro expansion, which is not caught by the test suite because GroupAction does not seem to have a test case.
