### PR TITLE
Action split into LeftAction and RightAction

### DIFF
--- a/core/src/main/scala/spire/algebra/Action.scala
+++ b/core/src/main/scala/spire/algebra/Action.scala
@@ -6,9 +6,9 @@ import scala.{ specialized => spec }
  * A (left) semigroup/monoid/group action of `G` on `P` is simply the implementation of
  * a method `actl(g, p)`, or `g +> p` in additive notation, such that:
  * 
- * 1. `(g |+| h) +> p === g +> (h +> p)` for all `g`, `h` in `G` and `p` in `P`.
+ * 1. `(g |+| h) |+|> p === g |+|> (h |+|> p)` for all `g`, `h` in `G` and `p` in `P`.
  * 
- * 2. `id +> p === p` for all `p` in `P` (if `id` is defined)
+ * 2. `id |+|> p === p` for all `p` in `P` (if `id` is defined)
  */
 trait Action[@spec(Int) P, G] extends Any {
   def actl(g: G, p: P): P

--- a/core/src/main/scala/spire/algebra/Action.scala
+++ b/core/src/main/scala/spire/algebra/Action.scala
@@ -4,16 +4,37 @@ import scala.{ specialized => spec }
 
 /**
  * A (left) semigroup/monoid/group action of `G` on `P` is simply the implementation of
- * a method `actl(g, p)`, or `g +> p` in additive notation, such that:
+ * a method `actl(g, p)`, or `g |+|> p`, such that:
  * 
  * 1. `(g |+| h) |+|> p === g |+|> (h |+|> p)` for all `g`, `h` in `G` and `p` in `P`.
  * 
  * 2. `id |+|> p === p` for all `p` in `P` (if `id` is defined)
  */
-trait Action[@spec(Int) P, G] extends Any {
+trait LeftAction[@spec(Int) P, G] extends Any {
   def actl(g: G, p: P): P
+}
+
+object LeftAction {
+  @inline def apply[P, G](G: LeftAction[P, G]) = G
+}
+
+/**
+ * A (right) semigroup/monoid/group action of `G` on `P` is simply the implementation of
+ * a method `actr(p, g)`, or `p <|+| g`, such that:
+ * 
+ * 1. `p <|+| (g |+| h) === (p <|+| g) <|+| h` for all `g`, `h` in `G` and `p` in `P`.
+ * 
+ * 2. `p <|+| id === p` for all `p` in `P` (if `id` is defined)
+ */
+trait RightAction[@spec(Int) P, G] extends Any {
   def actr(p: P, g: G): P
 }
+
+object RightAction {
+  @inline def apply[P, G](G: RightAction[P, G]) = G
+}
+
+trait Action[@spec(Int) P, G] extends Any with LeftAction[P, G] with RightAction[P, G]
 
 object Action {
   @inline def apply[P, G](G: Action[P, G]) = G

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -427,8 +427,8 @@ final class BitStringOps[A](lhs: A)(implicit ev: BitString[A]) {
   def rotateRight(rhs: Int): A = macro Ops.binop[Int, A]
 }
 
-final class ActionGroupOps[G](lhs: G) {
-  def |+|> [P](rhs: P)(implicit ev: Action[P, G]): P =
+final class LeftActionOps[G](lhs: G) {
+  def |+|> [P](rhs: P)(implicit ev: LeftAction[P, G]): P =
     macro Ops.binopWithEv[P, Action[P, G], P]
   def +> [P](rhs: P)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[P, AdditiveAction[P, G], P]
@@ -436,8 +436,8 @@ final class ActionGroupOps[G](lhs: G) {
     macro Ops.binopWithEv[P, MultiplicativeAction[P, G], P]
 }
 
-final class ActionPointOps[P](lhs: P) {
-  def <|+| [G](rhs: G)(implicit ev: Action[P, G]): P =
+final class RightActionOps[P](lhs: P) {
+  def <|+| [G](rhs: G)(implicit ev: RightAction[P, G]): P =
     macro Ops.binopWithEv[G, Action[P, G], P]
   def <+ [G](rhs: G)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[G, AdditiveAction[P, G], P]

--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -147,8 +147,8 @@ trait BitStringSyntax {
 }
 
 trait ActionSyntax {
-  implicit def actionGroupOps[G](g: G) = new ActionGroupOps(g)
-  implicit def actionPointOps[P](p: P) = new ActionPointOps(p)
+  implicit def leftActionOps[G](g: G) = new LeftActionOps(g)
+  implicit def rightActionOps[P](p: P) = new RightActionOps(p)
 }
 
 trait UnboundSyntax {


### PR DESCRIPTION
Hi all,

here is a split of Action into LeftAction and RightAction, in case the underlying transformation cannot be inverted.

Of course, provided the acting element comes from a group, the left action defines a right action and vice-versa.

Note: this is a prologue to my implementation of partial actions, where this split is needed. But I prefer to provide PRs in tiny pieces.

This single PR can be merged without too much discussion.