### PR TITLE
Fix bug with Rational(0D) constructor.

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -312,7 +312,9 @@ object Rational extends RationalInstances {
 
   implicit def apply(x: Float): Rational = apply(x.toDouble)
 
-  implicit def apply(x: Double): Rational = {
+  implicit def apply(x: Double): Rational = if (x == 0D) {
+    zero
+  } else {
     val bits = java.lang.Double.doubleToLongBits(x)
     val value = if ((bits >> 63) < 0) -(bits & 0x000FFFFFFFFFFFFFL | 0x0010000000000000L)
                 else (bits & 0x000FFFFFFFFFFFFFL | 0x0010000000000000L)

--- a/tests/src/test/scala/spire/math/RationalCheck.scala
+++ b/tests/src/test/scala/spire/math/RationalCheck.scala
@@ -56,4 +56,10 @@ class RationalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
   rat2("x / y == x * (y^-1)") { (x: Q, y: Q) => if (y != 0) x / y shouldBe x * y.reciprocal }
 
   rat3("(x + y) * z == x * z + y * z") { (x: Q, y: Q, z: Q) => (x + y) * z shouldBe x * z + y * z }
+
+  property("Round-trip Double") {
+    forAll("x") { (n: Double) =>
+      Rational(n).toDouble == n
+    }
+  }
 }

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -291,4 +291,8 @@ class RationalTest extends FunSuite {
     val z = Rational("1/287380324068203382157064120376241062")
     assert(x.gcd(y) === z) // As confirmed by Wolfram Alpha
   }
+
+  test("Rational(0D) is Zero") {
+    assert(Rational(0D) === Rational.zero)
+  }
 }


### PR DESCRIPTION
This would treat 0 (-0) as a value very close to, but not quite 0, and
we'd get back such a Rational (either positive or negative). This now
explicitly checks if the argument is 0 and returns Rational.zero.
