### PR TITLE
Fix bugs with ULong#toFloat and ULong#toDouble.

### DIFF
--- a/core/src/main/scala/spire/math/ULong.scala
+++ b/core/src/main/scala/spire/math/ULong.scala
@@ -31,7 +31,11 @@ object ULong extends ULongInstances {
     if (b == new ULong(0L)) a else gcd(b, a % b)
   }
 
-  private[spire] final val bigIntOffset: BigInt = BigInt(Long.MaxValue) + 1
+  private[spire] final val LimitAsDouble: Double =
+    spire.math.pow(2.0, 64)
+
+  private[spire] final val LimitAsBigInt: BigInt =
+    BigInt(1) << 64
 }
 
 class ULong(val signed: Long) extends AnyVal {
@@ -41,25 +45,24 @@ class ULong(val signed: Long) extends AnyVal {
   final def toInt: Int = signed.toInt
   final def toLong: Long = signed
 
-  final def toFloat: Float = if (signed < 0)
-    -(Long.MinValue.toFloat) - signed.toFloat
-  else
-    signed.toFloat
+  final def toFloat: Float = {
+    if (signed < 0) (ULong.LimitAsDouble + signed.toDouble).toFloat
+    else signed.toFloat
+  }
 
-  final def toDouble: Double = if (signed < 0)
-    -(Long.MinValue.toDouble) - signed.toDouble
-  else
-    signed.toDouble
+  // FIXME: it would be nice to write some "real" floating-point code
+  // to correctly find the nearest Double.
+  final def toDouble: Double =
+    toBigInt.toDouble
 
-  final def toBigInt: BigInt = if (signed >= 0)
-    BigInt(signed)
-  else
-    ULong.bigIntOffset + (signed & Long.MaxValue)
+  final def toBigInt: BigInt =
+    if (signed < 0) ULong.LimitAsBigInt + signed
+    else BigInt(signed)
 
-  override final def toString: String = if (this.signed >= 0L)
-    this.signed.toString
-  else
-    (-BigInt(Long.MinValue) * 2 + BigInt(this.signed)).toString // ugh, fixme
+  // FIXME: it would be nice to avoid converting to BigInt here
+  override final def toString: String =
+    if (signed >= 0L) signed.toString
+    else (ULong.LimitAsBigInt + signed).toString
 
   final def == (that: ULong): Boolean = this.signed == that.signed
   final def != (that: ULong): Boolean = this.signed != that.signed
@@ -76,7 +79,7 @@ class ULong(val signed: Long) extends AnyVal {
 
   @inline final def >= (that: ULong) = that <= this
   @inline final def > (that: ULong) = that < this
-  
+
   final def unary_- = ULong(this.signed)
 
   final def + (that: ULong) = ULong(this.signed + that.signed)

--- a/tests/src/test/scala/spire/math/UnsignedTest.scala
+++ b/tests/src/test/scala/spire/math/UnsignedTest.scala
@@ -103,6 +103,20 @@ class ULongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
       n.toString shouldBe n.toBigInt.toString
     }
   }
+
+  property("toFloat") {
+    forAll { (n: ULong) =>
+      n.toFloat shouldBe n.toBigInt.toFloat
+    }
+  }
+
+  property("toDouble") {
+    forAll { (n: ULong) =>
+      val d = new java.math.BigDecimal(n.toDouble).toPlainString
+      println(s"$n versus $d")
+      n.toDouble shouldBe n.toBigInt.toDouble
+    }
+  }
 }
 
 class UIntTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {


### PR DESCRIPTION
This commit adds tests in terms of BigInt to be sure that we are
generating a reasonable Float/Double value for ULong values.

Ideally we would write some custom floating point code to avoid
allocating BigInt/BigInteger instances when calling toFloat and
toDouble. However, this code fixes the immediate problem, and
only allocates those in cases where the ULong value is too large
to use code for Longs.

ULong#toString has a related issue -- it still constructs a
BigInt value.

Fixes #387