### PR TITLE
explicit return type annotation for Opt#toRight, toLeft

### DIFF
--- a/core/src/main/scala/spire/util/Opt.scala
+++ b/core/src/main/scala/spire/util/Opt.scala
@@ -63,9 +63,9 @@ class Opt[+A](val ref: A) extends OptVersions.Base {
 
   def iterator: Iterator[A] = if (ref == null) collection.Iterator.empty else collection.Iterator.single(ref)
 
-  def toRight[X](left: => X) =
+  def toRight[X](left: => X): Either[X, A] =
     if (ref == null) Left(left) else Right(ref)
 
-  def toLeft[X](right: => X) =
+  def toLeft[X](right: => X): Either[A, X] =
     if (ref == null) Right(right) else Left(ref)
 }


### PR DESCRIPTION
```
scala> spire.util.Opt("a").toRight(1)
res0: Product with Serializable with scala.util.Either[Int,String] = Right(a)
```