### PR TITLE
Fix Jet casting problems, and other fixes.

### DIFF
--- a/core/src/main/scala/spire/math/Jet.scala
+++ b/core/src/main/scala/spire/math/Jet.scala
@@ -6,7 +6,7 @@ import scala.reflect._
 import scala.{specialized => sp}
 
 import spire.algebra._
-import spire.std.array.ArrayEq
+import spire.std.ArraySupport
 import spire.syntax.isReal._
 import spire.syntax.nroot._
 import spire.syntax.vectorSpace._
@@ -206,7 +206,6 @@ final case class Jet[@sp(Float, Double) T](real: T, infinitesimal: Array[T])
    * This is consistent with abs
    */
   def signum()(implicit r: Signed[T]): Int = real.signum()
-  //def signum()(implicit r: Signed[T]): Int = r.signum(real)
 
   def asTuple = (real, infinitesimal)
 
@@ -215,10 +214,10 @@ final case class Jet[@sp(Float, Double) T](real: T, infinitesimal: Array[T])
   def isInfinitesimal(implicit r: IsReal[T]): Boolean = anyIsZero(real) && !isReal
 
   def eqv(b: Jet[T])(implicit o: Eq[T]): Boolean = {
-    real === b.real && infinitesimal === b.infinitesimal
+    real === b.real && ArraySupport.eqv(infinitesimal, b.infinitesimal)
   }
   def neqv(b: Jet[T])(implicit o: Eq[T]): Boolean = {
-    real =!= b.real || infinitesimal =!= b.infinitesimal
+    !(this eqv b)
   }
 
   def unary_-()(implicit f: Field[T], v: VectorSpace[Array[T], T]): Jet[T] = {


### PR DESCRIPTION
This PR is based on #331. It also fixes an issue that has been present for awhile: synthesizing extra type class instances unnecessarily.

Consider this somewhat-contrived example:

``` scala
def cutoff[A](ns: List[Jet[A]], m: Jet[A]): List[Jet[A]] = ns.map(_ % m)
```

Assuming we had the correct implicits in scope, we'd prefer to use the same `VectorSpace[Array[T], T]` instance for each member of `ns`. However, the design of `Jet[A]` made it difficult to achieve this while passing `ClassTag[A]` (which can be used to build a `VectorSpace[Array[T], T]`).

The final commit ensures that `Jet[A]` asks for the instances it needs in these cases.
