### PR TITLE
Partial move of abs from Signed to IsReal. Does not compile.

### DIFF
--- a/core/src/main/scala/spire/algebra/IsReal.scala
+++ b/core/src/main/scala/spire/algebra/IsReal.scala
@@ -11,6 +11,8 @@ trait IsReal[@spec A] extends Order[A] with Signed[A] {
   def round(a: A): A
   def isWhole(a: A): Boolean
   def toDouble(a: A): Double
+  /** An idempotent function that ensures an object has a non-negative sign. */
+  def abs(a: A): A
 }
 
 trait IsIntegral[@spec(Byte,Short,Int,Long) A] extends IsReal[A] {

--- a/core/src/main/scala/spire/algebra/NormedVectorSpace.scala
+++ b/core/src/main/scala/spire/algebra/NormedVectorSpace.scala
@@ -35,11 +35,11 @@ trait NormedVectorSpace0 {
 }
 
 trait NormedVectorSpaceFunctions {
-  def max[A, CC[A] <: SeqLike[A, CC[A]]](implicit field0: Field[A], order0: Order[A],
-      signed0: Signed[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]): NormedVectorSpace[CC[A], A] =
+  def max[A, CC[A] <: SeqLike[A, CC[A]]](implicit field0: Field[A], isReal0: IsReal[A],
+    cbf0: CanBuildFrom[CC[A], A, CC[A]]): NormedVectorSpace[CC[A], A] =
     new SeqMaxNormedVectorSpace[A, CC[A]]
 
   def Lp[A, CC[A] <: SeqLike[A, CC[A]]](p: Int)(implicit field0: Field[A], nroot0: NRoot[A],
-      signed0: Signed[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]): NormedVectorSpace[CC[A], A] =
+      isReal0: IsReal[A], cbf0: CanBuildFrom[CC[A], A, CC[A]]): NormedVectorSpace[CC[A], A] =
     new SeqLpNormedVectorSpace[A, CC[A]](p)
 }

--- a/core/src/main/scala/spire/algebra/Sign.scala
+++ b/core/src/main/scala/spire/algebra/Sign.scala
@@ -32,7 +32,6 @@ object Sign {
 
     override def sign(a: Sign): Sign = a
     def signum(a: Sign): Int = a.toInt
-    def abs(a: Sign): Sign = if (a == Negative) Positive else a
 
     def compare(x: Sign, y: Sign): Int = x.toInt - y.toInt
   }

--- a/core/src/main/scala/spire/algebra/Signed.scala
+++ b/core/src/main/scala/spire/algebra/Signed.scala
@@ -13,9 +13,6 @@ trait Signed[@spec(Double, Float, Int, Long) A] {
   /** Returns 0 if `a` is 0, > 0 if `a` is positive, and < 0 is `a` is negative. */
   def signum(a: A): Int
 
-  /** An idempotent function that ensures an object has a non-negative sign. */
-  def abs(a: A): A
-
   def isZero(a: A): Boolean = signum(a) == 0
 }
 

--- a/core/src/main/scala/spire/math/Algebraic.scala
+++ b/core/src/main/scala/spire/math/Algebraic.scala
@@ -131,7 +131,6 @@ private[math] trait AlgebraicOrder extends Order[Algebraic] {
 private[math] trait AlgebraicIsSigned extends Signed[Algebraic] {
   override def sign(a: Algebraic): Sign = a.sign
   def signum(a: Algebraic): Int = a.signum
-  def abs(a: Algebraic): Algebraic = a.abs
 }
 
 private[math] trait AlgebraicIsReal extends IsReal[Algebraic] with AlgebraicOrder with AlgebraicIsSigned {
@@ -143,6 +142,7 @@ private[math] trait AlgebraicIsReal extends IsReal[Algebraic] with AlgebraicOrde
     if (m < 0.5) a - m else a + 1 - m
   }
   def isWhole(a:Algebraic) = a % 1 == 0
+  def abs(a: Algebraic): Algebraic = a.abs
 }
 
 @SerialVersionUID(0L)

--- a/core/src/main/scala/spire/math/Complex.scala
+++ b/core/src/main/scala/spire/math/Complex.scala
@@ -116,7 +116,7 @@ final case class Complex[@spec(Float, Double) T](real: T, imag: T)
   def arg(implicit f: Field[T], t: Trig[T], o: IsReal[T]): T =
     if (isZero) f.zero else t.atan2(imag, real)
 
-  def norm(implicit f: Field[T], n: NRoot[T], o: Order[T]): T = hypot(real, imag)
+  def norm(implicit f: Field[T], n: NRoot[T], r: IsReal[T]): T = hypot(real, imag)
 
   def conjugate(implicit f: Rng[T]): Complex[T] = new Complex(real, -imag)
 
@@ -663,7 +663,6 @@ private[math] trait ComplexIsSigned[A] extends Signed[Complex[A]] {
   implicit def order: IsReal[A]
 
   def signum(a: Complex[A]): Int = a.signum
-  def abs(a: Complex[A]): Complex[A] = Complex[A](a.abs, algebra.zero)
 }
 
 @SerialVersionUID(1L)

--- a/core/src/main/scala/spire/math/Number.scala
+++ b/core/src/main/scala/spire/math/Number.scala
@@ -613,7 +613,6 @@ private[math] trait NumberOrder extends Order[Number] {
 
 private[math] trait NumberIsSigned extends Signed[Number] {
   def signum(a: Number): Int = a.signum
-  def abs(a: Number): Number = a.abs
 }
 
 private[math] trait NumberIsReal extends IsReal[Number] with NumberOrder with NumberIsSigned {
@@ -622,6 +621,7 @@ private[math] trait NumberIsReal extends IsReal[Number] with NumberOrder with Nu
   def floor(a:Number): Number = a.floor
   def round(a:Number): Number = a.round
   def isWhole(a:Number) = a.isWhole
+  def abs(a: Number): Number = a.abs
 }
 
 @SerialVersionUID(0L)

--- a/core/src/main/scala/spire/math/Real.scala
+++ b/core/src/main/scala/spire/math/Real.scala
@@ -507,7 +507,6 @@ object Real {
 class RealAlgebra extends RealIsFractional {}
 
 trait RealIsFractional extends Fractional[Real] with Order[Real] with Signed[Real] with Trig[Real] {
-  def abs(x: Real): Real = x.abs
   def signum(x: Real): Int = x.signum
 
   override def eqv(x: Real, y: Real): Boolean = x eqv y
@@ -554,6 +553,7 @@ trait RealIsFractional extends Fractional[Real] with Order[Real] with Signed[Rea
   def floor(x: Real): Real = x.floor
   def isWhole(x: Real): Boolean = x.isWhole
   def round(x: Real): Real = x.round
+  def abs(x: Real): Real = x.abs
 
   def toByte(x: Real): Byte = x.toRational.toByte
   def toInt(x: Real): Int = x.toRational.toInt

--- a/core/src/main/scala/spire/math/package.scala
+++ b/core/src/main/scala/spire/math/package.scala
@@ -27,7 +27,7 @@ package object math {
   final def abs(n: Long): Long = Math.abs(n)
   final def abs(n: Float): Float = Math.abs(n)
   final def abs(n: Double): Double = Math.abs(n)
-  final def abs[A](a: A)(implicit ev: Signed[A]): A = ev.abs(a)
+  final def abs[A](a: A)(implicit ev: IsReal[A]): A = ev.abs(a)
 
   /**
    * ceil
@@ -401,7 +401,7 @@ package object math {
   final def ulp(x: Float): Double = Math.ulp(x)
 
   final def hypot[@spec(Float, Double) A](x: A, y: A)
-    (implicit f: Field[A], n: NRoot[A], o: Order[A]): A = {
+    (implicit f: Field[A], n: NRoot[A], r: IsReal[A]): A = {
     import spire.implicits._
     if (x > y) x.abs * (1 + (y/x)**2).sqrt
     else y.abs * (1 + (x/y)**2).sqrt

--- a/core/src/main/scala/spire/std/seq.scala
+++ b/core/src/main/scala/spire/std/seq.scala
@@ -121,7 +121,7 @@ extends SeqInnerProductSpace[A, SA] with CoordinateSpace[SA, A] with Serializabl
  * `InnerProductSpace` instead.
  */
 @SerialVersionUID(0L)
-class SeqLpNormedVectorSpace[A: Field: NRoot: Signed, SA <: SeqLike[A, SA]](val p: Int)(implicit cbf: CanBuildFrom[SA,A,SA])
+class SeqLpNormedVectorSpace[A: Field: NRoot: IsReal, SA <: SeqLike[A, SA]](val p: Int)(implicit cbf: CanBuildFrom[SA,A,SA])
 extends SeqVectorSpace[A, SA] with NormedVectorSpace[SA, A] with Serializable {
   require(p > 0, "p must be > 0")
 
@@ -129,7 +129,7 @@ extends SeqVectorSpace[A, SA] with NormedVectorSpace[SA, A] with Serializable {
     @tailrec
     def loop(xi: Iterator[A], acc: A): A = {
       if (xi.hasNext) {
-        loop(xi, scalar.plus(acc, Signed[A].abs(scalar.pow(xi.next(), p))))
+        loop(xi, scalar.plus(acc, IsReal[A].abs(scalar.pow(xi.next(), p))))
       } else {
         NRoot[A].nroot(acc, p)
       }
@@ -144,13 +144,13 @@ extends SeqVectorSpace[A, SA] with NormedVectorSpace[SA, A] with Serializable {
  * norm).
  */
 @SerialVersionUID(0L)
-class SeqMaxNormedVectorSpace[A: Field: Order: Signed, SA <: SeqLike[A, SA]](implicit cbf: CanBuildFrom[SA,A,SA]) 
+class SeqMaxNormedVectorSpace[A: Field: IsReal, SA <: SeqLike[A, SA]](implicit cbf: CanBuildFrom[SA,A,SA]) 
 extends SeqVectorSpace[A, SA] with NormedVectorSpace[SA, A] with Serializable {
   def norm(v: SA): A = {
     @tailrec
     def loop(xi: Iterator[A], acc: A): A = {
       if (xi.hasNext) {
-        val x = Signed[A].abs(xi.next())
+        val x = IsReal[A].abs(xi.next())
         loop(xi, if (Order[A].gt(x, acc)) x else acc)
       } else {
         acc

--- a/core/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/src/main/scala/spire/syntax/std/Ops.scala
@@ -5,7 +5,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 import scala.{specialized => sp}
 
-import spire.algebra.{AdditiveMonoid, Field, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
+import spire.algebra.{AdditiveMonoid, Field, IsReal, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}
 import spire.syntax.cfor._
 import spire.syntax.field._
@@ -87,7 +87,7 @@ final class ArrayOps[@sp A](arr: Array[A]) {
     result
   }
 
-  def qnorm(p: Int)(implicit ev: Field[A], s: Signed[A], nr: NRoot[A]): A = {
+  def qnorm(p: Int)(implicit ev: Field[A], r: IsReal[A], nr: NRoot[A]): A = {
     var result = ev.one
     cfor(0)(_ < arr.length, _ + 1) { i => result += arr(i).abs.pow(p) }
     result.nroot(p)
@@ -204,7 +204,7 @@ final class SeqOps[@sp A, CC[A] <: Iterable[A]](as: CC[A]) {
     prod
   }
 
-  def qnorm(p: Int)(implicit ev: Field[A], s: Signed[A], nr: NRoot[A]): A = {
+  def qnorm(p: Int)(implicit ev: Field[A], r: IsReal[A], nr: NRoot[A]): A = {
     var t = ev.one
     //as.foreach(a => t = ev.plus(t, ev.pow(s.abs(a), p)))
     as.foreach(a => t += a.abs.pow(p))


### PR DESCRIPTION
Continued from #304.

I tried to move .abs to IsReal, the problem is that IsReal is not applied everywhere: for example, the Scala Numeric wrappers do not use IsReal, the vector space norm implementations have to be converted, and Complex does not implement IsReal either.

This is the WIP.