### PR TITLE
Override hashCode separately in LongRational and BigRational

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -441,7 +441,7 @@ private[math] abstract class Rationals[@specialized(Long) A](implicit integral: 
     def toBigInt: BigInt = (integral.toBigInt(num) / integral.toBigInt(den))
     def toBigDecimal: BigDecimal = integral.toBigDecimal(num) / integral.toBigDecimal(den)
 
-    def longValue = toBigInt.longValue    // Override if possible.
+    def longValue = toBigInt.longValue
     def intValue = longValue.intValue
 
     def floatValue = doubleValue.toFloat
@@ -478,11 +478,6 @@ private[math] abstract class Rationals[@specialized(Long) A](implicit integral: 
       val bits = (m | ((1023L - e) << 52))
       java.lang.Double.longBitsToDouble(bits)
     }
-      
-
-    override def hashCode: Int =
-      if (isWhole && toBigInt == toLong) unifiedPrimitiveHashcode
-      else 29 * (37 * num.## + den.##)
 
     override def equals(that: Any): Boolean = that match {
       case that: Real => this == that.toRational
@@ -764,10 +759,18 @@ private[math] object LongRationals extends Rationals[Long] {
           (SafeLong(n) * (r.d / dgcd) - SafeLong(r.n) * (d / dgcd)).signum
     }
 
-    override def equals(that: Any) = that match {
+    override def equals(that: Any): Boolean = that match {
       case that: LongRational => this.n == that.n && this.d == that.d
       case _ => super.equals(that)
     }
+
+    override def longValue: Long =
+      if(d == 1L) n
+      else n / d
+
+    override def hashCode: Int =
+      if (d==1) unifiedPrimitiveHashcode
+      else 29 * (37 * n.## + d.##)
   }
 }
 
@@ -935,6 +938,9 @@ private[math] object BigRationals extends Rationals[BigInt] {
           (SafeLong(r.d / dgcd) * n - SafeLong(d / dgcd) * r.n).signum
       }
     }
+
+    override def hashCode: Int =
+      29 * (37 * n.## + d.##)
   }
 }
 


### PR DESCRIPTION
In LongRational, we know that the numerator is within Long range, so we
always use unifiedPrimitiveHashcode if the denominator is 1. We also have
to override longValue, since that is used by unifiedPrimitiveHashcode.

In BigRational, we know that the numerator is larger than a long if the
denominator is 1, so we never have to use unifiedPrimitiveHashcode

Fixes #368