### PR TITLE
Fixed typo that lead to NumberFormatException

### DIFF
--- a/core/src/main/scala/spire/math/Interval.scala
+++ b/core/src/main/scala/spire/math/Interval.scala
@@ -789,7 +789,7 @@ object Interval {
         (left, x, y, right) match {
           case ("(", "-∞", "∞", ")") => Interval.all[Rational]
           case ("(", "-∞", y, ")") => Interval.below(Rational(y))
-          case ("(", "∞", y, "]") => Interval.atOrBelow(Rational(y))
+          case ("(", "-∞", y, "]") => Interval.atOrBelow(Rational(y))
           case ("(", x, "∞", ")") => Interval.above(Rational(x))
           case ("[", x, "∞", ")") => Interval.atOrAbove(Rational(x))
           case ("[", x, y, "]") => Interval.closed(Rational(x), Rational(y))


### PR DESCRIPTION
Fixed typo that lead to NumberFormatException when parsing intervals with
an open lower bound and an included upper bound.

Fixes #343
