### PR TITLE
Partial actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ to concepts from abstract algebra:
  * `Semigroup[A]` types with an associative binary operator `|+|`
  * `Monoid[A]` semigroups that have an identity element
  * `Group[A]` monoids that have an inverse operator
+ * `(Left/Right/)Action[P, G]` left/right/ actions of semigroups/monoids/groups
  * `Semiring[A]` types that form semigroups under `+` and `*`
  * `Rng[A]` types that form a group under `+` and a semigroup under `*`
  * `Rig[A]` types that form monoids under `+` and `*`
@@ -132,6 +133,9 @@ to concepts from abstract algebra:
  * `Trig[A]` types that support trigonometric functions
  * `Bool[A]` types that form a Boolean algebra
  * `Heyting[A]` types that form a Heyting algebra
+
+Variants of Semigroup/Monoid/Group/Action with partial operations are
+defined in the `spire.algebra.partial` subpackage.
 
 In addition to the type classes themselves, `spire.implicits` defines many
 implicits which provide unary and infix operators for the type classes. The

--- a/core/src/main/scala/spire/algebra/Action.scala
+++ b/core/src/main/scala/spire/algebra/Action.scala
@@ -34,6 +34,26 @@ object RightAction {
   @inline def apply[P, G](G: RightAction[P, G]) = G
 }
 
+/**
+  * A semigroup/monoid/group action of `G` on `P` is the combination of compatible
+  * left and right actions, providing:
+  * 
+  *  - the implementation of a method `actl(g, p)`, or `g |+|> p`, such that:
+  * 
+  * 1. `(g |+| h) |+|> p === g |+|> (h |+|> p)` for all `g`, `h` in `G` and `p` in `P`.
+  * 
+  * 2. `id |+|> p === p` for all `p` in `P` (if `id` is defined)
+  * 
+  *   - the implementation of a method `actr(p, g)`, or `p <|+| g`, such that:
+  * 
+  * 3. `p <|+| (g |+| h) === (p <|+| g) <|+| h` for all `g`, `h` in `G` and `p` in `P`.
+  * 
+  * 4. `p <|+| id === p` for all `p` in `P` (if `id` is defined)
+  * 
+  * In addition, if `G` is a group, left and right actions are compatible:
+  * 
+  * 5. `g |+|> p === p <|+| g.inverse`.
+  */
 trait Action[@spec(Int) P, G] extends Any with LeftAction[P, G] with RightAction[P, G]
 
 object Action {

--- a/core/src/main/scala/spire/algebra/partial/PartialAction.scala
+++ b/core/src/main/scala/spire/algebra/partial/PartialAction.scala
@@ -19,7 +19,7 @@ import spire.util.Opt
   * `(g.rightId ?|+|> p).get === p`, the operation `?|+|>` being defined.
   */
 trait LeftPartialAction[P, G] extends Any {
-  def actlIsDefined(g: G, p: P): Boolean
+  def actlIsDefined(g: G, p: P): Boolean = partialActl(g, p).nonEmpty
   def partialActl(g: G, p: P): Opt[P]
 }
 
@@ -28,7 +28,7 @@ object LeftPartialAction {
 
   implicit def fromLeftAction[P, G](implicit G: LeftAction[P, G]): LeftPartialAction[P, G] =
     new LeftPartialAction[P, G] {
-      def actlIsDefined(g: G, p: P) = true
+      override def actlIsDefined(g: G, p: P) = true
       def partialActl(g: G, p: P): Opt[P] = Opt(G.actl(g, p))
     }
 }
@@ -50,7 +50,7 @@ object LeftPartialAction {
   */
 
 trait RightPartialAction[P, G] extends Any {
-  def actrIsDefined(p: P, g: G): Boolean
+  def actrIsDefined(p: P, g: G): Boolean = partialActr(p, g).nonEmpty
   def partialActr(p: P, g: G): Opt[P]
 }
 
@@ -59,7 +59,7 @@ object RightPartialAction {
 
   implicit def fromRightAction[P, G](implicit G: RightAction[P, G]): RightPartialAction[P, G] =
     new RightPartialAction[P, G] {
-      def actrIsDefined(p: P, g: G) = true
+      override def actrIsDefined(p: P, g: G) = true
       def partialActr(p: P, g: G): Opt[P] = Opt(G.actr(p, g))
     }
 }
@@ -72,10 +72,9 @@ object PartialAction {
 
   implicit def fromAction[P, G](implicit G: Action[P, G]): PartialAction[P, G] =
     new PartialAction[P, G] {
-      def actlIsDefined(g: G, p: P) = true
+      override def actlIsDefined(g: G, p: P) = true
       def partialActl(g: G, p: P): Opt[P] = Opt(G.actl(g, p))
-      def actrIsDefined(p: P, g: G) = true
+      override def actrIsDefined(p: P, g: G) = true
       def partialActr(p: P, g: G): Opt[P] = Opt(G.actr(p, g))
     }
-
 }

--- a/core/src/main/scala/spire/algebra/partial/PartialAction.scala
+++ b/core/src/main/scala/spire/algebra/partial/PartialAction.scala
@@ -64,6 +64,38 @@ object RightPartialAction {
     }
 }
 
+/**
+  * A partial action is the combination of left and right partial actions, providing:
+  * 
+  * - a method `partialActl(g, p)`, or `g ?|+|> p` returning `Opt[P]`, such that:
+  * 
+  * 1. for all `g`, `h` in `G`, `p` in `P` such that `g |+|? h` and `h ?|+|> p` are defined,
+  * 
+  *    `((g |+|? h).get ?|+|> p).get === (g ?|+|> (h ?|+|> p).get).get` with all operations
+  *    defined.
+  * 
+  *  - a method `partialActr(p, g)`, or `p <|+|? g` returning `Opt[P]`, such that:
+  * 
+  * 2. for all `g`, `h` in `G`, `p` in `P` such that `g |+|? h` and `p <|+|? g` are defined,
+  * 
+  *    `(p <|+|? (g |+|? h).get).get === ((p <|+|? g).get |+|? h).get`, 
+  *    and all operations are defined.
+  * 
+  * In addition, if `G` is a groupoid, the following relations holds:
+  * 
+  * 3. for all `g` in `G` and `p` in `P` such that `g ?|+|> p` is defined:
+  * 
+  * `(g.rightId ?|+|> p).get === p`, the operation `?|+|>` being defined.
+  * 
+  * 4. for all `g` in `G` and `p` in `P` such that `p <|+|? g` is defined:
+  * 
+  * `(p <|+|? g.leftId).get === p`, the operation `<|+|?` being defined.
+  * 
+  * 5. for all `g` in `G` and `p` in `P` such that `g ?|+|> p` is defined:
+  * 
+  * `(g ?|+|> p).get === (p <|+|? g.inverse).get`
+  * 
+  */
 trait PartialAction[P, G] extends Any
     with LeftPartialAction[P, G] with RightPartialAction[P, G]
 

--- a/core/src/main/scala/spire/algebra/partial/PartialAction.scala
+++ b/core/src/main/scala/spire/algebra/partial/PartialAction.scala
@@ -1,0 +1,81 @@
+package spire.algebra
+package partial
+
+import spire.util.Opt
+
+/**
+  * A left partial action of a semigroupoid `G` on `P` is the implementation of
+  * a method `partialActl(g, p)`, or `g ?|+|> p` returning `Opt[P]`, such that:
+  * 
+  * 1. for all `g`, `h` in `G`, `p` in `P` such that `g |+|? h` and `h ?|+|> p` are defined,
+  * 
+  *    `((g |+|? h).get ?|+|> p).get === (g ?|+|> (h ?|+|> p).get).get` with all operations
+  *    defined.
+  * 
+  * In addition, if `G` is a partial monoid, the following relation holds:
+  * 
+  * 2. for all `g` in `G` and `p` in `P` such that `g ?|+|> p` is defined:
+  * 
+  * `(g.rightId ?|+|> p).get === p`, the operation `?|+|>` being defined.
+  */
+trait LeftPartialAction[P, G] extends Any {
+  def actlIsDefined(g: G, p: P): Boolean
+  def partialActl(g: G, p: P): Opt[P]
+}
+
+object LeftPartialAction {
+  @inline final def apply[P, G](implicit G: LeftPartialAction[P, G]) = G
+
+  implicit def fromLeftAction[P, G](implicit G: LeftAction[P, G]): LeftPartialAction[P, G] =
+    new LeftPartialAction[P, G] {
+      def actlIsDefined(g: G, p: P) = true
+      def partialActl(g: G, p: P): Opt[P] = Opt(G.actl(g, p))
+    }
+}
+
+/**
+  * A right partial action of a semigroupoid `G` on `P` is the implementation of
+  * a method `partialActr(p, g)`, or `p <|+|? g` returning `Opt[P]`, such that:
+  * 
+  * 1. for all `g`, `h` in `G`, `p` in `P` such that `g |+|? h` and `p <|+|? g` are defined,
+  * 
+  *    `(p <|+|? (g |+|? h).get).get === ((p <|+|? g).get |+|? h).get`, 
+  *    and all operations are defined.
+  * 
+  * In addition, if `G` is a partial monoid, the following relation holds:
+  * 
+  * 2. for all `g` in `G` and `p` in `P` such that `p <|+|? g` is defined:
+  * 
+  * `(p <|+|? g.leftId).get === p`, the operation `<|+|?` being defined.
+  */
+
+trait RightPartialAction[P, G] extends Any {
+  def actrIsDefined(p: P, g: G): Boolean
+  def partialActr(p: P, g: G): Opt[P]
+}
+
+object RightPartialAction {
+  @inline final def apply[P, G](implicit G: RightPartialAction[P, G]) = G
+
+  implicit def fromRightAction[P, G](implicit G: RightAction[P, G]): RightPartialAction[P, G] =
+    new RightPartialAction[P, G] {
+      def actrIsDefined(p: P, g: G) = true
+      def partialActr(p: P, g: G): Opt[P] = Opt(G.actr(p, g))
+    }
+}
+
+trait PartialAction[P, G] extends Any
+    with LeftPartialAction[P, G] with RightPartialAction[P, G]
+
+object PartialAction {
+  @inline final def apply[P, G](implicit G: PartialAction[P, G]) = G
+
+  implicit def fromAction[P, G](implicit G: Action[P, G]): PartialAction[P, G] =
+    new PartialAction[P, G] {
+      def actlIsDefined(g: G, p: P) = true
+      def partialActl(g: G, p: P): Opt[P] = Opt(G.actl(g, p))
+      def actrIsDefined(p: P, g: G) = true
+      def partialActr(p: P, g: G): Opt[P] = Opt(G.actr(p, g))
+    }
+
+}

--- a/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
+++ b/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
@@ -1,0 +1,53 @@
+package spire.optional
+
+import scala.{specialized => sp}
+
+import scala.collection.SeqLike
+import scala.collection.generic.CanBuildFrom
+
+import spire.algebra.{Action, Group}
+import spire.algebra.partial.PartialAction
+import spire.syntax.cfor._
+import spire.syntax.group._
+import spire.util._
+
+final class MapIntIntIntAction extends Action[Int, Map[Int, Int]] {
+  def actr(k: Int, perm: Map[Int, Int]): Int = perm.getOrElse(k, k)
+  def actl(perm: Map[Int, Int], k: Int): Int = perm.find(_._2 == k).fold(k)(_._1)
+}
+
+final class MapIntIntGroup extends Group[Map[Int, Int]] {
+  def id = Map.empty[Int, Int]
+  def op(x: Map[Int, Int], y: Map[Int, Int]) = {
+    val preimages = x.keys ++ y.keys
+
+    (Map.empty[Int, Int] /: preimages) {
+      case (prevMap, preimage) =>
+        val imageX = x.getOrElse(preimage, preimage)
+        val image = y.getOrElse(imageX, imageX)
+        if (preimage != image) prevMap + (preimage -> image) else prevMap
+    }
+  }
+  def inverse(a: Map[Int, Int]): Map[Int, Int] = a.map(_.swap).toMap
+}
+
+final class MapIntIntSeqPartialAction[A, SA <: SeqLike[A, SA]](implicit cbf: CanBuildFrom[SA, A, SA]) extends PartialAction[SA, Map[Int, Int]] {
+  import mapIntIntPermutation._
+  def partialActl(perm: Map[Int, Int], sa: SA): Opt[SA] = {
+    if (perm.isEmpty) return Opt(sa)
+    if (perm.keys.max >= sa.size) return Opt.empty[SA]
+    val builder = cbf()
+    cforRange(0 until sa.size) { k =>
+      builder += sa(perm.getOrElse(k, k))
+    }
+    Opt(builder.result())
+  }
+  def partialActr(sa: SA, perm: Map[Int, Int]) =
+    partialActl(perm.inverse, sa)
+}
+
+object mapIntIntPermutation {
+  implicit val MapIntIntIntAction: Action[Int, Map[Int, Int]] = new MapIntIntIntAction
+  implicit val MapIntIntGroup: Group[Map[Int, Int]] = new MapIntIntGroup
+  implicit def MapIntIntSeqPartialAction[A, CC[A] <: SeqLike[A, CC[A]]](implicit cbf: CanBuildFrom[CC[A], A, CC[A]]): PartialAction[CC[A], Map[Int, Int]] = new MapIntIntSeqPartialAction[A, CC[A]]
+}

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -446,6 +446,20 @@ final class BitStringOps[A](lhs: A)(implicit ev: BitString[A]) {
   def rotateRight(rhs: Int): A = macro Ops.binop[Int, A]
 }
 
+final class LeftPartialActionOps[G](lhs: G) {
+  def ?|+|> [P](rhs: P)(implicit ev: LeftPartialAction[P, G]): Opt[P] =
+    macro Ops.binopWithEv[P, LeftPartialAction[P, G], Opt[P]]
+  def ??|+|> [P](rhs: P)(implicit ev: LeftPartialAction[P, G]): Boolean =
+    macro Ops.binopWithEv[P, LeftPartialAction[P, G], Boolean]
+}
+
+final class RightPartialActionOps[P](lhs: P) {
+  def <|+|? [G](rhs: G)(implicit ev: RightPartialAction[P, G]): Opt[P] =
+    macro Ops.binopWithEv[G, RightPartialAction[P, G], Opt[P]]
+  def <|+|?? [G](rhs: G)(implicit ev: RightPartialAction[P, G]): Boolean =
+    macro Ops.binopWithEv[G, RightPartialAction[P, G], Boolean]
+}
+
 final class LeftActionOps[G](lhs: G) {
   def |+|> [P](rhs: P)(implicit ev: LeftAction[P, G]): P =
     macro Ops.binopWithEv[P, Action[P, G], P]

--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -157,6 +157,11 @@ trait BitStringSyntax {
   implicit def bitStringOps[A: BitString](a: A) = new BitStringOps(a)
 }
 
+trait PartialActionSyntax {
+  implicit def leftPartialActionOps[G](g: G) = new LeftPartialActionOps(g)
+  implicit def rightPartialActionOps[P](p: P) = new RightPartialActionOps(p)
+}
+
 trait ActionSyntax {
   implicit def leftActionOps[G](g: G) = new LeftActionOps(g)
   implicit def rightActionOps[P](p: P) = new RightActionOps(p)
@@ -262,6 +267,7 @@ trait AllSyntax extends
     HeytingSyntax with
     BoolSyntax with
     BitStringSyntax with
+    PartialActionSyntax with
     ActionSyntax with
     TorsorSyntax with
     IntegralSyntax with

--- a/core/src/main/scala/spire/syntax/package.scala
+++ b/core/src/main/scala/spire/syntax/package.scala
@@ -48,6 +48,7 @@ package object syntax {
 
   object bitString extends BitStringSyntax
 
+  object partialAction extends PartialActionSyntax
   object action extends ActionSyntax
   object torsor extends TorsorSyntax
 

--- a/core/src/main/scala/spire/util/Opt.scala
+++ b/core/src/main/scala/spire/util/Opt.scala
@@ -1,8 +1,20 @@
 package spire.util
- 
+
+import spire.algebra.Eq
+import spire.syntax.eq._
+
 object Opt extends OptVersions {
   def apply[A](a: A): Opt[A] = new Opt(a)
   def empty[A]: Opt[A] = new Opt[A](null.asInstanceOf[A])
+
+  implicit def Eq[A: Eq]: Eq[Opt[A]] = new Eq[Opt[A]] {
+    def eqv(x: Opt[A], y: Opt[A]): Boolean =
+      if (x.isEmpty) y.isEmpty else {
+        if (y.isEmpty)
+          false
+        x.ref === y.ref
+      }
+  }
 }
 
 class Opt[+A](val ref: A) extends OptVersions.Base {

--- a/macros/src/main/scala/spire/macros/Syntax.scala
+++ b/macros/src/main/scala/spire/macros/Syntax.scala
@@ -16,6 +16,12 @@ object Ops extends machinist.Ops {
       ("$bar$plus$bar$qmark", "partialOp"),
       ("$bar$minus$bar$qmark", "partialOpInverse"),
 
+      // partial actions ?|+|> ??|+|> <|+|? <|+|??
+      ("$qmark$bar$plus$bar$greater", "partialActl"),
+      ("$qmark$qmark$bar$plus$bar$greater", "actlIsDefined"),
+      ("$less$bar$plus$bar$qmark", "partialActr"),
+      ("$less$bar$plus$bar$qmark$qmark", "actrIsDefined"),
+      
       // square root
       (uesc('√'), "sqrt"),
 

--- a/scalacheck-binding/src/main/scala/spire/laws/PartialActionLaws.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/PartialActionLaws.scala
@@ -1,0 +1,156 @@
+package spire.laws
+
+import spire.algebra._
+import spire.algebra.partial._
+import spire.implicits._
+
+import org.typelevel.discipline.Laws
+
+import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Prop._
+
+object PartialActionLaws {
+  def apply[G: Eq: Arbitrary, A: Eq: Arbitrary] = new PartialActionLaws[G, A] {
+    val scalarLaws = PartialGroupLaws[G]
+    def EquA = Eq[A]
+    def ArbA = implicitly[Arbitrary[A]]
+  }
+}
+
+trait PartialActionLaws[G, A] extends Laws {
+
+  val scalarLaws: PartialGroupLaws[G]
+
+  import scalarLaws.{ Equ => EqG, Arb => ArG }
+
+  implicit def EquA: Eq[A]
+  implicit def ArbA: Arbitrary[A]
+
+  def leftSemigroupoidPartialAction(implicit G: LeftPartialAction[A, G], G0: Semigroupoid[G]) = new ActionProperties(
+    name = "leftSemigroupAction",
+    sl = _.semigroupoid(G0),
+    parents = Seq.empty,
+
+    "left compatibility" → forAll { (g: G, h: G, a: A) =>
+      ( (h ??|+|> a) && (g |+|?? h) ) ==>
+        ((g |+|? h).get ??|+|> a) && ((g |+|? h).get ?|+|> a).get === (g ?|+|> (h ?|+|> a).get).get
+    }
+  )
+
+  def rightSemigroupoidPartialAction(implicit G: RightPartialAction[A, G], G0: Semigroupoid[G]) = new ActionProperties(
+    name = "rightSemigroupAction",
+    sl = _.semigroupoid(G0),
+    parents = Seq.empty,
+
+    "right compatibility" → forAll { (g: G, h: G, a: A) =>
+      ( (a <|+|?? g) && (g |+|?? h) ) ==>
+      (a <|+|?? (g |+|? h).get) && ((a <|+|? (g |+|? h).get).get === ((a <|+|? g).get <|+|? h).get)
+    }
+  )
+
+  def semigroupoidPartialAction(implicit G: PartialAction[A, G], G0: Semigroupoid[G]) = new ActionProperties(
+    name = "semigroupAction",
+    sl = _.semigroupoid(G0),
+    parents = Seq(leftSemigroupoidPartialAction, rightSemigroupoidPartialAction)
+  )
+
+  def groupoidPartialAction(implicit G: PartialAction[A, G], G0: Groupoid[G]) = new ActionProperties(
+    name = "groupoidPartialAction",
+    sl = _.groupoid(G0),
+    parents = Seq(semigroupoidPartialAction),
+
+    "left action identity" → forAll { (g: G, a: A) =>
+      (g ??|+|> a) ==>
+      ((g.rightId ??|+|> a) && ((g.rightId ?|+|> a).get === a))
+    },
+
+    "right action identity" → forAll { (g: G, a: A) =>
+      (a <|+|?? g) ==>
+      ((a <|+|?? g.leftId) && ((a <|+|? g.leftId).get === a))
+    },
+
+
+    "left and right partial action compatibility" → forAll { (a: A, g: G) =>
+      (a <|+|?? g) ==>
+      ((g.inverse ??|+|> a) && ((a <|+|? g).get === (g.inverse ?|+|> a).get))
+    }
+  )
+
+  def leftSemigroupPartialAction(implicit G: LeftPartialAction[A, G], G0: Semigroup[G]) = new ActionProperties(
+    name = "leftSemigroupPartialAction",
+    sl = _.semigroup(G0),
+    parents = Seq.empty,
+
+    "left compatibility" → forAll { (g: G, h: G, a: A) =>
+      ( (h ??|+|> a) && ((g |+| h) ??|+|> a) ) ==>
+      (((g |+| h) ?|+|> a).get === (g ?|+|> (h ?|+|> a).get).get)
+    }
+  )
+
+  def rightSemigroupPartialAction(implicit G: RightPartialAction[A, G], G0: Semigroup[G]) = new ActionProperties(
+    name = "rightSemigroupPartialAction",
+    sl = _.semigroup(G0),
+    parents = Seq.empty,
+
+    "right compatibility" → forAll { (a: A, g: G, h: G) =>
+      ( (a <|+|?? g) && (a <|+|?? (g |+| h)) ) ==>
+      ((a <|+|? (g |+| h)).get === ((a <|+|? g).get <|+|? h).get)
+    }
+  )
+
+  def semigroupPartialAction(implicit G: PartialAction[A, G], G0: Semigroup[G]) = new ActionProperties(
+    name = "semigroupPartialAction",
+    sl = _.semigroup(G0),
+    parents = Seq(leftSemigroupPartialAction, rightSemigroupPartialAction)
+  )
+
+  def leftMonoidPartialAction(implicit G: LeftPartialAction[A, G], G0: Monoid[G]) = new ActionProperties(
+    name = "leftMonoidPartialAction",
+    sl = _.monoid(G0),
+    parents = Seq(leftSemigroupPartialAction),
+
+    "left identity" → forAll { (a: A) =>
+      (G0.id ??|+|> a) && ((G0.id ?|+|> a).get === a)
+    }
+  )
+
+  def rightMonoidPartialAction(implicit G: RightPartialAction[A, G], G0: Monoid[G]) = new ActionProperties(
+    name = "rightMonoidPartialAction",
+    sl = _.monoid(G0),
+    parents = Seq(rightSemigroupPartialAction),
+
+    "right identity" → forAll { (a: A) =>
+      (a <|+|?? G0.id) && ((a <|+|? G0.id).get === a)
+    }
+  )
+
+
+  def monoidPartialAction(implicit G: PartialAction[A, G], G0: Monoid[G]) = new ActionProperties(
+    name = "monoidPartialAction",
+    sl = _.monoid(G0),
+    parents = Seq(semigroupPartialAction, leftSemigroupPartialAction, rightSemigroupPartialAction)
+  )
+
+  def groupPartialAction(implicit G: PartialAction[A, G], G0: Group[G]) = new ActionProperties(
+    name = "groupPartialAction",
+    sl = _.group(G0),
+    parents = Seq(monoidPartialAction),
+
+    "right -> left action compatibility" → forAll { (a: A, g: G) =>
+      !(a <|+|?? g) || ((g ??|+|> a) && ((a <|+|? g).get === (g.inverse ?|+|> a).get))
+    },
+
+    "left -> right action compatibility" → forAll { (a: A, g: G) =>
+      !(g ??|+|> a) || ((a <|+|?? g) && ((g ?|+|> a).get === (a <|+|? g.inverse).get))
+    }
+  )
+
+  class ActionProperties(
+    val name: String,
+    val sl: scalarLaws.type => scalarLaws.RuleSet,
+    val parents: Seq[ActionProperties],
+    val props: (String, Prop)*
+  ) extends RuleSet {
+    val bases = Seq("scalar" → sl(scalarLaws))
+  }
+}

--- a/scalacheck-binding/src/main/scala/spire/laws/SpireArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/SpireArbitrary.scala
@@ -144,6 +144,25 @@ object SpireArbitrary {
         Group[FreeAbGroup[A]].combinen(FreeAbGroup(a), n)
       }.foldLeft(FreeAbGroup.id[A])(_ |+| _)
     })
+
+  /** Represents a permutation encoded as a map from preimages to images, including
+    * only pairs that are moved by the permutation (so the identity is Map.empty).
+    */
+  case class Perm(map: Map[Int, Int])
+  implicit def arbPerm: Arbitrary[Perm] = Arbitrary(Gen.parameterized { parameters =>
+    import parameters.rng
+    val domainSize = parameters.size / 10 + 1
+    val images = new Array[Int](domainSize)
+    spire.syntax.cfor.cforRange(0 until domainSize) { i =>
+      val j = rng.nextInt(i + 1) // uses the Fisher-Yates shuffle, inside out variant
+      images(i) = images(j)
+      images(j) = i
+    }
+    Perm((Map.empty[Int, Int] /: images.zipWithIndex) {
+      case (prevMap, (preimage, image)) if preimage != image => prevMap + (preimage -> image)
+      case (prevMap, _) => prevMap
+    })
+  })
 }
 
 // vim: expandtab:ts=2:sw=2

--- a/tests/src/test/scala/spire/PartialSyntaxTest.scala
+++ b/tests/src/test/scala/spire/PartialSyntaxTest.scala
@@ -3,38 +3,54 @@ package spire
 import spire.algebra._
 import spire.algebra.partial._
 import spire.optional.partialIterable._
+import spire.optional.mapIntIntPermutation._
 import spire.std.int._
 import spire.util._
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{FunSuite, Matchers, NonImplicitAssertions}
 import org.scalatest.prop.Checkers
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 
-class PartialSyntaxTest extends FunSuite with Checkers with BaseSyntaxTest {
+import spire.syntax.eq._
+import spire.syntax.cfor._
+import spire.std.boolean._
+
+class PartialSyntaxTest extends FunSuite with Checkers with BaseSyntaxTest with NonImplicitAssertions {
+
+  import laws.SpireArbitrary._
 
   implicit val IntGroup: Group[Int] = implicitly[AdditiveGroup[Int]].additive
   implicit val SeqIntEq: Eq[Seq[Int]] = spire.optional.genericEq.generic[Seq[Int]]
 
   test("Semigroupoid syntax")(check(forAll { (a: Seq[Int], b: Seq[Int]) => testSemigroupoidSyntax(a, b) }))
   test("Groupoid syntax")(check(forAll { (a: Seq[Int], b: Seq[Int]) => testGroupoidSyntax(a, b) }))
+  test("Partial action syntax")(check(forAll { (seq: Seq[Int], perm: Perm) => testPartialActionSyntax(seq, perm.map) }))
 
   def testSemigroupoidSyntax[A: Semigroupoid: Eq](a: A, b: A) = {
     import spire.syntax.semigroupoid._
-    ((a |+|? b) == Semigroupoid[A].partialOp(a, b)) &&
-    ((a |+|?? b) == Semigroupoid[A].opIsDefined(a, b))
+    ((a |+|? b) === Semigroupoid[A].partialOp(a, b)) &&
+    ((a |+|?? b) === Semigroupoid[A].opIsDefined(a, b))
   }
 
   def testGroupoidSyntax[A: Groupoid: Eq](a: A, b: A) = {
     import spire.syntax.groupoid._
-    (a.isId == Groupoid[A].isId(a)) &&
-    (a.leftId == Groupoid[A].leftId(a)) &&
-    (a.rightId == Groupoid[A].rightId(a)) &&
-    ((a |+|? b) == Groupoid[A].partialOp(a, b)) &&
-    ((a |+|?? b) == Groupoid[A].opIsDefined(a, b))
-    ((a |-|? b) == Groupoid[A].partialOpInverse(a, b)) &&
-    ((a |-|?? b) == Groupoid[A].opInverseIsDefined(a, b))
+    (a.isId === Groupoid[A].isId(a)) &&
+    (a.leftId === Groupoid[A].leftId(a)) &&
+    (a.rightId === Groupoid[A].rightId(a)) &&
+    ((a |+|? b) === Groupoid[A].partialOp(a, b)) &&
+    ((a |+|?? b) === Groupoid[A].opIsDefined(a, b))
+    ((a |-|? b) === Groupoid[A].partialOpInverse(a, b)) &&
+    ((a |-|?? b) === Groupoid[A].opInverseIsDefined(a, b))
+  }
+
+  def testPartialActionSyntax(seq: Seq[Int], perm: Map[Int, Int]) = {
+    import spire.syntax.partialAction._
+    ((perm ?|+|> seq) === PartialAction[Seq[Int], Map[Int, Int]].partialActl(perm, seq)) &&
+    ((seq <|+|? perm) === PartialAction[Seq[Int], Map[Int, Int]].partialActr(seq, perm)) &&
+    ((perm ??|+|> seq) === PartialAction[Seq[Int], Map[Int, Int]].actlIsDefined(perm, seq)) &&
+    ((seq <|+|?? perm) === PartialAction[Seq[Int], Map[Int, Int]].actrIsDefined(seq, perm))
   }
 }

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -5,10 +5,11 @@ import spire.algebra.free._
 import spire.algebra.lattice._
 import spire.math._
 import spire.optional.partialIterable._
+import spire.optional.mapIntIntPermutation._
 import spire.implicits.{
   SeqOrder => _, SeqEq => _,
   ArrayOrder => _, ArrayEq => _,
-  MapEq => _,
+  MapEq => _, MapGroup => _,
   _ }
 
 import scala.{ specialized => spec }
@@ -16,6 +17,7 @@ import scala.{ specialized => spec }
 import org.typelevel.discipline.scalatest.Discipline
 
 import org.scalatest.FunSuite
+import org.scalacheck.Arbitrary
 
 class LawTests extends FunSuite with Discipline {
 
@@ -111,4 +113,6 @@ class LawTests extends FunSuite with Discipline {
 
   checkAll("Order[Int]", OrderLaws[Int].order)
   checkAll("LatticePartialOrder[Int]", LatticePartialOrderLaws[Int].boundedLatticePartialOrder(intMinMaxLattice, implicitly[Order[Int]]))
+
+  checkAll("Map[Int, Int]", PartialActionLaws.apply[Map[Int, Int], Seq[Int]](implicitly, Arbitrary(arbPerm.arbitrary.map(_.map)), implicitly, implicitly).groupPartialAction)
 }


### PR DESCRIPTION
Implementation of partial actions, i.e. left or right actions that can either succeed or fail, with the result represented as an `Opt[A]`.

An optional implementation of permutations using `Map[Int, Int]` is provided in `spire.optional`, to provide the material for syntax and law tests. This part could be moved completely in the tests package (what do you think, @non and @tixxit ?); a complete implementation of permutations, finite groups, etc..., is outside the scope of Spire.

Supercedes and replaces #357.