### PR TITLE
Signed[A].abs is made optional, to be used when A is an additive group

### DIFF
--- a/core/src/main/scala/spire/algebra/Signed.scala
+++ b/core/src/main/scala/spire/algebra/Signed.scala
@@ -14,7 +14,8 @@ trait Signed[@spec(Double, Float, Int, Long) A] {
   def signum(a: A): Int
 
   /** An idempotent function that ensures an object has a non-negative sign. */
-  def abs(a: A): A
+  def abs(a: A)(implicit ev: AdditiveGroup[A]): A =
+    if (signum(a) < 0) ev.negate(a) else a
 
   def isZero(a: A): Boolean = signum(a) == 0
 }
@@ -27,5 +28,5 @@ object Signed {
 
 private[algebra] class OrderedRingIsSigned[A](implicit o: Order[A], r: Ring[A]) extends Signed[A] {
   def signum(a: A) = o.compare(a, r.zero)
-  def abs(a: A) = if (signum(a) < 0) r.negate(a) else a
+  override def abs(a: A)(implicit ev: AdditiveGroup[A]) = if (signum(a) < 0) r.negate(a) else a
 }

--- a/core/src/main/scala/spire/math/FixedPoint.scala
+++ b/core/src/main/scala/spire/math/FixedPoint.scala
@@ -4,7 +4,7 @@ import spire.syntax.ring._
 import spire.syntax.order._
 import spire.syntax.convertableFrom._
 
-import spire.algebra.{Order, Signed}
+import spire.algebra.{AdditiveGroup, Order, Signed}
 
 import scala.{specialized => spec}
 
@@ -287,7 +287,7 @@ object FixedPoint {
       implicit val ctxt: ApproximationContext[Rational] =
         ApproximationContext(Rational(1L, scale.denom) * 2)
 
-      def abs(x: FixedPoint): FixedPoint = x.abs
+      override def abs(x: FixedPoint)(implicit ev: AdditiveGroup[FixedPoint]): FixedPoint = x.abs
       def signum(x: FixedPoint): Int = x.signum
 
       override def eqv(x: FixedPoint, y: FixedPoint): Boolean = x == y

--- a/core/src/main/scala/spire/math/ScalaWrappers.scala
+++ b/core/src/main/scala/spire/math/ScalaWrappers.scala
@@ -56,7 +56,7 @@ private[spire] trait ScalaNumericWrapper[A] extends scala.math.Numeric[A] with S
   def toLong(x: A) = conversions.toLong(x)
 
   override def signum(x:A): Int = signed.signum(x)
-  override def abs(x: A): A = signed.abs(x)
+  override def abs(x: A): A = signed.abs(x)(structure)
 }
 
 private[spire] trait ScalaFractionalWrapper[A] extends ScalaNumericWrapper[A] with scala.math.Fractional[A] {

--- a/core/src/main/scala/spire/math/package.scala
+++ b/core/src/main/scala/spire/math/package.scala
@@ -12,7 +12,7 @@ import scala.math.ScalaNumericConversions
 
 import BigDecimal.RoundingMode.{FLOOR, HALF_UP, CEILING}
 
-import spire.algebra.{EuclideanRing, Field, IsReal, NRoot, Order, Signed, Trig}
+import spire.algebra.{AdditiveGroup, EuclideanRing, Field, IsReal, NRoot, Order, Signed, Trig}
 import spire.std.bigDecimal._
 import spire.syntax.nroot._
 
@@ -27,7 +27,7 @@ package object math {
   final def abs(n: Long): Long = Math.abs(n)
   final def abs(n: Float): Float = Math.abs(n)
   final def abs(n: Double): Double = Math.abs(n)
-  final def abs[A](a: A)(implicit ev: Signed[A]): A = ev.abs(a)
+  final def abs[A](a: A)(implicit ev: Signed[A] with AdditiveGroup[A]): A = ev.abs(a)
 
   /**
    * ceil

--- a/scalacheck-binding/src/main/scala/spire/laws/BaseLaws.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/BaseLaws.scala
@@ -21,7 +21,7 @@ trait BaseLaws[A] extends Laws {
   implicit def Arb: Arbitrary[A]
 
 
-  def signed(implicit A: Signed[A]) = new SimpleRuleSet(
+  def signed(implicit A: Signed[A] with AdditiveGroup[A]) = new SimpleRuleSet(
     name = "signed",
     "abs non-negative" → forAll((x: A) =>
       x.abs.sign != Sign.Negative

--- a/tests/src/test/scala/spire/SyntaxTest.scala
+++ b/tests/src/test/scala/spire/SyntaxTest.scala
@@ -114,7 +114,7 @@ trait BaseSyntaxTest {
       ((a compare b) == Order[A].compare(a, b))
   }
 
-  def testSignedSyntax[A: Signed](a: A) = {
+  def testSignedSyntax[A: Signed: AdditiveGroup](a: A) = {
     import spire.syntax.signed._
     (a.sign == Signed[A].sign(a)) &&
       (a.signum == Signed[A].signum(a)) &&

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -16,7 +16,7 @@ import java.math.MathContext
 
 
 class SignedTest extends FunSuite {
-  def runWith[@spec(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A) {
+  def runWith[@spec(Int, Long, Float, Double) A: Signed: AdditiveGroup: ClassTag](neg: A, pos: A, zero: A) {
     val m = implicitly[ClassTag[A]]
 
     //// the name to use for this A

--- a/tests/src/test/scala/spire/math/ArbitrarySupport.scala
+++ b/tests/src/test/scala/spire/math/ArbitrarySupport.scala
@@ -63,7 +63,7 @@ object ArbitrarySupport {
   implicit def sized[A: EuclideanRing: Signed: Arbitrary, L: Size, U: Size]: Arbitrary[Sized[A, L, U]] =
     Arbitrary(arbitrary[A].map(a => Sized((a % (Size[U] - Size[L])).abs + Size[L])))
 
-  implicit def positive[A: Signed: Arbitrary]: Arbitrary[Positive[A]] =
+  implicit def positive[A: Signed: AdditiveGroup: Arbitrary]: Arbitrary[Positive[A]] =
     Arbitrary(arbitrary[A].map(_.abs).filter(_.signum > 0).map(Positive(_)))
   implicit def negative[A: Signed: AdditiveGroup: Arbitrary]: Arbitrary[Negative[A]] =
     Arbitrary(arbitrary[A].map(-_.abs).filter(_.signum < 0).map(Negative(_)))


### PR DESCRIPTION
Hi all,

some mathematical objects are signed (or have parity), without necessarily having an absolute value.

For example, permutations have either sign +1 or -1, but the absolute value cannot be computed. There are several options:

i) leave `Signed` as is, and have users implement `def abs(a: A) = sys.error("Not implemented")` for such objects,
ii) write in the type class `def abs(a: A)(implicit ev: this.type <:< AdditiveGroup[A])` which has the advantage of being "free" especially when inlined
iii) write `def abs(a: A)(implicit ev: AdditiveGroup[A])` which requires the side-effect instantiation of `AdditiveGroup[A]`
iv) create an additional `SignedAbs` typeclass, which can be provided automatically from any `A: Signed: AdditiveGroup`, with specialized implementations for the primitive types

I tried to implement ii), but there is a conflict with `IsReal[A]` which does not inherit `AdditiveGroup[A]`. Having `IsReal` inherit `AdditiveGroup` causes implicit resolution to fail because of ambiguity when implicits `Field[A]` and `IsReal[A]` clash.

I dislike the solution iii) because `abs` can be called quite often in user code, on types like Double, etc..., where the actual computation is very fast and any overhead is painful.

The status quo is not good because `Signed` is probably going to be migrated to non/algebra at some stage, and it should not have this kind of idiosyncrasies.