### PR TITLE
Added override to LongRational.equals

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -763,6 +763,11 @@ private[math] object LongRationals extends Rationals[Long] {
         else
           (SafeLong(n) * (r.d / dgcd) - SafeLong(r.n) * (d / dgcd)).signum
     }
+
+    override def equals(that: Any) = that match {
+      case that: LongRational => this.n == that.n && this.d == that.d
+      case _ => super.equals(that)
+    }
   }
 }
 


### PR DESCRIPTION
ensures that a comparison between two LongRational numbers happens
without any boxing. Speeds up == between two LongRationals
significantly.

Fixes #366