### PR TITLE
Unify and fix Polynomial's equals and hashCode methods.

### DIFF
--- a/core/src/main/scala/spire/math/poly/PolyDense.scala
+++ b/core/src/main/scala/spire/math/poly/PolyDense.scala
@@ -36,6 +36,23 @@ class PolyDense[@spec(Double) C] private[spire] (val coeffs: Array[C])
     }
   }
 
+  def termsIterator: Iterator[Term[C]] =
+    new TermIterator
+
+  class TermIterator extends Iterator[Term[C]] {
+    private[this] var e: Int = 0
+    private[this] def findNext(): Unit =
+      while (e < coeffs.length && coeffs(e) == 0) e += 1
+    findNext()
+    def hasNext: Boolean = e < coeffs.length
+    def next: Term[C] = {
+      val term = Term[C](coeffs(e), e)
+      e += 1
+      findNext()
+      term
+    }
+  }
+
   def coeffsArray(implicit ring: Semiring[C]): Array[C] = coeffs
 
   def nth(n: Int)(implicit ring: Semiring[C]): C =

--- a/core/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/src/main/scala/spire/math/poly/PolySparse.scala
@@ -30,6 +30,23 @@ case class PolySparse[@spec(Double) C] private [spire] (val exp: Array[Int], val
 
   def degree: Int = if (isZero) 0 else exp(exp.length - 1)
 
+  def termsIterator: Iterator[Term[C]] =
+    new TermIterator
+
+  class TermIterator extends Iterator[Term[C]] {
+    private[this] var i: Int = 0
+    private[this] def findNext(): Unit =
+      while (i < exp.length && coeff(i) == 0) i += 1
+    findNext()
+    def hasNext: Boolean = i < exp.length
+    def next: Term[C] = {
+      val term = Term[C](coeff(i), exp(i))
+      i += 1
+      findNext()
+      term
+    }
+  }
+
   def coeffsArray(implicit ring: Semiring[C]): Array[C] = if (isZero) {
     new Array[C](0)
   } else {

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -115,12 +115,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     property(s"$name p /~ p = 1") {
       forAll { (p: P) =>
         if (!p.isZero) {
-          val x = p /~ p
-          if (x != one) {
-            println(s"x=$x x.degree=${x.degree} x.##=${x.##} x.terms=${x.termsIterator.toList}")
-            println(s"one=$one one.degree=${one.degree} one.##=${one.##} one.terms=${one.termsIterator.toList}")
-          }
-          x shouldBe one
+          p /~ p x shouldBe one
         }
       }
     }

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -113,7 +113,16 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     }
 
     property(s"$name p /~ p = 1") {
-      forAll { (p: P) => if (!p.isZero) p /~ p shouldBe one }
+      forAll { (p: P) =>
+        if (!p.isZero) {
+          val x = p /~ p
+          if (x != one) {
+            println(s"x=$x x.degree=${x.degree} x.##=${x.##} x.terms=${x.termsIterator.toList}")
+            println(s"one=$one one.degree=${one.degree} one.##=${one.##} one.terms=${one.termsIterator.toList}")
+          }
+          x shouldBe one
+        }
+      }
     }
 
     property(s"$name p % p = 0") {
@@ -177,13 +186,19 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
 
   property("sparse p = p") {
     forAll { (p: PolySparse[Rational]) =>
+      val d = p.toDense
       p shouldBe p
+      p shouldBe d
+      p.## shouldBe d.##
     }
   }
 
   property("dense p = p") {
     forAll { (p: PolyDense[Rational]) =>
+      val s = p.toSparse
       p shouldBe p
+      p shouldBe s
+      p.## shouldBe s.##
     }
   }
 
@@ -208,6 +223,14 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
   property("apply(p.toString) = p") {
     forAll { (p: PolyDense[Rational]) =>
       Polynomial(p.toString) shouldBe p
+    }
+  }
+
+  property("apply(r, 0) = r") {
+    forAll { (r: Rational) =>
+      val p = Polynomial(r, 0)
+      p shouldBe r
+      p.## shouldBe r.##
     }
   }
 

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -113,11 +113,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     }
 
     property(s"$name p /~ p = 1") {
-      forAll { (p: P) =>
-        if (!p.isZero) {
-          p /~ p x shouldBe one
-        }
-      }
+      forAll { (p: P) => if (!p.isZero) p /~ p shouldBe one }
     }
 
     property(s"$name p % p = 0") {


### PR DESCRIPTION
This commit adds a termsIterator method to Polynomial. This method
returns an Iterator[Term[C]] for all non-zero coefficients in the
polynomial, from smallest-exponent to largest. This iterator is
used to implement equality and hashCode in a standardized way that
works for dense and sparse polynomials.

The hashing formula used is essentially:

  val it: Iterator[Term[C]] = p.termsIterator
  val ns: Iterator[Int] = it.map(t => (0xfeed1257 * t.exp) ^ t.coeff.##)
  val hashCode: Int = ns.foldLeft(0)(_ ^ _)

One useful side-effect is that if the terms iterator is empty
(i.e. the polynomial is zero) the hash code is 0. Also, if p
consists of a single term whose exponent is zero, the overall
hashCode will be identical to the hash code of the term's
cofficient.

One gotcha with the termsIterator method is that it uses a
(_ == 0) test to filter out terms whose coefficient is zero.
This necessary in order to support universal equality, and is
documented in the method's ScalaDoc comment. We could choose
to make this method private to Spire if it is deemed to be
"too dangerous".

Fixes #410.

Review by @tixxit and @rklaehn.