### PR TITLE
Bump Scala 2.11 version, SBT version, etc.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,8 +20,8 @@ object MyBuild extends Build {
 
   // Dependencies
 
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.1.3"
-  lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.3"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.2.1"
+  lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.6"
 
   // Release step
 
@@ -52,9 +52,9 @@ object MyBuild extends Build {
   override lazy val settings = super.settings ++ Seq(
     organization := "org.spire-math",
 
-    scalaVersion := "2.11.2",
+    scalaVersion := "2.11.4",
 
-    crossScalaVersions := Seq("2.10.2", "2.11.2"),
+    crossScalaVersions := Seq("2.10.2", "2.11.4"),
 
     licenses := Seq("BSD-style" -> url("http://opensource.org/licenses/MIT")),
     homepage := Some(url("http://spire-math.org")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
This commit upgrades the following versions:
- Scala 2.11.2 -> 2.11.4
- SBT 0.13.5 -> 0.13.7
- ScalaTest 2.1.3 -> 2.2.1
- ScalaCheck 1.11.3 -> 1.11.6
