### PR TITLE
WIP: JMH benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TAGS
 .lib
 .history
 .*.swp
+.idea

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
@@ -1,0 +1,121 @@
+package spire.benchmark.jmh
+
+import java.util.concurrent.TimeUnit
+
+import scala.{specialized => spec}
+
+import org.openjdk.jmh.annotations._
+
+import spire.algebra._
+import spire.implicits._
+import spire.math._
+import spire.math.algebraic._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class AddBenchmarks {
+
+  def addGeneric[@spec(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
+    var total = Ring[A].zero
+    var i = 0
+    val len = data.length
+    while (i < len) { total = Ring[A].plus(total, data(i)); i += 1 }
+    total
+  }
+
+  def addFastComplexes(data:Array[Long]):Long = {
+    var total = FastComplex(0.0F, 0.0F)
+    var i = 0
+    val len = data.length
+    while (i < len) { total = FastComplex.add(total, data(i)); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addIntsDirect(state:IntState): Int = {
+    val data = state.values
+    var total = 0
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addIntsGeneric(state:IntState): Int = addGeneric(state.values)
+
+  @Benchmark
+  def addLongsDirect(state:LongState): Long = {
+    val data = state.values
+    var total = 0L
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+
+  }
+
+  @Benchmark
+  def addLongsGeneric(state:LongState): Long = addGeneric(state.values)
+
+  @Benchmark
+  def addFloatsDirect(state:FloatState): Float = {
+    val data = state.values
+    var total = 0.0F
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+
+  }
+
+  @Benchmark
+  def addFloatsGeneric(state:FloatState): Float = addGeneric(state.values)
+
+  @Benchmark
+  def addDoublesDirect(state:DoubleState): Double = {
+    val data = state.values
+    var total = 0.0
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addDoublesGeneric(state:DoubleState): Double = addGeneric(state.values)
+
+  @Benchmark
+  def addMaybeDoublesDirect(state:MaybeDoubleState): MaybeDouble = {
+    val data = state.values
+    var total = MaybeDouble(0.0)
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addComplexesDirect(state:ComplexState): Complex[Double] = {
+    val data = state.values
+    var total = Complex.zero[Double]
+    var i = 0
+    val len = data.length
+    while (i < len) { total += data(i); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addComplexesGeneric(state:ComplexState): Complex[Double] = addGeneric(state.values)
+
+  @Benchmark
+  def addFastComplexes(state:FastComplexState): Long = {
+    val data = state.values
+    var total = FastComplex(0.0F, 0.0F)
+    var i = 0
+    val len = data.length
+    while (i < len) { total = FastComplex.add(total, data(i)); i += 1 }
+    total
+  }
+
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/ComplexState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/ComplexState.scala
@@ -1,0 +1,11 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations._
+import spire.math.Complex
+
+@State(Scope.Thread)
+class ComplexState extends StateSupport {
+  var values: Array[Complex[Double]] = _
+  @Setup
+  def setup: Unit = values = init(size)(nextComplex)
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/DoubleState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/DoubleState.scala
@@ -1,0 +1,12 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class DoubleState extends StateSupport {
+  var values: Array[Double] = _
+  @Setup
+  def setup: Unit = values = init(size)(nextDouble)
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FastComplexState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FastComplexState.scala
@@ -1,0 +1,13 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+import spire.math.FastComplex
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class FastComplexState extends StateSupport {
+  var values: Array[Long] = _
+  @Setup
+  def setup: Unit = values = init(size)(FastComplex(nextFloat(), nextFloat()))
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FloatState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FloatState.scala
@@ -1,0 +1,12 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class FloatState extends StateSupport {
+  var values: Array[Float] = _
+  @Setup
+  def setup: Unit = values = init(size)(nextFloat)
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/IntState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/IntState.scala
@@ -1,0 +1,12 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class IntState extends StateSupport {
+  var values: Array[Int] = _
+  @Setup
+  def setup: Unit = values = init(size)(nextInt)
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/LongState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/LongState.scala
@@ -1,0 +1,12 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class LongState extends StateSupport {
+  var values: Array[Long] = _
+  @Setup
+  def setup: Unit = values = init(size)(nextLong)
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/MaybeDoubleState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/MaybeDoubleState.scala
@@ -1,0 +1,13 @@
+package spire.benchmark.jmh
+
+import org.openjdk.jmh.annotations.{Scope, Setup, State}
+import spire.math.algebraic.MaybeDouble
+
+import scala.util.Random._
+
+@State(Scope.Thread)
+class MaybeDoubleState extends StateSupport {
+  var values: Array[MaybeDouble] = _
+  @Setup
+  def setup: Unit = values = init(size)(MaybeDouble(nextDouble))
+}

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StateSupport.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StateSupport.scala
@@ -1,0 +1,13 @@
+package spire.benchmark.jmh
+
+import spire.benchmark.FixtureSupport
+
+trait StateSupport extends FixtureSupport {
+  //TODO Make sizes configurable
+  //val size = 10 * 1000
+  //val size = 100 * 1000
+  val size = 200 * 1000
+  //val size = 1 * 1000 * 1000
+  //val size = 4 * 1000 * 1000
+  //val size = 20 * 1000 * 1000
+}

--- a/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
@@ -22,34 +22,7 @@ import java.math.BigInteger
 /**
  * Extend this to create an actual benchmarking class.
  */
-trait MyBenchmark extends SimpleBenchmark {
-
-  /**
-   * Sugar for building arrays using a per-cell init function.
-   */
-  def init[A:ClassTag](size:Int)(f: => A) = {
-    val data = Array.ofDim[A](size)
-    for (i <- 0 until size) data(i) = f
-    data
-  }
-
-  /**
-   * Sugar for building arrays using a per-cell init function.
-   */
-  def mkarray[A:ClassTag:Order](size:Int, layout:String)(f: => A): Array[A] = {
-    val data = init(size)(f)
-    val ct = implicitly[ClassTag[A]]
-    val order = Order[A]
-    layout match {
-      case "random" =>
-      case "sorted" => spire.math.Sorting.sort(data)(order, ct)
-      case "reversed" => spire.math.Sorting.sort(data)(order.reverse, ct)
-      case _ => sys.error(s"unknown layout: $layout")
-    }
-    data
-  }
-
-  def nextComplex = Complex(nextDouble, nextDouble)
+trait MyBenchmark extends SimpleBenchmark with FixtureSupport {
 
   /**
    * Sugar to run 'f' for 'reps' number of times.

--- a/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
@@ -1,0 +1,40 @@
+package spire.benchmark
+
+import spire.math.Complex
+
+import scala.reflect.ClassTag
+
+import spire.algebra.Order
+
+import scala.util.Random._
+
+trait FixtureSupport {
+
+  /**
+   * Sugar for building arrays using a per-cell init function.
+   */
+  def init[A:ClassTag](size:Int)(f: => A) = {
+    val data = Array.ofDim[A](size)
+    for (i <- 0 until size) data(i) = f
+    data
+  }
+
+  /**
+   * Sugar for building arrays using a per-cell init function.
+   */
+  def mkarray[A:ClassTag:Order](size:Int, layout:String)(f: => A): Array[A] = {
+    val data = init(size)(f)
+    val ct = implicitly[ClassTag[A]]
+    val order = Order[A]
+    layout match {
+      case "random" =>
+      case "sorted" => spire.math.Sorting.sort(data)(order, ct)
+      case "reversed" => spire.math.Sorting.sort(data)(order.reverse, ct)
+      case _ => sys.error(s"unknown layout: $layout")
+    }
+    data
+  }
+
+  def nextComplex = Complex(nextDouble, nextDouble)
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,6 +6,8 @@ import sbtunidoc.Plugin.UnidocKeys._
 
 import com.typesafe.sbt.pgp.PgpKeys._
 
+import pl.project13.scala.sbt.SbtJmh
+
 import sbtrelease._
 import sbtrelease.ReleasePlugin._
 import sbtrelease.ReleasePlugin.ReleaseKeys._
@@ -277,6 +279,14 @@ object MyBuild extends Build {
 
     // enable forking in run
     fork in run := true
+  ) ++ noPublish
+
+  lazy val benchmarkJmh: Project = Project("benchmark-jmh", file("benchmark-jmh")).
+    settings(benchmarkJmhSettings: _*).
+    dependsOn(core, benchmark)
+
+  lazy val benchmarkJmhSettings = SbtJmh.jmhSettings ++ Seq(
+    name := "spire-benchmark-jmh"
   ) ++ noPublish
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.1")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.6")


### PR DESCRIPTION
This is an initial PR to start a discussion regarding the approach. My plan was to be conservative and port the existing benchmarks to JMH in a separate subproject called benchmark-jmh that depends on the `benchmark` subproject (for code reuse).

To run the benchmarks, one can do `benchmark-jmh/run`. See https://github.com/ktoso/sbt-jmh for more details about the sbt-jmh plugin. Note that it also includes JMH samples, which may be a good way to get an idea of how it works.

Results from running it on my laptop:

```
Benchmark                                    Mode  Samples     Score  Score error  Units
s.b.j.AddBenchmarks.addComplexesDirect       avgt       30  1829.296       92.173  us/op
s.b.j.AddBenchmarks.addComplexesGeneric      avgt       30  2230.329      140.297  us/op
s.b.j.AddBenchmarks.addDoublesDirect         avgt       30   189.686        1.467  us/op
s.b.j.AddBenchmarks.addDoublesGeneric        avgt       30   190.520        1.898  us/op
s.b.j.AddBenchmarks.addFastComplexes         avgt       30   649.856        4.134  us/op
s.b.j.AddBenchmarks.addFloatsDirect          avgt       30   191.667        1.385  us/op
s.b.j.AddBenchmarks.addFloatsGeneric         avgt       30   192.435        1.365  us/op
s.b.j.AddBenchmarks.addIntsDirect            avgt       30    64.146        0.398  us/op
s.b.j.AddBenchmarks.addIntsGeneric           avgt       30    63.780        0.363  us/op
s.b.j.AddBenchmarks.addLongsDirect           avgt       30    68.989        1.163  us/op
s.b.j.AddBenchmarks.addLongsGeneric          avgt       30    70.461        1.837  us/op
s.b.j.AddBenchmarks.addMaybeDoublesDirect    avgt       30  5588.012       91.623  us/op
```