### PR TITLE
Fixed #323 partially completed merge.

### DIFF
--- a/scalacheck-binding/src/main/scala/spire/laws/LatticeLaws.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/LatticeLaws.scala
@@ -75,6 +75,16 @@ trait LatticeLaws[A] extends Laws {
       )
   )
 
+  def boundedBelowLattice(implicit A: Lattice[A] with BoundedJoinSemilattice[A]) = new LatticeProperties(
+    name = "boundedBelowLattice",
+    parents = Seq(boundedJoinSemilattice, lattice)
+  )
+
+  def boundedAboveLattice(implicit A: Lattice[A] with BoundedMeetSemilattice[A]) = new LatticeProperties(
+    name = "boundedAboveLattice",
+    parents = Seq(boundedMeetSemilattice, lattice)
+  )
+
   def boundedLattice(implicit A: BoundedLattice[A]) = new LatticeProperties(
     name = "boundedLattice",
     parents = Seq(boundedJoinSemilattice, boundedMeetSemilattice, lattice)

--- a/scalacheck-binding/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
@@ -21,7 +21,7 @@ trait LatticePartialOrderLaws[A] extends Laws {
   implicit def Equ: Eq[A]
   implicit def Arb: Arbitrary[A]
 
-  def joinSemilatticePartialOrder(implicit A: JoinSemilattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def joinSemilatticePartialOrder(implicit A: JoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "joinSemilatticePartialOrder",
     parents = Seq.empty,
     bases = Seq("order" → OrderLaws[A].partialOrder, "lattice" → LatticeLaws[A].joinSemilattice),
@@ -30,7 +30,7 @@ trait LatticePartialOrderLaws[A] extends Laws {
     )
   )
 
-  def meetSemilatticePartialOrder(implicit A: MeetSemilattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def meetSemilatticePartialOrder(implicit A: MeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "meetSemilatticePartialOrder",
     parents = Seq.empty,
     bases = Seq("order" → OrderLaws[A].partialOrder, "lattice" → LatticeLaws[A].meetSemilattice),
@@ -39,13 +39,13 @@ trait LatticePartialOrderLaws[A] extends Laws {
     )
   )
 
-  def latticePartialOrder(implicit A: Lattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def latticePartialOrder(implicit A: Lattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "latticePartialOrder",
     parents = Seq(joinSemilatticePartialOrder, meetSemilatticePartialOrder),
     bases = Seq.empty
   )
 
-  def boundedJoinSemilatticePartialOrder(implicit A: BoundedJoinSemilattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def boundedJoinSemilatticePartialOrder(implicit A: BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedJoinSemilatticePartialOrder",
     parents = Seq(joinSemilatticePartialOrder),
     bases = Seq("lattice" → LatticeLaws[A].boundedJoinSemilattice),
@@ -54,7 +54,7 @@ trait LatticePartialOrderLaws[A] extends Laws {
     )
   )
 
-  def boundedMeetSemilatticePartialOrder(implicit A: BoundedMeetSemilattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def boundedMeetSemilatticePartialOrder(implicit A: BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedMeetSemilatticePartialOrder",
     parents = Seq(meetSemilatticePartialOrder),
     bases = Seq("lattice" → LatticeLaws[A].boundedMeetSemilattice),
@@ -63,7 +63,19 @@ trait LatticePartialOrderLaws[A] extends Laws {
     )
   )
 
-  def boundedLatticePartialOrder(implicit A: BoundedLattice[A] with PartialOrder[A]) = new LatticePartialOrderProperties(
+  def boundedBelowLatticePartialOrder(implicit A: Lattice[A] with BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
+    name = "boundedBelowLatticePartialOrder",
+    parents = Seq(boundedJoinSemilatticePartialOrder, latticePartialOrder),
+    bases = Seq("lattice" → LatticeLaws[A].boundedBelowLattice)
+  )
+
+  def boundedAboveLatticePartialOrder(implicit A: Lattice[A] with BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
+    name = "boundedAboveLatticePartialOrder",
+    parents = Seq(boundedMeetSemilatticePartialOrder, latticePartialOrder),
+    bases = Seq("lattice" → LatticeLaws[A].boundedAboveLattice)
+  )
+
+  def boundedLatticePartialOrder(implicit A: BoundedLattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedLatticePartialOrder",
     parents = Seq(boundedJoinSemilatticePartialOrder, boundedMeetSemilatticePartialOrder),
     bases = Seq("lattice" → LatticeLaws[A].boundedLattice)

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -106,5 +106,5 @@ class LawTests extends FunSuite with Discipline {
   }
 
   checkAll("Order[Int]", OrderLaws[Int].order)
-  checkAll("LatticePartialOrder[Int]", LatticePartialOrderLaws[Int].boundedLatticePartialOrder(intMinMaxLattice))
+  checkAll("LatticePartialOrder[Int]", LatticePartialOrderLaws[Int].boundedLatticePartialOrder(intMinMaxLattice, implicitly[Order[Int]]))
 }


### PR DESCRIPTION
The PR #323 was only partially merged.

This fixes the issue of having a compound `Lattice[A] with PartialOrder[A]`, splitting instead the implementations.
