### PR TITLE
Add an iterator method to Interval[A].

### DIFF
--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -1,5 +1,7 @@
 package spire.math
 
+import scala.util.Try
+
 import org.scalatest.FunSuite
 import spire.implicits.{eqOps => _, _}
 import spire.random.{Uniform, Dist}
@@ -409,6 +411,79 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
       Eq[Interval[Rational]].eqv(c, e) shouldBe true
       Eq[Interval[Rational]].eqv(d, e) shouldBe true
       Eq[Interval[Rational]].eqv(e, e) shouldBe true
+    }
+  }
+}
+
+class IntervalIteratorCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  import ArbitrarySupport._
+
+  property("bounded intervals are ok") {
+    forAll { (n1: Rational, n2: Rational, num0: Byte) =>
+      val (x, y) = if (n1 <= n2) (n1, n2) else (n2, n1)
+
+      val num = ((num0 & 255) % 13) + 1
+
+      def testEndpoints(interval: Interval[Rational], step: Rational, hasLower: Boolean, hasUpper: Boolean) {
+        val ns = interval.iterator(step).toSet
+        ns(x) shouldBe hasLower
+        ns(y) shouldBe hasUpper
+        val extra = if (hasLower && hasUpper) 2 else if (hasLower || hasUpper) 1 else 0
+        ns.size shouldBe (num - 1 + extra)
+      }
+
+      val cc = Interval.closed(x, y)     // [x, y]
+      val oo = Interval.open(x, y)       // (x, y)
+      val oc = Interval.openLower(x, y)  // (x, y]
+      val co = Interval.openUpper(x, y)  // [x, y)
+
+      val step = (y - x) / num
+
+      if (step.isZero) {
+        List(cc, oo, oc, co).foreach { xs =>
+          Try(xs.iterator(0)).isFailure shouldBe true
+        }
+      } else {
+        val triples = List((cc, true, true), (oo, false, false), (oc, false, true), (co, true, false))
+        triples.foreach { case (interval, hasLower, hasUpper) =>
+          testEndpoints(interval, step, hasLower, hasUpper)
+          testEndpoints(interval, -step, hasLower, hasUpper)
+        }
+      }
+    }
+  }
+
+  property("half-unbound intervals are ok") {
+    forAll { (n: Rational, s: Rational) =>
+
+      val step0 = s.abs
+
+      val cu = Interval.atOrAbove(n) // [n, ∞)
+      val ou = Interval.above(n)     // (n, ∞)
+      val uc = Interval.atOrBelow(n) // (-∞, n]
+      val uo = Interval.below(n)     // (-∞, n)
+
+      if (step0.isZero) {
+        List(cu, ou, uc, uo).foreach { xs =>
+          Try(xs.iterator(0)).isFailure shouldBe true
+        }
+      } else {
+        val triples = List((cu, true, 1), (ou, false, 1), (uc, true, -1), (uo, false, -1))
+        triples.foreach { case (interval, hasN, mult) =>
+          val step = step0 * mult
+          val it = interval.iterator(step)
+          val expected = if (hasN) n else n + step
+          it.next() shouldBe expected
+          Try(interval.iterator(-step)).isFailure shouldBe true
+        }
+      }
+    }
+  }
+
+  property("unbound intervals are not supported") {
+    forAll { (step: Rational) =>
+      Try(Interval.all[Rational].iterator(step)).isFailure shouldBe true
     }
   }
 }


### PR DESCRIPTION
This method allows users to easily iterate over an exact range:

```
val ns = Interval(0L, Long.MaxValue)

val longs1 = ns.iterator(2L).take(30).toList
val longs2 = ns.iterator(Long.MaxValue / 3).toList
```

There is some safe-guarding to avoid overflow in the case of
fixed-width integer types (Int, Long, etc.). However, there is
no attempt to compensate for arithmetic error during addition.
Using Interval[Rational] in these cases is probably better.
