### PR TITLE
Adds a fast path for comparisons between LongRationals

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -1,5 +1,7 @@
 package spire.math
 
+import spire.macros.Checked
+import spire.std.long.LongAlgebra
 import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 
@@ -745,11 +747,15 @@ private[math] object LongRationals extends Rationals[Long] {
 
     def compare(r: Rational): Int = r match {
       case r: LongRationals.LongRational =>
-        val dgcd = spire.math.gcd(d, r.d)
-        if (dgcd == 1L)
-          (SafeLong(n) * r.d - SafeLong(r.n) * d).signum
-        else
-          (SafeLong(n) * (r.d / dgcd) - SafeLong(r.n) * (d / dgcd)).signum
+        Checked.tryOrElse {
+          LongAlgebra.compare(n * r.d, r.n * d)
+        } {
+          val dgcd = spire.math.gcd(d, r.d)
+          if (dgcd == 1L)
+            (SafeLong(n) * r.d - SafeLong(r.n) * d).signum
+          else
+            (SafeLong(n) * (r.d / dgcd) - SafeLong(r.n) * (d / dgcd)).signum
+        }
 
       case r: BigRational =>
         val dgcd = spire.math.gcd(d, (r.d % d).toLong)


### PR DESCRIPTION
Adds a fast path that does a simple comparison without calculating a gcd
and without wrapping to SafeLong. In case of overflow, the generic code
will be executed.

This improves performance of comparisons between small to medium rationals
significantly, while having only an insignificant negative performance
impact in the overflow case.

LongAlgebra.compare is used for the comparison since java.lang.Long.compare
is not availble prior to java 7. This should be switched to java.lang.Long.compare as soon
as java 6 compatibility is dropped.

Fixes #370