### PR TITLE
Fix FastComplex encoding when imaginary bits are negative

### DIFF
--- a/core/src/main/scala/spire/math/Complex.scala
+++ b/core/src/main/scala/spire/math/Complex.scala
@@ -458,7 +458,12 @@ object FastComplex {
 
   // encode two floats representing a complex number
   @inline final def encode(real: Float, imag: Float): Long = {
-    (bits(imag).toLong << 32) + bits(real).toLong
+    val imagBits = bits(imag)
+    // don't use toLong directly - that moves the sign bit to the left of
+    // the long, and the shift would eliminate it
+    var res = (imagBits & 0x7fffffff).toLong << 32 // remove sign
+    if (imagBits < 0) res |= 0x8000000000000000l   // add sign again
+    res | bits(real).toLong
   }
 
   // encode two floats representing a complex number in polar form

--- a/tests/src/test/scala/spire/math/ComplexTest.scala
+++ b/tests/src/test/scala/spire/math/ComplexTest.scala
@@ -113,6 +113,9 @@ class ComplexTest extends FunSuite {
 
     assert(fc.real(z) == 0.0F)
     assert(fc.imag(z) < 0.000000001F)
+
+    assert(fc.multiply(fc.i, fc.i) === fc.one)
+    assert(fc.imag(fc(-1f, 0f)) === 0f)
   }
 
   test("try using FloatComplex") {


### PR DESCRIPTION
Before this patch

```
scala> FastComplex.imag(FastComplex.multiply(FastComplex(0,1), FastComplex(0,1)))
res8: Float = NaN
```

Unfortunately, after this patch, two tests fail. Maybe a bug in `FastComplex.pow`? Imag should be close to `0.0f`, not `NaN`.

```
scala>     val i = FloatComplex.i
scala>     val one = FloatComplex.one
scala>     val e = FloatComplex(scala.math.E, 0.0)
scala>     val pi = FloatComplex(scala.math.Pi, 0.0)
scala>     e.pow(i * pi)
res10: spire.math.FloatComplex = (-1.0+NaNi)
```
