### PR TITLE
Use unicode superscripts for exponents of polynomials

### DIFF
--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -106,16 +106,17 @@ object Polynomial extends PolynomialInstances {
     // do some pre-processing to remove whitespace/outer parens
     val t = s.trim
     val u = if (t.startsWith("(") && t.endsWith(")")) t.substring(1, t.length - 1) else t
+    val v = Term.removeSuperscript(u)
 
     // parse out the terms
-    val ts = parse(u, Nil)
+    val ts = parse(v, Nil)
 
     // make sure we have at most one variable
     val vs = ts.view.map(_.v).toSet.filter(_ != "")
     if (vs.size > 1) throw new IllegalArgumentException("only univariate polynomials supported")
 
     // we're done!
-    Polynomial(ts.map(t => (t.e, t.c)).toMap)
+    (Polynomial.zero[Rational] /: ts)((a, t) => a + Polynomial(t.c, t.e))
   }
 
   private final def split[@spec(Double) C: ClassTag](poly: Polynomial[C]): (Array[Int], Array[C]) = {

--- a/core/src/main/scala/spire/math/poly/Term.scala
+++ b/core/src/main/scala/spire/math/poly/Term.scala
@@ -46,7 +46,7 @@ case class Term[@spec(Float, Double) C](coeff: C, exp: Int) { lhs =>
     def expString = exp match {
       case 0 => ""
       case 1 => "x"
-      case _ => s"x^$exp"
+      case _ => "x" + exp.toString.map(superscript)
     }
 
     def simpleCoeff: Option[String] = coeff match {
@@ -82,4 +82,31 @@ object Term {
 
   private val IsZero = "0".r
   private val IsNegative = "-(.*)".r
+
+  private val digitToSuperscript = Array(
+    '0' -> '\u2070',
+    '1' -> '\u2071',
+    '2' -> '\u2072',
+    '3' -> '\u2073',
+    '4' -> '\u2074',
+    '5' -> '\u2075',
+    '6' -> '\u2076',
+    '7' -> '\u2077',
+    '8' -> '\u2078',
+    '9' -> '\u2079',
+    '-' -> '\u207B',
+    '1' -> '\u00B9',
+    '2' -> '\u00B2',
+    '3' -> '\u00B3'
+  )
+
+  private val superscriptRegex =
+    "[\\u2070\\u2071\\u2072\\u2073\\u2074\\u2075\\u2076\\u2077\\u2078\\u2079\\u207B\\u00B9\\u00B2\\u00B3]+".r
+
+  private[spire] def removeSuperscript(text: String): String =
+    superscriptRegex.replaceAllIn(text, "^" + _.group(0).map(removeSuperscript))
+
+  private val superscript : (Char => Char) = Map(digitToSuperscript:_*)
+
+  private val removeSuperscript : (Char => Char) = Map(digitToSuperscript.map(_.swap):_*)
 }

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -258,6 +258,7 @@ class PolynomialTest extends FunSuite {
     val p = Polynomial(Array(Term(r"1/2", 0), Term(r"1/4", 2), Term(r"2", 1)))
     assert(p.terms.toSet === Set(Term(r"1/2", 0), Term(r"1/4", 2), Term(r"2", 1)))
     assert(p === Polynomial("1/4x^2 + 2x + 1/2"))
+    assert(p === Polynomial("1/4x² + 2x + 1/2"))
     assert(p === Polynomial(Map(2 -> r"1/4", 1 -> r"2", 0 -> r"1/2")))
   }
 

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -259,6 +259,7 @@ class PolynomialTest extends FunSuite {
     assert(p.terms.toSet === Set(Term(r"1/2", 0), Term(r"1/4", 2), Term(r"2", 1)))
     assert(p === Polynomial("1/4x^2 + 2x + 1/2"))
     assert(p === Polynomial("1/4x² + 2x + 1/2"))
+    assert(p === Polynomial("1/4x² + x + x + 1/2"))
     assert(p === Polynomial(Map(2 -> r"1/4", 1 -> r"2", 0 -> r"1/2")))
   }
 


### PR DESCRIPTION
Also allow unicode superscripts when parsing polynomials. The ascii version `x^2` is still supported.

- I put the unicode support code in poly.Term and made it private. Is there a better place to put it?

- I made a small additional change to parse. Before, `poly"(x² + x² + 1)"` would give `(x² + 1)` (everything but the last coefficient for each exponent is ignored). Now the terms are added, so `poly"(x² + x² + 1)"` gives `(2x² + 1)`. The downside is that parsing is slightly slower for large polynomials, but I think correctness trumps speed.