### PR TITLE
Improve Gaussian[A] and add Exponential[A].

### DIFF
--- a/core/src/main/scala/spire/random/Exponential.scala
+++ b/core/src/main/scala/spire/random/Exponential.scala
@@ -11,7 +11,9 @@ trait Exponential[@sp(Float, Double) A] extends Any {
 }
 
 object Exponential extends ExponentialInstances {
-  @inline final def apply[@sp(Float,Double) A](implicit g: Exponential[A]): Exponential[A] = g
+  @inline final def apply[@sp(Float, Double) A](implicit e: Exponential[A]): Exponential[A] = e
+
+  def apply[@sp(Float, Double) A](rate: A)(implicit e: Exponential[A]): Dist[A] = e(rate)
 }
 
 trait ExponentialInstances {

--- a/core/src/main/scala/spire/random/Gaussian.scala
+++ b/core/src/main/scala/spire/random/Gaussian.scala
@@ -2,12 +2,12 @@ package spire.random
 
 import java.math.MathContext
 
-import scala.{specialized => spec}
+import scala.{specialized => sp}
 import scala.annotation.tailrec
 
 import spire.algebra.{Field, NRoot, Order, Trig}
 
-trait Gaussian[@spec(Float, Double) A] extends Any {
+trait Gaussian[@sp(Float, Double) A] extends Any {
   /**
    * Return an `A` that is normally distributed about `mean` with a standard
    * deviation of `stdDev`.
@@ -16,7 +16,9 @@ trait Gaussian[@spec(Float, Double) A] extends Any {
 }
 
 object Gaussian extends GaussianInstances {
-  @inline final def apply[@spec(Float,Double) A](implicit g: Gaussian[A]): Gaussian[A] = g
+  @inline final def apply[@sp(Float,Double) A](implicit g: Gaussian[A]): Gaussian[A] = g
+
+  def apply[@sp A](mean: A, stdDev: A)(implicit g: Gaussian[A]): Dist[A] = g(mean, stdDev)
 }
 
 trait GaussianInstances {
@@ -44,7 +46,7 @@ trait GaussianInstances {
 /**
  * An implementation of `Gaussian` that uses the Marsaglia algorithm.
  */
-final class MarsagliaGaussian[@spec(Float, Double) A: Field: NRoot: Trig: Order: Uniform] extends Gaussian[A] {
+final class MarsagliaGaussian[@sp(Float, Double) A: Field: NRoot: Trig: Order: Uniform] extends Gaussian[A] {
   import spire.syntax.field._
   import spire.syntax.nroot._
   import spire.syntax.trig._

--- a/core/src/main/scala/spire/random/Uniform.scala
+++ b/core/src/main/scala/spire/random/Uniform.scala
@@ -1,10 +1,10 @@
 package spire.random
 
-import scala.{specialized => spec}
+import scala.{specialized => sp}
 
 import spire.math.{Rational, UInt, ULong}
 
-trait Uniform[@spec A] extends Any { self =>
+trait Uniform[@sp A] extends Any { self =>
   /**
    * Return an `A` that is uniformly distributed between `min` and `max` inclusive.
    */
@@ -12,7 +12,9 @@ trait Uniform[@spec A] extends Any { self =>
 }
 
 object Uniform {
-  @inline final def apply[@spec A](implicit u: Uniform[A]): Uniform[A] = u
+  @inline final def apply[@sp A](implicit u: Uniform[A]): Uniform[A] = u
+
+  def apply[@sp A](min: A, max: A)(implicit u: Uniform[A]): Dist[A] = u(min, max)
 
   implicit val UniformInt: Uniform[Int] =
     new Uniform[Int] {


### PR DESCRIPTION
This commit hooks up the ziggurat algorithm we have for generating
fast normally-distributed Double values, making Gaussian[A] a lot
faster. It also introduces Exponential[A], which also uses the
ziggurat method (and only works for Float/Double currently).

Review by @tixxit and/or @dusank 
