### PR TITLE
Fix bug in rational cooperative equality

### DIFF
--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -491,7 +491,7 @@ private[math] abstract class Rationals[@specialized(Long) A](implicit integral: 
       case that: Natural => isWhole && this == Rational(that.toBigInt)
       case that: Complex[_] => that == this
       case that: Quaternion[_] => that == this
-      case that => unifiedPrimitiveEquals(that)
+      case that => isValidLong && unifiedPrimitiveEquals(that)
     }
 
     override def toString: String = if (den == 1L)


### PR DESCRIPTION
unifiedPrimitiveEquals is only supposed to be called for types that "are
happy to be converted to a Long", so we need to sort out non-long rationals
before.

Fixes #406