### PR TITLE
Rational sumdiff fastpath

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -556,7 +556,7 @@ private[math] object LongRationals extends Rationals[Long] {
       else LongRational(-n, d)
 
     def +(r: Rational): Rational = r match {
-      case r: LongRationals.LongRational =>
+      case r: LongRational =>
         val dgcd: Long = spire.math.gcd(d, r.d)
         if (dgcd == 1L) {
           Checked.tryOrReturn[Rational] {
@@ -617,28 +617,38 @@ private[math] object LongRationals extends Rationals[Long] {
 
 
     def -(r: Rational): Rational = r match {
-      case r: LongRationals.LongRational =>
+      case r: LongRational =>
         val dgcd: Long = spire.math.gcd(d, r.d)
         if (dgcd == 1L) {
-
-          val num = SafeLong(n) * r.d - SafeLong(r.n) * d
-          val den = SafeLong(d) * r.d
-          Rational(num, den)
+          Checked.tryOrReturn[Rational] {
+            build(n * r.d - r.n * d, d * r.d)
+          } {
+            Rational(SafeLong(n) * r.d - SafeLong(r.n) * d, SafeLong(d) * r.d)
+          }
 
         } else {
 
           val lden: Long = d / dgcd
           val rden: Long = r.d / dgcd
-          val num: SafeLong = SafeLong(n) * rden - SafeLong(r.n) * lden
-          val ngcd: Long = num match {
-            case SafeLongLong(x) => spire.math.gcd(x, dgcd)
-            case SafeLongBigInt(x) => spire.math.gcd(dgcd, (x % dgcd).toLong)
-          }
+          Checked.tryOrReturn {
+            val num: Long = n * rden - r.n * lden
 
-          if (ngcd == 1L)
-            Rational(num, SafeLong(lden) * r.d)
-          else
-            Rational(num / ngcd, SafeLong(lden) * (r.d / ngcd))
+            val ngcd: Long = spire.math.gcd(num, dgcd)
+
+            if (ngcd == 1L)
+              build(num, lden * r.d)
+            else
+              build(div(num, ngcd), lden * div(r.d, ngcd))
+          } {
+            val num: BigInt = BigInt(n) * rden - BigInt(r.n) * lden
+
+            val ngcd: Long = spire.math.gcd(dgcd, (num % dgcd).toLong)
+
+            if (ngcd == 1L)
+              Rational(SafeLong(num), SafeLong(lden) * r.d)
+            else
+              Rational(SafeLong(num) / ngcd, SafeLong(lden) * (r.d / ngcd))
+          }
         }
       case r: BigRational =>
         val dgcd: Long = spire.math.gcd(d, (r.d % d).toLong)

--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -513,6 +513,8 @@ private[math] object LongRationals extends Rationals[Long] {
     else unsafeBuild(-n, -d)
   }
 
+  private[this] def div(a:Long, b:Long): Long = a / b
+
   def unsafeBuild(n: Long, d: Long): Rational = {
     if (n == 0L) return Rational.zero
 
@@ -557,26 +559,35 @@ private[math] object LongRationals extends Rationals[Long] {
       case r: LongRationals.LongRational =>
         val dgcd: Long = spire.math.gcd(d, r.d)
         if (dgcd == 1L) {
-
-          val num = SafeLong(n) * r.d + SafeLong(r.n) * d
-          val den = SafeLong(d) * r.d
-          Rational(num, den)
+          Checked.tryOrReturn[Rational] {
+            build(n * r.d + r.n * d, d * r.d)
+          } {
+            Rational(SafeLong(n) * r.d + SafeLong(r.n) * d, SafeLong(d) * r.d)
+          }
 
         } else {
 
           val lden: Long = d / dgcd
           val rden: Long = r.d / dgcd
-          val num: SafeLong = SafeLong(n) * rden + SafeLong(r.n) * lden
+          Checked.tryOrReturn {
+            val num: Long = n * rden + r.n * lden
 
-          val ngcd: Long = num match {
-            case SafeLongLong(x) => spire.math.gcd(x, dgcd)
-            case SafeLongBigInt(x) => spire.math.gcd(dgcd, (x % dgcd).toLong)
+            val ngcd: Long = spire.math.gcd(num, dgcd)
+
+            if (ngcd == 1L)
+              build(num, lden * r.d)
+            else
+              build(div(num, ngcd), lden * div(r.d, ngcd))
+          } {
+            val num: BigInt = BigInt(n) * rden + BigInt(r.n) * lden
+
+            val ngcd: Long = spire.math.gcd(dgcd, (num % dgcd).toLong)
+
+            if (ngcd == 1L)
+              Rational(SafeLong(num), SafeLong(lden) * r.d)
+            else
+              Rational(SafeLong(num) / ngcd, SafeLong(lden) * (r.d / ngcd))
           }
-
-          if (ngcd == 1L)
-            Rational(num, SafeLong(lden) * r.d)
-          else
-            Rational(num / ngcd, SafeLong(lden) * (r.d / ngcd))
         }
       case r: BigRational =>
         val dgcd: Long = spire.math.gcd(d, (r.d % d).toLong)


### PR DESCRIPTION
This gives the + and - operation the same fastpath treatment as #378 did for * and / . However, the whole thing is a bit more involved in this case because there are more cases.

There is a lot of code duplication between + and -, but my initial attempt to factor this out was unsuccessful due to -Long.MinValue not being a Long. Gave me a good feeling that it was immediately caught by the tests.

One thing I am not sure about: I define a method `def div(a:Long, b:Long) = a / b` to perform an unchecked division from within the Checked block. But I am not sure if this is a good idea and e.g. if it would also work if it was `@inline def div(a:Long, b:Long) = a / b`. Maybe if I knew something about macros that would help...

The improvement is not quite as large as in the case of * and /, since we still have to find common fractions with sum and div. Even if we know that the result is a LongRational, we call LongRationals.build(n,d) instead of just LongRational(n,d). But it is still quite an improvement.

Here is the benchmark code and results for + (- is similar):

Code:
```scala
import ichi.bench.Thyme
import spire.math.Rational

object RationalSumBench extends App {
  val th = Thyme.warmed(warmth = Thyme.HowWarm.Bench, verbose = println)
  def bench(title:String, a:Rational, b:Rational) : Unit = {
    println(s"Rational sum benchmark $title ${a.getClass.getSimpleName}($a) ${b.getClass.getSimpleName}($b)")
    th.pbenchWarm(th.Warm(a + b), title = "+")
  }
  bench("Integer", Rational(12345), Rational(1, 67890))
  bench("LeftInteger", Rational(12345), Rational(67890,12347))
  bench("RightInteger", Rational(12345,67891), Rational(1, 67890))
  bench("Small", Rational(12345,67891), Rational(67890,12347))
  bench("Medium", Rational(Long.MaxValue,Int.MaxValue - 1), Rational(Int.MaxValue - 3, Long.MaxValue))
  bench("Large", Rational(Long.MaxValue) + Rational(1,3), Rational(Long.MaxValue) + Rational(1,5))
}
```

Results on this branch:
```
Rational sum benchmark Integer LongRational(12345) LongRational(1/67890)
Benchmark for + (140 calls in 2.472 s)
  Time:    64.92 ns   95% CI 62.18 ns - 67.66 ns   (n=19)
  Garbage: 0.8106 ns   (n=1 sweeps measured)
Rational sum benchmark LeftInteger LongRational(12345) LongRational(67890/12347)
Benchmark for + (140 calls in 2.542 s)
  Time:    67.82 ns   95% CI 64.90 ns - 70.75 ns   (n=19)
  Garbage: 0.2384 ns   (n=2 sweeps measured)
Rational sum benchmark RightInteger LongRational(12345/67891) LongRational(1/67890)
Benchmark for + (140 calls in 3.533 s)
  Time:    95.45 ns   95% CI 92.11 ns - 98.79 ns   (n=20)
  Garbage: 0.2384 ns   (n=2 sweeps measured)
Rational sum benchmark Small LongRational(12345/67891) LongRational(67890/12347)
Benchmark for + (140 calls in 3.327 s)
  Time:    89.46 ns   95% CI 86.07 ns - 92.86 ns   (n=20)
  Garbage: 0.2861 ns   (n=3 sweeps measured)
Rational sum benchmark Medium LongRational(1317624576693539401/306783378) LongRational(2147483644/9223372036854775807)
Benchmark for + (140 calls in 2.358 s)
  Time:    2.035 us   95% CI 1.939 us - 2.131 us   (n=20)
  Garbage: 24.41 ns   (n=5 sweeps measured)
Rational sum benchmark Large BigRational(27670116110564327422/3) BigRational(46116860184273879036/5)
Benchmark for + (140 calls in 2.554 s)
  Time:    536.5 ns   95% CI 511.3 ns - 561.7 ns   (n=20)
  Garbage: 4.959 ns   (n=8 sweeps measured)
```

Results from master:
```
Rational sum benchmark Integer LongRational(12345) LongRational(1/67890)
Benchmark for + (140 calls in 2.148 s)
  Time:    114.3 ns   95% CI 107.8 ns - 120.8 ns   (n=19)
  Garbage: 1.907 ns   (n=8 sweeps measured)
Rational sum benchmark LeftInteger LongRational(12345) LongRational(67890/12347)
Benchmark for + (60 calls in 1.925 s)
  Time:    119.2 ns   95% CI 113.1 ns - 125.2 ns   (n=20)
  Garbage: 1.335 ns   (n=6 sweeps measured)
Rational sum benchmark RightInteger LongRational(12345/67891) LongRational(1/67890)
Benchmark for + (140 calls in 2.454 s)
  Time:    132.9 ns   95% CI 127.3 ns - 138.5 ns   (n=20)
  Garbage: 1.526 ns   (n=7 sweeps measured)
Rational sum benchmark Small LongRational(12345/67891) LongRational(67890/12347)
Benchmark for + (60 calls in 2.008 s)
  Time:    125.7 ns   95% CI 121.0 ns - 130.4 ns   (n=19)
  Garbage: 1.335 ns   (n=6 sweeps measured)
Rational sum benchmark Medium LongRational(1317624576693539401/306783378) LongRational(2147483644/9223372036854775807)
Benchmark for + (140 calls in 2.301 s)
  Time:    1.996 us   95% CI 1.926 us - 2.066 us   (n=20)
  Garbage: 12.21 ns   (n=3 sweeps measured)
Rational sum benchmark Large BigRational(27670116110564327422/3) BigRational(46116860184273879036/5)
Benchmark for + (140 calls in 2.513 s)
  Time:    537.9 ns   95% CI 520.5 ns - 555.4 ns   (n=20)
  Garbage: 6.866 ns   (n=8 sweeps measured)
```