### PR TITLE
Improved compatibility with future non/algebra traits.

### DIFF
--- a/core/src/main/scala/spire/algebra/Group.scala
+++ b/core/src/main/scala/spire/algebra/Group.scala
@@ -2,17 +2,15 @@ package spire.algebra
 
 import scala.{ specialized => spec }
 
-trait HasInverse[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any {
-  /**
-    * Return the inverse of `a`.
-    */
-  def inverse(a: A): A
-}
-
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with HasInverse[A] {
+trait Group[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
+
+  /**
+   * Return the inverse of `a`.
+   */
+  def inverse(a: A): A
 
   /**
    * Combine `a` with the inverse of `b`.

--- a/core/src/main/scala/spire/algebra/Monoid.scala
+++ b/core/src/main/scala/spire/algebra/Monoid.scala
@@ -2,27 +2,22 @@ package spire.algebra
 
 import scala.{ specialized => spec }
 
-trait HasIsId[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
-  /**
-    * Tests if `a` is the identity.
-    */
-  def isId(a: A)(implicit ev: Eq[A]): Boolean
-}
-
 /**
  * A monoid is a semigroup with an identity. A monoid is a specialization of a
  * semigroup, so its operation must be associative. Additionally,
  * `op(x, id) == op(id, x) == x`. For example, if we have `Monoid[String]`,
  * with `op` as string concatenation, then `id = ""`.
  */
-trait Monoid[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] with HasIsId[A] {
+trait Monoid[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * Return the identity element for this monoid.
    */
   def id: A
 
-  // default implementation
+  /**
+    * Tests if `a` is the identity.
+    */
   def isId(a: A)(implicit ev: Eq[A]) = ev.eqv(a, id)
 
   /**

--- a/core/src/main/scala/spire/algebra/partial/Groupoid.scala
+++ b/core/src/main/scala/spire/algebra/partial/Groupoid.scala
@@ -14,9 +14,14 @@ import spire.syntax.eq._
   *       `((a.inverse |+|? a).get |+|? b) === b`
   * 
   */
-trait Groupoid[A] extends Any with Semigroupoid[A] with HasIsId[A] with HasInverse[A] {
+trait Groupoid[A] extends Any with Semigroupoid[A] {
+  /** Tests if `a` is an identity. */
   def isId(a: A)(implicit ev: Eq[A]) = a === leftId(a)
+  /** Returns the inverse element of `a` such that `(a |+|? a.inverse).get` is an identity. */
+  def inverse(a: A): A
+  /** Returns the left identity of `a`. */
   def leftId(a: A): A = partialOp(a, inverse(a)).get
+  /** Returns the right identity of `a`. */
   def rightId(a: A): A = partialOp(inverse(a), a).get
   def partialOpInverse(x: A, y: A): Opt[A] = partialOp(x, inverse(y))
   def opInverseIsDefined(x: A, y: A): Boolean = opIsDefined(x, inverse(y))

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -104,17 +104,14 @@ final class SignedOps[A:Signed](lhs: A) {
   def isSignNonNegative(): Boolean = macro Ops.unop[Boolean]
 }
 
-final class HasIsIdOps[A](lhs:A)(implicit ev: HasIsId[A]) {
-  def isId(implicit ev1: Eq[A]): Boolean = macro Ops.unopWithEv2[Eq[A], Boolean]
-}
-
-final class HasInverseOps[A](lhs:A)(implicit ev: HasInverse[A]) {
-  def inverse(): A = macro Ops.unop[A]
-}
-
 final class SemigroupoidOps[A](lhs:A)(implicit ev:Semigroupoid[A]) {
   def |+|? (rhs: A): Opt[A] = macro Ops.binop[A, Opt[A]]
   def |+|?? (rhs: A): Boolean = macro Ops.binop[A, Boolean]
+}
+
+final class GroupoidCommonOps[A](lhs:A)(implicit ev:Groupoid[A]) {
+  def inverse(): A = ev.inverse(lhs)
+  def isId(implicit ev1: Eq[A]): Boolean = ev.isId(lhs)(ev1)
 }
 
 final class GroupoidOps[A](lhs:A)(implicit ev:Groupoid[A]) {
@@ -128,7 +125,12 @@ final class SemigroupOps[A](lhs:A)(implicit ev:Semigroup[A]) {
   def |+|(rhs:A): A = macro Ops.binop[A, A]
 }
 
+final class MonoidOps[A](lhs:A)(implicit ev: Monoid[A]) {
+  def isId(implicit ev1: Eq[A]): Boolean = macro Ops.unopWithEv2[Eq[A], Boolean]
+}
+
 final class GroupOps[A](lhs:A)(implicit ev:Group[A]) {
+  def inverse(): A = macro Ops.unop[A]
   def |-|(rhs:A): A = macro Ops.binop[A, A]
 }
 
@@ -444,8 +446,8 @@ final class BitStringOps[A](lhs: A)(implicit ev: BitString[A]) {
   def rotateRight(rhs: Int): A = macro Ops.binop[Int, A]
 }
 
-final class LeftActionOps[G](lhs: G) {
-  def |+|> [P](rhs: P)(implicit ev: LeftAction[P, G]): P =
+final class ActionGroupOps[G](lhs: G) {
+  def |+|> [P](rhs: P)(implicit ev: Action[P, G]): P =
     macro Ops.binopWithEv[P, Action[P, G], P]
   def +> [P](rhs: P)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[P, AdditiveAction[P, G], P]
@@ -453,8 +455,8 @@ final class LeftActionOps[G](lhs: G) {
     macro Ops.binopWithEv[P, MultiplicativeAction[P, G], P]
 }
 
-final class RightActionOps[P](lhs: P) {
-  def <|+| [G](rhs: G)(implicit ev: RightAction[P, G]): P =
+final class ActionPointOps[P](lhs: P) {
+  def <|+| [G](rhs: G)(implicit ev: Action[P, G]): P =
     macro Ops.binopWithEv[G, Action[P, G], P]
   def <+ [G](rhs: G)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[G, AdditiveAction[P, G], P]

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -446,8 +446,8 @@ final class BitStringOps[A](lhs: A)(implicit ev: BitString[A]) {
   def rotateRight(rhs: Int): A = macro Ops.binop[Int, A]
 }
 
-final class ActionGroupOps[G](lhs: G) {
-  def |+|> [P](rhs: P)(implicit ev: Action[P, G]): P =
+final class LeftActionOps[G](lhs: G) {
+  def |+|> [P](rhs: P)(implicit ev: LeftAction[P, G]): P =
     macro Ops.binopWithEv[P, Action[P, G], P]
   def +> [P](rhs: P)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[P, AdditiveAction[P, G], P]
@@ -455,8 +455,8 @@ final class ActionGroupOps[G](lhs: G) {
     macro Ops.binopWithEv[P, MultiplicativeAction[P, G], P]
 }
 
-final class ActionPointOps[P](lhs: P) {
-  def <|+| [G](rhs: G)(implicit ev: Action[P, G]): P =
+final class RightActionOps[P](lhs: P) {
+  def <|+| [G](rhs: G)(implicit ev: RightAction[P, G]): P =
     macro Ops.binopWithEv[G, Action[P, G], P]
   def <+ [G](rhs: G)(implicit ev: AdditiveAction[P, G]): P =
     macro Ops.binopWithEv[G, AdditiveAction[P, G], P]

--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -1,5 +1,6 @@
 package spire.syntax
 
+import spire.NoImplicit
 import spire.algebra._
 import spire.algebra.lattice._
 import spire.algebra.partial._
@@ -30,19 +31,12 @@ trait SignedSyntax {
   implicit def signedOps[A: Signed](a: A) = new SignedOps(a)
 }
 
-trait HasIsIdSyntax {
-  implicit def hasIsIdOps[A](a:A)(implicit ev: HasIsId[A]) = new HasIsIdOps(a)
-}
-
-trait HasInverseSyntax {
-  implicit def hasInverseOps[A](a:A)(implicit ev: HasInverse[A]) = new HasInverseOps(a) 
-}
-
 trait SemigroupoidSyntax {
   implicit def semigroupoidOps[A:Semigroupoid](a:A) = new SemigroupoidOps[A](a)
 }
 
-trait GroupoidSyntax extends SemigroupoidSyntax with HasIsIdSyntax with HasInverseSyntax {
+trait GroupoidSyntax extends SemigroupoidSyntax {
+  implicit def groupoidCommonOps[A](a:A)(implicit ev: Groupoid[A], ni: NoImplicit[Monoid[A]]) = new GroupoidCommonOps[A](a)(ev)
   implicit def groupoidOps[A](a:A)(implicit ev: Groupoid[A]) = new GroupoidOps[A](a)
 }
 
@@ -50,9 +44,11 @@ trait SemigroupSyntax {
   implicit def semigroupOps[A:Semigroup](a:A) = new SemigroupOps(a)
 }
 
-trait MonoidSyntax extends SemigroupSyntax with HasIsIdSyntax
+trait MonoidSyntax extends SemigroupSyntax {
+  implicit def monoidOps[A](a:A)(implicit ev: Monoid[A]) = new MonoidOps(a)
+}
 
-trait GroupSyntax extends MonoidSyntax with HasInverseSyntax {
+trait GroupSyntax extends MonoidSyntax {
   implicit def groupOps[A:Group](a:A) = new GroupOps(a)
 }
 
@@ -162,8 +158,8 @@ trait BitStringSyntax {
 }
 
 trait ActionSyntax {
-  implicit def leftActionOps[G](g: G) = new LeftActionOps(g)
-  implicit def rightActionOps[P](p: P) = new RightActionOps(p)
+  implicit def actionGroupOps[G](g: G) = new ActionGroupOps(g)
+  implicit def actionPointOps[P](p: P) = new ActionPointOps(p)
 }
 
 trait UnboundSyntax {

--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -158,8 +158,8 @@ trait BitStringSyntax {
 }
 
 trait ActionSyntax {
-  implicit def actionGroupOps[G](g: G) = new ActionGroupOps(g)
-  implicit def actionPointOps[P](p: P) = new ActionPointOps(p)
+  implicit def leftActionOps[G](g: G) = new LeftActionOps(g)
+  implicit def rightActionOps[P](p: P) = new RightActionOps(p)
 }
 
 trait UnboundSyntax {


### PR DESCRIPTION
Follow-up of #353 

I found a trick to avoid ambiguous implicits between the regular and partial hierarchies, at the price of boxing the `Groupoid[A].inverse` and `.isId()` method calls (for now).

Correcting also Action syntax that was lost in the merge.