### PR TITLE
Replace some sys.errors with proper exceptions.

### DIFF
--- a/core/src/main/scala/spire/math/Algebraic.scala
+++ b/core/src/main/scala/spire/math/Algebraic.scala
@@ -121,7 +121,7 @@ private[math] trait AlgebraicIsField extends Field[Algebraic] with AlgebraicIsEu
 
 private[math] trait AlgebraicIsNRoot extends NRoot[Algebraic] {
   def nroot(a: Algebraic, k: Int): Algebraic = a nroot k
-  def fpow(a:Algebraic, b:Algebraic) = sys.error("fixme")
+  def fpow(a:Algebraic, b:Algebraic) = throw new ArithmeticException("fpow not supported by Algebraic")
 }
 
 private[math] trait AlgebraicOrder extends Order[Algebraic] {

--- a/core/src/main/scala/spire/math/Integral.scala
+++ b/core/src/main/scala/spire/math/Integral.scala
@@ -24,10 +24,10 @@ class IntegralOps[A](lhs: A)(implicit ev: Integral[A]) {
   def coerce(a: A): Long = {
     val n = ev.toBigInt(a)
     if (Long.MinValue <= n && n <= Long.MaxValue) ev.toLong(a)
-    else sys.error("$lhs too large")
+    else throw new IllegalArgumentException(s"$lhs too large")
   }
 
-  def !(): BigInt = spire.math.fact(coerce(lhs))
+  def ! : BigInt = spire.math.fact(coerce(lhs))
 
   def choose(rhs: A): BigInt = spire.math.choose(coerce(lhs), coerce(rhs))
 }

--- a/core/src/main/scala/spire/math/Number.scala
+++ b/core/src/main/scala/spire/math/Number.scala
@@ -102,11 +102,11 @@ sealed trait Number extends ScalaNumericConversions with Serializable {
   final def >(rhs: Number): Boolean = compare(rhs) > 0
   final def >=(rhs: Number): Boolean = compare(rhs) >= 0
 
-  def &(rhs: Number): Number = sys.error("%s not an integer" format this)
-  def |(rhs: Number): Number = sys.error("%s not an integer" format this)
-  def ^(rhs: Number): Number = sys.error("%s not an integer" format this)
-  def <<(rhs: Number): Number = sys.error("%s not an integer" format this)
-  def >>(rhs: Number): Number = sys.error("%s not an integer" format this)
+  def &(rhs: Number): Number = throw new UnsupportedOperationException("%s not an integer" format this)
+  def |(rhs: Number): Number = throw new UnsupportedOperationException("%s not an integer" format this)
+  def ^(rhs: Number): Number = throw new UnsupportedOperationException("%s not an integer" format this)
+  def <<(rhs: Number): Number = throw new UnsupportedOperationException("%s not an integer" format this)
+  def >>(rhs: Number): Number = throw new UnsupportedOperationException("%s not an integer" format this)
 
   def floor: Number
   def ceil: Number
@@ -230,23 +230,23 @@ private[math] case class IntNumber(n: SafeLong) extends Number { lhs =>
 
   override def &(rhs: Number): Number = rhs match {
     case IntNumber(x) => IntNumber(n & x)
-    case _ => sys.error("%s not an integer" format rhs)
+    case _ => throw new IllegalArgumentException("%s not an integer" format rhs)
   }
   override def |(rhs: Number): Number = rhs match {
     case IntNumber(x) => IntNumber(n | x)
-    case _ => sys.error("%s not an integer" format rhs)
+    case _ => throw new IllegalArgumentException("%s not an integer" format rhs)
   }
   override def ^(rhs: Number): Number = rhs match {
     case IntNumber(x) => IntNumber(n ^ x)
-    case _ => sys.error("%s not an integer" format rhs)
+    case _ => throw new IllegalArgumentException("%s not an integer" format rhs)
   }
   override def <<(rhs: Number): Number = rhs match {
     case IntNumber(x) => IntNumber(n << x.toInt)
-    case _ => sys.error("%s not an integer" format rhs)
+    case _ => throw new IllegalArgumentException("%s not an integer" format rhs)
   }
   override def >>(rhs: Number): Number = rhs match {
     case IntNumber(x) => IntNumber(n >> x.toInt)
-    case _ => sys.error("%s not an integer" format rhs)
+    case _ => throw new IllegalArgumentException("%s not an integer" format rhs)
   }
 
   def sqrt: Number =

--- a/core/src/main/scala/spire/math/Real.scala
+++ b/core/src/main/scala/spire/math/Real.scala
@@ -277,7 +277,7 @@ object Real extends RealInstances {
   def log(x: Real): Real = {
     val t = x(2)
     val n = sizeInBase(t, 2) - 3
-    if (t < 0) sys.error("log of negative number")
+    if (t < 0) throw new ArithmeticException("log of negative number")
     else if (t < 4) -log(x.reciprocal)
     else if (t < 8) logDr(x)
     else logDr(div2n(x, n)) + Real(n) * log2
@@ -287,7 +287,7 @@ object Real extends RealInstances {
     val u = x / log2
     val n = u(0)
     val s = x - Real(n) * log2
-    if (!n.isValidInt) sys.error("sorry")
+    if (!n.isValidInt) throw new ArithmeticException("invalid power in exp")
     else if (n < 0) div2n(expDr(s), -n.toInt)
     else if (n > 0) mul2n(expDr(s), n.toInt)
     else expDr(s)

--- a/core/src/main/scala/spire/math/package.scala
+++ b/core/src/main/scala/spire/math/package.scala
@@ -239,7 +239,7 @@ package object math {
       else bigIntPow(t, b * b, e >> 1)
 
     if (ex.signum < 0) {
-      if (base.signum == 0) sys.error("zero can't be raised to negative power")
+      if (base.signum == 0) throw new ArithmeticException("zero can't be raised to negative power")
       else if (base == 1) base
       else if (base == -1) if (ex.testBit(0)) BigInt(1) else base
       else BigInt(0)
@@ -263,7 +263,7 @@ package object math {
       else longPow(t, b * b, e >> 1L)
 
     if (exponent < 0L) {
-      if(base == 0L) sys.error("zero can't be raised to negative power")
+      if(base == 0L) throw new ArithmeticException("zero can't be raised to negative power")
       else if (base == 1L) 1L
       else if (base == -1L) if ((exponent & 1L) == 0L) -1L else 1L
       else 0L

--- a/core/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/src/main/scala/spire/math/prime/Siever.scala
@@ -38,7 +38,7 @@ import SieveUtil._
  * will instantiate a Siever for you with reasonable parameters.
  */
 case class Siever(chunkSize: Int, cutoff: SafeLong) {
-  if (chunkSize % 480 != 0) sys.error("chunkSize must be a multiple of 480")
+  require(chunkSize % 480 != 0, "chunkSize must be a multiple of 480")
 
   val arr = BitSet.alloc(chunkSize)
   var start: SafeLong = SafeLong(0)
@@ -49,7 +49,7 @@ case class Siever(chunkSize: Int, cutoff: SafeLong) {
   sieve.init(fastq, slowq)
 
   def largestBelow(n: SafeLong): SafeLong = {
-    if (n < 3) sys.error("invalid argument: %s" format n)
+    if (n < 3) throw new IllegalArgumentException("invalid argument: %s" format n)
     if (n == 3) return SafeLong(2)
 
     var i = 3


### PR DESCRIPTION
Just got bit by a bug where I was catching `ArithmeticException`s in, eg, `log`, but some types where throwing `RuntimeException`s (via `sys.error`). Replaced a bunch of `sys.error`s with real exceptions.
