### PR TITLE
Use stricter scalac options with Spire.

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
@@ -25,7 +25,7 @@ class AnyValAddBenchmarks extends MyBenchmark {
   var floats:Array[Float] = null
   var doubles:Array[Double] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     bytes = init(size)(nextInt.toByte)
     shorts = init(size)(nextInt.toShort)
     ints = init(size)(nextInt)

--- a/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
@@ -24,7 +24,7 @@ class AnyValSubtractBenchmarks extends MyBenchmark {
   var floats:Array[Float] = null
   var doubles:Array[Double] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     bytes = init(size)(nextInt.toByte)
     shorts = init(size)(nextInt.toShort)
     ints = init(size)(nextInt)

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -27,7 +27,7 @@ class ArrayOrderBenchmarks extends MyBenchmark {
   var e: Array[Int] = null
   var f: Array[Int] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     val size = spire.math.pow(2, pow).toInt
 
     a = init(size)(nextInt)

--- a/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
@@ -22,7 +22,7 @@ class CForBenchmarks extends MyBenchmark {
 
   var arr: Array[Long] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     arr = init(size)(scala.math.abs(nextInt - 1).toInt + 1)
   }
 
@@ -54,7 +54,7 @@ class CForBenchmarks extends MyBenchmark {
   def timeForIntArrayMultiply(reps:Int) = run(reps)(doForGcd)
   def timeCForIntArrayMultiply(reps:Int) = run(reps)(doCForIntArrayMultiply)
 
-  def doWhileOr {
+  def doWhileOr(): Unit = {
     var t: Long = 0L
     var i: Int = 0
     val len = size - 1
@@ -69,7 +69,7 @@ class CForBenchmarks extends MyBenchmark {
     while (i < len3) { t = t ^ or(arr(i + 1), arr(i + 2)); i += 1 }
   }
 
-  def doWhileMin {
+  def doWhileMin(): Unit = {
     var t: Long = 0L
     var i: Int = 0
     val len = size - 1
@@ -84,7 +84,7 @@ class CForBenchmarks extends MyBenchmark {
     while (i < len3) { t = t ^ min(arr(i + 1), arr(i + 2)); i += 1 }
   }
 
-  def doWhileGcd {
+  def doWhileGcd(): Unit = {
     var t: Long = 0L
     var i: Int = 0
     val len = size - 1
@@ -99,84 +99,84 @@ class CForBenchmarks extends MyBenchmark {
     while (i < len3) { t = t ^ gcd(arr(i + 1), arr(i + 2)); i += 1 }
   }
 
-  def doWhileIntArrayMultiply {
+  def doWhileIntArrayMultiply(): Unit = {
     val arr2 = arr.clone
     val len = size - 1
     var i = 0
     while (i < len) {
       val value = arr2(i)
-      arr2(i) = value * 2 
+      arr2(i) = value * 2
       i = i + 1
     }
   }
 
-  def doTailrecOr {
+  def doTailrecOr(): Unit = {
     var t: Long = 0L
     val len = size - 1
-    @tailrec def loop1(i: Int) {
+    @tailrec def loop1(i: Int): Unit = {
       if (i < len) { t = t ^ or(arr(i), arr(i + 1)); loop1(i + 1) }
     }
     loop1(0)
 
     val len2 = size / 2
-    @tailrec def loop2(i: Int) {
+    @tailrec def loop2(i: Int): Unit = {
       if (i < len2) { t = t ^ or(arr(i + 3), arr(i + 2)); loop2(i + 1) }
     }
     loop2(0)
 
     val len3 = size / 3
-    @tailrec def loop3(i: Int) {
+    @tailrec def loop3(i: Int): Unit = {
       if (i < len2) { t = t ^ or(arr(i + 1), arr(i + 2)); loop3(i + 1) }
     }
     loop3(0)
   }
 
-  def doTailrecMin {
+  def doTailrecMin(): Unit = {
     var t: Long = 0L
     val len = size - 1
-    @tailrec def loop1(i: Int) {
+    @tailrec def loop1(i: Int): Unit = {
       if (i < len) { t = t ^ min(arr(i), arr(i + 1)); loop1(i + 1) }
     }
     loop1(0)
 
     val len2 = size / 2
-    @tailrec def loop2(i: Int) {
+    @tailrec def loop2(i: Int): Unit = {
       if (i < len2) { t = t ^ min(arr(i + 3), arr(i + 2)); loop2(i + 1) }
     }
     loop2(0)
 
     val len3 = size / 3
-    @tailrec def loop3(i: Int) {
+    @tailrec def loop3(i: Int): Unit = {
       if (i < len2) { t = t ^ min(arr(i + 1), arr(i + 2)); loop3(i + 1) }
     }
     loop3(0)
   }
 
-  def doTailrecGcd {
+  def doTailrecGcd(): Unit = {
     var t: Long = 0L
     val len = size - 1
-    @tailrec def loop1(i: Int) {
+    @tailrec def loop1(i: Int): Unit = {
       if (i < len) { t = t ^ gcd(arr(i), arr(i + 1)); loop1(i + 1) }
     }
     loop1(0)
 
     val len2 = size / 2
-    @tailrec def loop2(i: Int) {
+    @tailrec def loop2(i: Int): Unit = {
       if (i < len2) { t = t ^ gcd(arr(i + 3), arr(i + 2)); loop2(i + 1) }
     }
     loop2(0)
 
     val len3 = size / 3
-    @tailrec def loop3(i: Int) {
+    @tailrec def loop3(i: Int): Unit = {
       if (i < len2) { t = t ^ gcd(arr(i + 1), arr(i + 2)); loop3(i + 1) }
     }
     loop3(0)
   }
 
-  def doTailrecIntArrayMultiply {
+  def doTailrecIntArrayMultiply(): Unit = {
     val arr2 = arr.clone
     val len = size
-    @tailrec def loop(i: Int) {
+    @tailrec def loop(i: Int): Unit = {
       if (i < len) {
         val value = arr2(i)
         arr2(i) = value * 2
@@ -186,8 +186,8 @@ class CForBenchmarks extends MyBenchmark {
     loop(0)
   }
 
-  
-  def doForeachOr {
+
+  def doForeachOr(): Unit = {
     var t: Long = 0L
     val len = size - 1
     (0 until len).foreach { i => t = t ^ or(arr(i), arr(i + 1)) }
@@ -199,7 +199,7 @@ class CForBenchmarks extends MyBenchmark {
     (0 until len3).foreach { i => t = t ^ or(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForeachMin {
+  def doForeachMin(): Unit = {
     var t: Long = 0L
     val len = size - 1
     (0 until len).foreach { i => t = t ^ min(arr(i), arr(i + 1)) }
@@ -211,7 +211,7 @@ class CForBenchmarks extends MyBenchmark {
     (0 until len3).foreach { i => t = t ^ min(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForeachGcd {
+  def doForeachGcd(): Unit = {
     var t: Long = 0L
     val len = size - 1
     (0 until len).foreach { i => t = t ^ gcd(arr(i), arr(i + 1)) }
@@ -223,7 +223,7 @@ class CForBenchmarks extends MyBenchmark {
     (0 until len3).foreach { i => t = t ^ gcd(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForeachIntArrayMultiply {
+  def doForeachIntArrayMultiply(): Unit = {
     val arr2 = arr.clone
     val len = size
     (0 until len).foreach { i =>
@@ -232,7 +232,7 @@ class CForBenchmarks extends MyBenchmark {
     }
   }
 
-  def doForOr {
+  def doForOr(): Unit = {
     var t: Long = 0L
     val len = size - 1
     for (i <- 0 until len) { t = t ^ or(arr(i), arr(i + 1)) }
@@ -244,7 +244,7 @@ class CForBenchmarks extends MyBenchmark {
     for (i <- 0 until len3) { t = t ^ or(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForMin {
+  def doForMin(): Unit = {
     var t: Long = 0L
     val len = size - 1
     for (i <- 0 until len) { t = t ^ min(arr(i), arr(i + 1)) }
@@ -256,7 +256,7 @@ class CForBenchmarks extends MyBenchmark {
     for (i <- 0 until len3) { t = t ^ min(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForGcd {
+  def doForGcd(): Unit = {
     var t: Long = 0L
     val len = size - 1
     for (i <- 0 until len) { t = t ^ gcd(arr(i), arr(i + 1)) }
@@ -268,7 +268,7 @@ class CForBenchmarks extends MyBenchmark {
     for (i <- 0 until len3) { t = t ^ gcd(arr(i + 1), arr(i + 2)) }
   }
 
-  def doForIntArrayMultiply {
+  def doForIntArrayMultiply(): Unit = {
     val arr2 = arr.clone
     val len = size
     for (i <- 0 until len) {
@@ -277,7 +277,7 @@ class CForBenchmarks extends MyBenchmark {
     }
   }
 
-  def doCForOr {
+  def doCForOr(): Unit = {
     var t: Long = 0L
     val len = size - 1
     cfor(0)(_ < len, _ + 1) { i => t = t ^ or(arr(i), arr(i + 1)) }
@@ -289,7 +289,7 @@ class CForBenchmarks extends MyBenchmark {
     cfor(0)(_ < len3, _ + 1) { i => t = t ^ or(arr(i + 1), arr(i + 2)) }
   }
 
-  def doCForMin {
+  def doCForMin(): Unit = {
     var t: Long = 0L
     val len = size - 1
     cfor(0)(_ < len, _ + 1) { i => t = t ^ min(arr(i), arr(i + 1)) }
@@ -301,7 +301,7 @@ class CForBenchmarks extends MyBenchmark {
     cfor(0)(_ < len3, _ + 1) { i => t = t ^ min(arr(i + 1), arr(i + 2)) }
   }
 
-  def doCForGcd {
+  def doCForGcd(): Unit = {
     var t: Long = 0L
     val len = size - 1
     cfor(0)(_ < len, _ + 1) { i => t = t ^ gcd(arr(i), arr(i + 1)) }
@@ -313,7 +313,7 @@ class CForBenchmarks extends MyBenchmark {
     cfor(0)(_ < len3, _ + 1) { i => t = t ^ gcd(arr(i + 1), arr(i + 2)) }
   }
 
-  def doCForIntArrayMultiply {
+  def doCForIntArrayMultiply(): Unit = {
     val arr2 = arr.clone
     val len = size
     cfor(0)(_ < len, _ + 1) { 

--- a/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
@@ -23,7 +23,7 @@ class ComplexAddBenchmarks extends MyBenchmark {
   var longs:Array[Long] = null
   var fcs:Array[FloatComplex] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     complexes = init(size)(Complex(nextFloat(), nextFloat()))
     longs = init(size)(FastComplex(nextFloat(), nextFloat()))
     fcs = init(size)(FloatComplex(nextFloat(), nextFloat()))

--- a/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
@@ -57,7 +57,7 @@ class FpFilterBenchmark extends MyBenchmark {
 
   var points: Array[Point2] = _
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     points = init(size)(Point2(Random.nextDouble, Random.nextDouble))
   }
 

--- a/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
@@ -24,7 +24,7 @@ class GcdBenchmarks extends MyBenchmark {
   var longs: Array[Long] = null
   var bigs: Array[BigInteger] = null
 
-  override def setUp() {
+  override def setUp(): Unit = {
     longs = init(200000)(nextLong)
     bigs = init(200000)(new BigInteger(nextLong.toString))
   }

--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -80,7 +80,7 @@ class MapSemigroupBenchmarks extends MyBenchmark with BenchmarkData {
     arr
   }
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     if (mapType == "random") {
       maps = genMaps { i => (nextInt, nextInt) }
     } else if (mapType == "sparse") {

--- a/benchmark/src/main/scala/spire/benchmark/MaybeAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MaybeAddBenchmarks.scala
@@ -19,7 +19,7 @@ class MaybeAddBenchmarks extends MyBenchmark {
 
   var maybeDoubles:Array[MaybeDouble] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     maybeDoubles = init(size)(MaybeDouble(nextDouble))
   }
 

--- a/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
@@ -24,7 +24,7 @@ class Mo5Benchmarks extends MyBenchmark {
 
   val len = 5000000
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     as = init(len)(nextInt)
   }
 

--- a/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
@@ -35,7 +35,7 @@ class NaturalBenchmarks extends MyBenchmark {
   var bigints: Array[BigInt] = _
   var safes: Array[SafeLong] = _
 
-  override def setUp() {
+  override def setUp(): Unit = {
     size = Math.pow(2, pow).toInt
     bigints = init(size)(BigInt(bits, Random))
     nats = bigints.map(Natural(_))

--- a/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
@@ -28,7 +28,7 @@ class PolynomialBenchmarks extends MyBenchmark {
   var spireSparseDoublePolys: Array[Polynomial[Double]] = null
   var commonsDoublePolys: Array[PolynomialFunction] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
 
     val coeffs: Array[Array[Rational]] =
       init(100)(init(size)(arbitraryRational))

--- a/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
@@ -24,7 +24,7 @@ class PowBenchmarks extends MyBenchmark {
   var longs: Array[Long] = null
   var ints: Array[Int] = null
 
-  override def setUp() {
+  override def setUp(): Unit = {
     ints = init(200000)(nextInt)
     longs = init(200000)(nextLong)
   }

--- a/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
@@ -40,7 +40,7 @@ class RandomBenchmarks extends MyBenchmark with BenchmarkData {
   val burtle2Rng = spire.random.rng.BurtleRot2.fromSeed(ints4)
   val burtle3Rng = spire.random.rng.BurtleRot3.fromSeed(ints4)
   val cmwc5Rng = spire.random.rng.Cmwc5.fromSeed(longs5)
-  val well512aRng = spire.random.rng.Well512a.fromSeed(ints16, 0)
+  val well512aRng = spire.random.rng.Well512a.fromSeed((ints16, 0))
   val well1024aRng = spire.random.rng.Well1024a.fromArray(ints16)
   val well19937aRng = spire.random.rng.Well19937a.fromArray(ints16)
   val well19937cRng = spire.random.rng.Well19937c.fromArray(ints16)

--- a/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
@@ -28,7 +28,7 @@ class RatComparisonBenchmarks extends MyBenchmark {
   var nums:Array[Int] = null
   var denoms:Array[Int] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     nums = init(size)(nextInt)
     denoms = init(size)(nextInt)
 

--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -28,7 +28,7 @@ class RationalBenchmarks extends MyBenchmark with BenchmarkData {
   private var bigRats: Array[BigIntRational] = _
   private var longRats: Array[LongRational] = _
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     rats = init(size)(Rational(BigInt(bits, Random), BigInt(bits, Random) + 1))
     bigRats = init(size)(BigIntRational(BigInt(bits, Random), BigInt(bits, Random) + 1))
     if (bits <= 32) {

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -20,7 +20,7 @@ class RexBenchmarks extends MyBenchmark with BenchmarkData {
   var fs: Array[Float] = null
   var ds: Array[Double] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     val size = spire.math.pow(2, pow).toInt
     fs = mkarray(size, "random")(nextGaussian.toFloat)
     ds = mkarray(size, "random")(nextGaussian)

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -29,7 +29,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
   var bs: Array[Int] = null
   var cs: Array[Int] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     size = spire.math.pow(2, pow).toInt
     //as = init(size)(scala.math.abs(nextInt).toInt % 1000 + 1)
     //bs = init(size)(scala.math.abs(nextInt).toInt % 1000 + 1)
@@ -61,20 +61,20 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
   /**
    * Pairwise addition between arrays
    */
-  def doPairwiseDirect(as: Array[Int], bs: Array[Int], cs: Array[Int]) {
+  def doPairwiseDirect(as: Array[Int], bs: Array[Int], cs: Array[Int]): Unit = {
     var i = 0
     val len = as.length
     while (i < len) { cs(i) = as(i) + bs(i); i += 1 }
   }
 
-  def doPairwiseGeneric[A:ScalaN](as:Array[A], bs: Array[A], cs: Array[A]) {
+  def doPairwiseGeneric[A:ScalaN](as:Array[A], bs: Array[A], cs: Array[A]): Unit = {
     import ScalaN.Implicits._
     var i = 0
     val len = as.length
     while (i < len) { cs(i) = as(i) + bs(i); i += 1 }
   }
 
-  def doPairwiseSpire[@spec(Int) A:Ring](as:Array[A], bs: Array[A], cs: Array[A]) {
+  def doPairwiseSpire[@spec(Int) A:Ring](as:Array[A], bs: Array[A], cs: Array[A]): Unit = {
     import spire.implicits._
     var i = 0
     val len = as.length

--- a/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
@@ -55,7 +55,7 @@ class SelectionBenchmarks extends MyBenchmark {
     if (layout == "sorted") data else data.reverse
   }
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     val size = spire.math.pow(2, pow).toInt
 
     is = if (typ == "int") mkarray(size, layout)(nextInt) else null

--- a/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
@@ -13,7 +13,7 @@ object SieveBenchmark {
     a
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val defaults: List[Long] = (
       1L ::
       10L ::

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -62,7 +62,7 @@ class SortingBenchmarks extends MyBenchmark with BenchmarkData {
   var cs: Array[Complex[Double]] = null
   var cs2: Array[FakeComplex[Double]] = null
 
-  override protected def setUp() {
+  override protected def setUp(): Unit = {
     val size = spire.math.pow(2, pow).toInt
 
     def complexToFake(c: Complex[Double]) = new FakeComplex(c.real, c.imag)

--- a/core/src/main/scala/spire/math/Searching.scala
+++ b/core/src/main/scala/spire/math/Searching.scala
@@ -57,7 +57,7 @@ object Searching {
     var candidates = ArrayBuffer.empty[A]
     // removes the j-th element of candidates by swapping the last
     // element with it
-    def fastRemove(j: Int) {
+    def fastRemove(j: Int): Unit = {
       if (j < candidates.length - 1)
         candidates(j) = candidates(candidates.length - 1)
       candidates.remove(candidates.length - 1)
@@ -66,7 +66,7 @@ object Searching {
       // if we prove that a is not minimal, it should not be added to candidates
       var aIsNotMinimal = false
       // compare a against each candidate, starting from the last
-      @tailrec def inspect(i: Int) {
+      @tailrec def inspect(i: Int): Unit = {
         if (i >= 0) {
           val c = a.partialCompare(candidates(i))
           // if a <= candidates(i), this candidate can be removed

--- a/core/src/main/scala/spire/math/Selection.scala
+++ b/core/src/main/scala/spire/math/Selection.scala
@@ -26,12 +26,12 @@ trait SelectLike extends Any with Select {
    * This is an in-place algorithm and is not stable and it WILL mess up the
    * order of equal elements.
    */
-  final def select[@spec A: Order: ClassTag](data: Array[A], k: Int) {
+  final def select[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit = {
     select(data, 0, data.length, 1, k)
   }
 
   // Copy of InsertSort.sort, but with a stride.
-  final def sort[@spec A](data: Array[A], left: Int, right: Int, stride: Int)(implicit o: Order[A]) {
+  final def sort[@spec A](data: Array[A], left: Int, right: Int, stride: Int)(implicit o: Order[A]): Unit = {
     var i = left
     while (i < right) {
       val item = data(i)
@@ -46,7 +46,7 @@ trait SelectLike extends Any with Select {
   }
 
   @tailrec
-  protected final def select[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int, k: Int) {
+  protected final def select[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int, k: Int): Unit = {
     val length = (right - left + stride - 1) / stride
     if (length < 10) {
       sort(data, left, right, stride)
@@ -110,7 +110,7 @@ trait SelectLike extends Any with Select {
 }
 
 trait MutatingMedianOf5 {
-  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]) {
+  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
     var i0 = offset
     var i1 = offset + 1 * stride
     var i2 = offset + 2 * stride
@@ -152,7 +152,7 @@ trait HighBranchingMedianOf5 {
 
   // Benchmarks show that this is slightly faster than the version above.
 
-  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]) {
+  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
     val ai1 = data(offset)
     val ai2 = data(offset + stride)
     val ai3 = data(offset + 2 * stride)

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -22,8 +22,7 @@ object InsertionSort extends Sort {
   final def sort[@spec A:Order:ClassTag](data:Array[A]) =
     sort(data, 0, data.length)
 
-  final def sort[@spec A](data:Array[A], start:Int, end:Int)
-    (implicit o:Order[A], ct:ClassTag[A]) {
+  final def sort[@spec A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
 
     var i = start + 1
     while (i < end) {
@@ -49,7 +48,7 @@ object MergeSort extends Sort {
   @inline final def startWidth = 8
   @inline final def startStep = 16
 
-  final def sort[@spec A:Order:ClassTag](data:Array[A]) {
+  final def sort[@spec A:Order:ClassTag](data:Array[A]): Unit = {
     val len = data.length
 
     if (len <= startStep) return InsertionSort.sort(data)
@@ -90,9 +89,7 @@ object MergeSort extends Sort {
    * left and right ranges of the input to merge, as well as the area of the
    * ouput to write to.
    */
-  @inline final def merge[@spec A]
-    (in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)
-    (implicit o:Order[A]) {
+  @inline final def merge[@spec A](in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)(implicit o:Order[A]): Unit = {
 
     var ii = start
     var jj = mid
@@ -118,9 +115,7 @@ object QuickSort {
 
   final def sort[@spec A:Order:ClassTag](data:Array[A]) = qsort(data, 0, data.length - 1)
 
-  final def qsort[@spec A]
-    (data:Array[A], left: Int, right: Int)
-    (implicit o:Order[A], ct:ClassTag[A]) {
+  final def qsort[@spec A](data:Array[A], left: Int, right: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
 
     if (right - left < limit) return InsertionSort.sort(data, left, right + 1)
 
@@ -130,9 +125,7 @@ object QuickSort {
     qsort(data, next + 1, right)
   }
 
-  final def partition[@spec A]
-    (data:Array[A], left:Int, right:Int, pivot:Int)
-    (implicit o:Order[A], ct:ClassTag[A]): Int = {
+  final def partition[@spec A](data:Array[A], left:Int, right:Int, pivot:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
 
     val value = data(pivot)
 

--- a/core/src/main/scala/spire/math/prime/BitSet.scala
+++ b/core/src/main/scala/spire/math/prime/BitSet.scala
@@ -20,12 +20,12 @@ object BitSet {
 
 case class BitSet(length: Int, array: Array[Int]) {
 
-  def +=(n: Int) {
+  def +=(n: Int): Unit = {
     val q = n >>> 5
     array(q) = array(q) | (1 << (n & 31))
   }
 
-  def -=(n: Int) {
+  def -=(n: Int): Unit = {
     val q = n >>> 5
     array(q) = array(q) & ~(1 << (n & 31))
   }

--- a/core/src/main/scala/spire/math/prime/SieveSegment.scala
+++ b/core/src/main/scala/spire/math/prime/SieveSegment.scala
@@ -80,7 +80,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     SafeLong(-1L) // fail
   }
 
-  def init(fastq: FastFactors, slowq: FactorHeap) {
+  def init(fastq: FastFactors, slowq: FactorHeap): Unit = {
     initMod30()
     if (start == 0) {
       initFirst(fastq, slowq)
@@ -92,7 +92,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     }
   }
 
-  def initMod30() {
+  def initMod30(): Unit = {
     val arr = primes.array
     assert(arr.length % 15 == 0)
     val limit = arr.length
@@ -106,7 +106,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     }
   }
 
-  private def initFromArray(fastq: FastFactors) {
+  private def initFromArray(fastq: FastFactors): Unit = {
     val arr = fastq.arr
     var i = 0
 
@@ -131,7 +131,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     }
   }
 
-  @tailrec private def initFromQueue(limit: SafeLong, q: FactorHeap) {
+  @tailrec private def initFromQueue(limit: SafeLong, q: FactorHeap): Unit = {
     if (q.isEmpty) return ()
 
     val factor = q.dequeue
@@ -157,7 +157,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     }
   }
 
-  def initFirst(fastq: FastFactors, slowq: FactorHeap) {
+  def initFirst(fastq: FastFactors, slowq: FactorHeap): Unit = {
     var p: Int = 1
     val len = primes.length
     val buf = ArrayBuffer.empty[FastFactor]
@@ -184,7 +184,7 @@ case class SieveSegment(start: SafeLong, primes: BitSet, cutoff: SafeLong) {
     fastq.arr = buf.toArray
   }
 
-  def initRest(slowq: FactorHeap) {
+  def initRest(slowq: FactorHeap): Unit = {
     if (start >= cutoff) return ()
 
     val len: Long = if (start + primes.length >= cutoff)

--- a/core/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/src/main/scala/spire/math/prime/Siever.scala
@@ -97,7 +97,7 @@ case class Siever(chunkSize: Int, cutoff: SafeLong) {
     return SafeLong(0) // impossible
   }
 
-  private def initNextSieve() {
+  private def initNextSieve(): Unit = {
     start += chunkSize
     limit += chunkSize
     val csq = cutoff ** 2

--- a/core/src/main/scala/spire/random/Dist.scala
+++ b/core/src/main/scala/spire/random/Dist.scala
@@ -72,7 +72,7 @@ trait Dist[@spec A] extends Any { self =>
     }
   }
 
-  def repeat[CC[A] <: Seq[A]](n: Int)(implicit cbf: CanBuildFrom[Nothing, A, CC[A]]): Dist[CC[A]] =
+  def repeat[CC[X] <: Seq[X]](n: Int)(implicit cbf: CanBuildFrom[Nothing, A, CC[A]]): Dist[CC[A]] =
     new Dist[CC[A]] {
       def apply(gen: Generator): CC[A] = {
         val builder = cbf()
@@ -110,7 +110,7 @@ trait Dist[@spec A] extends Any { self =>
 
   import scala.collection.generic.CanBuildFrom
 
-  def sample[CC[A] <: Iterable[A]](n: Int)(implicit gen: Generator, cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
+  def sample[CC[X] <: Iterable[X]](n: Int)(implicit gen: Generator, cbf: CanBuildFrom[CC[A], A, CC[A]]): CC[A] = {
     val b = cbf()
     b.sizeHint(n)
     var i = 0
@@ -149,7 +149,7 @@ trait Dist[@spec A] extends Any { self =>
 }
 
 final class DistIterator[A](next: Dist[A], gen: Generator) extends Iterator[A] {
-  final def hasNext(): Boolean = true
+  final def hasNext: Boolean = true
   final def next(): A = next(gen)
 }
 

--- a/core/src/main/scala/spire/random/Generator.scala
+++ b/core/src/main/scala/spire/random/Generator.scala
@@ -199,7 +199,7 @@ abstract class Generator {
   /**
    * Fill an array with random Longs.
    */
-  def fillLongs(arr: Array[Long]) {
+  def fillLongs(arr: Array[Long]): Unit = {
     var i = 0
     val len = arr.length
     while (i < len) {
@@ -220,7 +220,7 @@ abstract class Generator {
   /**
    * Fill an array with random Ints.
    */
-  def fillInts(arr: Array[Int]) {
+  def fillInts(arr: Array[Int]): Unit = {
     var i = 0
     val len = arr.length
     while (i < len) {
@@ -241,7 +241,7 @@ abstract class Generator {
   /**
    * Fill an array with random Shorts.
    */
-  def fillShorts(arr: Array[Short]) {
+  def fillShorts(arr: Array[Short]): Unit = {
     var i = 0
     val len = arr.length
     val llen = len & 0xfffffffe
@@ -267,7 +267,7 @@ abstract class Generator {
   /**
    * Fill an array with random Bytes.
    */
-  def fillBytes(arr: Array[Byte]) {
+  def fillBytes(arr: Array[Byte]): Unit = {
     var i = 0
     val len = arr.length
     val llen = len & 0xfffffffc
@@ -302,7 +302,7 @@ abstract class Generator {
   /**
    * Fill an Array[A] using the given Dist[A] instance.
    */
-  def fillArray[@spec A: Dist](arr: Array[A]) {
+  def fillArray[@spec A: Dist](arr: Array[A]): Unit = {
     var i = 0
     val len = arr.length
     while (i < len) {
@@ -365,7 +365,7 @@ abstract class Generator {
     chosen
   }
 
-  def shuffle[@spec A](as: Array[A])(implicit gen: Generator) {
+  def shuffle[@spec A](as: Array[A])(implicit gen: Generator): Unit = {
     var i: Int = as.length - 1
     while (i > 0) {
       val n: Int = gen.nextInt(i)
@@ -400,11 +400,11 @@ abstract class Generator {
   def fillGaussians(arr: Array[Double]): Unit =
     fillGaussians(arr, 0.0, 1.0)
 
-  def fillGaussians(arr: Array[Double], mean: Double, stddev: Double) {
+  def fillGaussians(arr: Array[Double], mean: Double, stddev: Double): Unit = {
     var i = 0
     val len = arr.length & 0xfffffffe
 
-    @tailrec def loop(i: Int, x: Double, y: Double) {
+    @tailrec def loop(i: Int, x: Double, y: Double): Unit = {
       val s = x * x + y * y
       if (s >= 1.0 || s == 0.0) {
         loop(i, nextDouble() * 2 - 1, nextDouble() * 2 - 1)

--- a/core/src/main/scala/spire/random/rng/BurtleRot32.scala
+++ b/core/src/main/scala/spire/random/rng/BurtleRot32.scala
@@ -32,7 +32,7 @@ abstract class BurtleRot32(_a: Int, _b: Int, _c: Int, _d: Int) extends IntBasedG
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < 16) Arrays.copyOf(bytes, 16) else bytes
     val bb = ByteBuffer.wrap(bs)
     a = bb.getInt()
@@ -72,7 +72,7 @@ abstract class BurtleCompanion[G <: BurtleRot32] extends GeneratorCompanion[G, A
  * from [[http://burtleburtle.net/bob/rand/]]
  */
 final class BurtleRot2(_a: Int, _b: Int, _c: Int, _d: Int) extends BurtleRot32(_a, _b, _c, _d) {
-  protected def advance() {
+  protected def advance(): Unit = {
     val e = a - rotateLeft(b,27)
     a = b ^ rotateLeft(c,17)
     b = c + d
@@ -94,7 +94,7 @@ object BurtleRot2 extends BurtleCompanion[BurtleRot2] {
  * Algorithm from [[http://burtleburtle.net/bob/rand/]]
  */
 final class BurtleRot3(_a: Int, _b: Int, _c: Int, _d: Int) extends BurtleRot32(_a, _b, _c, _d) {
-  protected def advance() {
+  protected def advance(): Unit = {
     val e = a - rotateLeft(b, 23)
     a = b ^ rotateLeft(c, 16)
     b = c + rotateLeft(d, 11)

--- a/core/src/main/scala/spire/random/rng/Cmwc5.scala
+++ b/core/src/main/scala/spire/random/rng/Cmwc5.scala
@@ -23,7 +23,7 @@ final class Cmwc5(_x: Long, _y: Long, _z: Long, _w: Long, _v: Long) extends Long
     longs
   }
 
-  def setSeed(longs: Array[Long]) {
+  def setSeed(longs: Array[Long]): Unit = {
     x = longs(0)
     y = longs(1)
     z = longs(2)
@@ -42,7 +42,7 @@ final class Cmwc5(_x: Long, _y: Long, _z: Long, _w: Long, _v: Long) extends Long
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < 40) Arrays.copyOf(bytes, 40) else bytes
     val bb = ByteBuffer.wrap(bs)
     x = bb.getLong()

--- a/core/src/main/scala/spire/random/rng/DevPrng.scala
+++ b/core/src/main/scala/spire/random/rng/DevPrng.scala
@@ -43,7 +43,7 @@ class CycledFile(f: File) extends Generator { self =>
       throw new IllegalArgumentException("%s contains less than 8 bytes" format f)
   }
 
-  def reinit() {
+  def reinit(): Unit = {
     if (dis != null) dis.close()
     dis = new DataInputStream(new FileInputStream(f))
   }

--- a/core/src/main/scala/spire/random/rng/Marsaglia32a6.scala
+++ b/core/src/main/scala/spire/random/rng/Marsaglia32a6.scala
@@ -32,7 +32,7 @@ class Marsaglia32a6(_x: Int, _y: Int, _z: Int, _w: Int, _v: Int, _d: Int) extend
     ints
   }
 
-  def setSeed(seed: Array[Int]) {
+  def setSeed(seed: Array[Int]): Unit = {
     val zs = if (seed.length < 6) Arrays.copyOf(seed, 6) else seed
     x = zs(0)
     y = zs(0)
@@ -54,7 +54,7 @@ class Marsaglia32a6(_x: Int, _y: Int, _z: Int, _w: Int, _v: Int, _d: Int) extend
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < 24) Arrays.copyOf(bytes, 24) else bytes
     val bb = ByteBuffer.wrap(bs)
     x = bb.getInt()

--- a/core/src/main/scala/spire/random/rng/MersenneTwister32.scala
+++ b/core/src/main/scala/spire/random/rng/MersenneTwister32.scala
@@ -54,7 +54,7 @@ final class MersenneTwister32 protected[random](mt: Array[Int], mti0: Int = 625)
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
     cfor(0)(_ < N, _ + 1) { i => mt(i) = bb.getInt() }
@@ -126,9 +126,12 @@ object MersenneTwister32 extends GeneratorCompanion[MersenneTwister32, (Array[In
         new MersenneTwister32(mt, mti)
     }
 
-  def fromArray(arr: Array[Int]): MersenneTwister32 = fromSeed((Utils.seedFromArray(N, arr)), N + 1)
+  def fromArray(arr: Array[Int]): MersenneTwister32 =
+    fromSeed((Utils.seedFromArray(N, arr), N + 1))
 
-  def fromBytes(bytes: Array[Byte]): MersenneTwister32 = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): MersenneTwister32 =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : MersenneTwister32 = fromSeed((Utils.seedFromInt(N, Utils.intFromTime(time))), N + 1)
+  def fromTime(time: Long = System.nanoTime) : MersenneTwister32 =
+    fromSeed((Utils.seedFromInt(N, Utils.intFromTime(time)), N + 1))
 }

--- a/core/src/main/scala/spire/random/rng/MersenneTwister64.scala
+++ b/core/src/main/scala/spire/random/rng/MersenneTwister64.scala
@@ -54,7 +54,7 @@ final class MersenneTwister64 protected[random](mt: Array[Long], mti0: Int = 313
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
     cfor(0)(_ < N, _ + 1) { i => mt(i) = bb.getLong() }

--- a/core/src/main/scala/spire/random/rng/Well1024a.scala
+++ b/core/src/main/scala/spire/random/rng/Well1024a.scala
@@ -119,7 +119,7 @@ object Well1024a extends GeneratorCompanion[Well1024a, (Array[Int], Int)] {
 
   @inline private final def mat0pos(t: Int, v: Int): Int = v ^ (v >>> t)
   @inline private final def mat0neg(t: Int, v: Int): Int = v ^ (v << -t)
-                                                                                   
+
   def randomSeed(): (Array[Int], Int) =
     (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
@@ -131,11 +131,11 @@ object Well1024a extends GeneratorCompanion[Well1024a, (Array[Int], Int)] {
     }
 
   def fromArray(arr: Array[Int]): Well1024a =
-    fromSeed(Utils.seedFromArray(R, arr), 0)
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
   def fromBytes(bytes: Array[Byte]): Well1024a =
     fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
   def fromTime(time: Long = System.nanoTime): Well1024a =
-    fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/core/src/main/scala/spire/random/rng/Well19937a.scala
+++ b/core/src/main/scala/spire/random/rng/Well19937a.scala
@@ -53,7 +53,7 @@ final class Well19937a protected[random](state: Array[Int], i0: Int) extends Int
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
@@ -110,8 +110,9 @@ object Well19937a extends GeneratorCompanion[Well19937a, (Array[Int], Int)] {
   @inline private final def mat0neg(t: Int, v: Int) = v ^ (v << -t)
   @inline private final def mat1(v: Int)            = v
   @inline private final def mat3pos(t: Int, v: Int) = v >>> t
-                                                                                   
-  def randomSeed(): (Array[Int], Int) = (Utils.seedFromInt(R, Utils.intFromTime()), 0)
+
+  def randomSeed(): (Array[Int], Int) =
+    (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
   def fromSeed(seed: (Array[Int], Int)): Well19937a =
     seed match {
@@ -120,9 +121,12 @@ object Well19937a extends GeneratorCompanion[Well19937a, (Array[Int], Int)] {
         new Well19937a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well19937a = fromSeed(Utils.seedFromArray(R, arr), 0)
+  def fromArray(arr: Array[Int]): Well19937a =
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
-  def fromBytes(bytes: Array[Byte]): Well19937a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): Well19937a =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well19937a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+  def fromTime(time: Long = System.nanoTime): Well19937a =
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/core/src/main/scala/spire/random/rng/Well19937c.scala
+++ b/core/src/main/scala/spire/random/rng/Well19937c.scala
@@ -53,7 +53,7 @@ final class Well19937c protected[random](state: Array[Int], i0: Int) extends Int
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
@@ -118,7 +118,7 @@ object Well19937c extends GeneratorCompanion[Well19937c, (Array[Int], Int)] {
   @inline private final def mat0neg(t: Int, v: Int) = v ^ (v << -t)
   @inline private final def mat1(v: Int)            = v
   @inline private final def mat3pos(t: Int, v: Int) = v >>> t
-                                                                                   
+
   def randomSeed(): (Array[Int], Int) = (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
   def fromSeed(seed: (Array[Int], Int)): Well19937c =
@@ -128,9 +128,12 @@ object Well19937c extends GeneratorCompanion[Well19937c, (Array[Int], Int)] {
         new Well19937c(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well19937c = fromSeed(Utils.seedFromArray(R, arr), 0)
+  def fromArray(arr: Array[Int]): Well19937c =
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
-  def fromBytes(bytes: Array[Byte]): Well19937c = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): Well19937c =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well19937c = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+  def fromTime(time: Long = System.nanoTime): Well19937c =
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/core/src/main/scala/spire/random/rng/Well44497a.scala
+++ b/core/src/main/scala/spire/random/rng/Well44497a.scala
@@ -53,7 +53,7 @@ final class Well44497a protected[random](state: Array[Int], i0: Int) extends Int
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
@@ -121,8 +121,9 @@ object Well44497a extends GeneratorCompanion[Well44497a, (Array[Int], Int)] {
       ((v << r) ^ (v >>> (32 - r))) & ds
     }
   }
-                                                                                   
-  def randomSeed(): (Array[Int], Int) = (Utils.seedFromInt(R, Utils.intFromTime()), 0)
+
+  def randomSeed(): (Array[Int], Int) =
+    (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
   def fromSeed(seed: (Array[Int], Int)): Well44497a =
     seed match {
@@ -131,9 +132,12 @@ object Well44497a extends GeneratorCompanion[Well44497a, (Array[Int], Int)] {
         new Well44497a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well44497a = fromSeed(Utils.seedFromArray(R, arr), 0)
+  def fromArray(arr: Array[Int]): Well44497a =
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
-  def fromBytes(bytes: Array[Byte]): Well44497a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): Well44497a =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well44497a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+  def fromTime(time: Long = System.nanoTime): Well44497a =
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/core/src/main/scala/spire/random/rng/Well44497b.scala
+++ b/core/src/main/scala/spire/random/rng/Well44497b.scala
@@ -53,7 +53,7 @@ final class Well44497b protected[random](state: Array[Int], i0: Int) extends Int
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
@@ -129,8 +129,9 @@ object Well44497b extends GeneratorCompanion[Well44497b, (Array[Int], Int)] {
       ((v << r) ^ (v >>> (32 - r))) & ds
     }
   }
-                                                                                   
-  def randomSeed(): (Array[Int], Int) = (Utils.seedFromInt(R, Utils.intFromTime()), 0)
+
+  def randomSeed(): (Array[Int], Int) =
+    (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
   def fromSeed(seed: (Array[Int], Int)): Well44497b =
     seed match {
@@ -139,9 +140,12 @@ object Well44497b extends GeneratorCompanion[Well44497b, (Array[Int], Int)] {
         new Well44497b(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well44497b = fromSeed(Utils.seedFromArray(R, arr), 0)
+  def fromArray(arr: Array[Int]): Well44497b =
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
-  def fromBytes(bytes: Array[Byte]): Well44497b = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): Well44497b =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well44497b = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+  def fromTime(time: Long = System.nanoTime): Well44497b =
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/core/src/main/scala/spire/random/rng/Well512a.scala
+++ b/core/src/main/scala/spire/random/rng/Well512a.scala
@@ -60,7 +60,7 @@ final class Well512a protected[random](state: Array[Int], i0: Int) extends IntBa
     bytes
   }
 
-  def setSeedBytes(bytes: Array[Byte]) {
+  def setSeedBytes(bytes: Array[Byte]): Unit = {
     val bs = if (bytes.length < BYTES) util.Arrays.copyOf(bytes, BYTES) else bytes
     val bb = ByteBuffer.wrap(bs)
 
@@ -119,8 +119,9 @@ object Well512a extends GeneratorCompanion[Well512a, (Array[Int], Int)] {
   @inline private final def mat0neg(t: Int, v: Int)         = v ^ (v << -t)
   @inline private final def mat3neg(t: Int, v: Int)         = v << -t
   @inline private final def mat4neg(t: Int, b: Int, v: Int) = v ^ ((v << -t) & b)
-                                                                                   
-  def randomSeed(): (Array[Int], Int) = (Utils.seedFromInt(R, Utils.intFromTime()), 0)
+
+  def randomSeed(): (Array[Int], Int) =
+    (Utils.seedFromInt(R, Utils.intFromTime()), 0)
 
   def fromSeed(seed: (Array[Int], Int)): Well512a =
     seed match {
@@ -129,9 +130,12 @@ object Well512a extends GeneratorCompanion[Well512a, (Array[Int], Int)] {
         new Well512a(state, stateIndex)
     }
 
-  def fromArray(arr: Array[Int]): Well512a = fromSeed(Utils.seedFromArray(R, arr), 0)
+  def fromArray(arr: Array[Int]): Well512a =
+    fromSeed((Utils.seedFromArray(R, arr), 0))
 
-  def fromBytes(bytes: Array[Byte]): Well512a = fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
+  def fromBytes(bytes: Array[Byte]): Well512a =
+    fromArray(Pack.intsFromBytes(bytes, bytes.length / 4))
 
-  def fromTime(time: Long = System.nanoTime) : Well512a = fromSeed(Utils.seedFromInt(R, Utils.intFromTime(time)), 0)
+  def fromTime(time: Long = System.nanoTime): Well512a =
+    fromSeed((Utils.seedFromInt(R, Utils.intFromTime(time)), 0))
 }

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -153,7 +153,7 @@ object Variable {
   case class Ignored(label: String = Unlabeled) extends Variable[Nothing] {
     def apply() = new Builder[String, String => List[Nothing]] {
       def += (s: String) = this
-      def clear() { }
+      def clear(): Unit = ()
       def result() = s => Nil
     }
   }
@@ -161,7 +161,7 @@ object Variable {
   case class Continuous[+F](label: String = Unlabeled, f: String => F) extends Variable[F] {
     def apply() = new Builder[String, String => List[F]] {
       def += (s: String) = this
-      def clear() { }
+      def clear(): Unit = ()
       def result() = { s => f(s) :: Nil }
     }
   }
@@ -174,7 +174,7 @@ object Variable {
         categories += s
         this
       }
-      def clear() { categories = Set.empty }
+      def clear(): Unit = { categories = Set.empty }
       def result() = {
         val orderedCategories = categories.toList
 
@@ -197,7 +197,7 @@ object Variable {
         }
         this
       }
-      def clear() { values.clear(); defaultBuilder.clear() }
+      def clear(): Unit = { values.clear(); defaultBuilder.clear() }
       def result() = {
         val real = defaultBuilder.result()
         val occurences = values.foldLeft(Map.empty[List[F], Int]) { (acc, v) =>

--- a/examples/src/main/scala/spire/example/graphing.scala
+++ b/examples/src/main/scala/spire/example/graphing.scala
@@ -5,7 +5,7 @@ import spire.implicits._
 import spire.math._
 
 object Graphing {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val r = 9.0
 

--- a/examples/src/main/scala/spire/example/kleene.scala
+++ b/examples/src/main/scala/spire/example/kleene.scala
@@ -484,9 +484,9 @@ object KleeneDemo {
   }
 
   /**
-   * 
+   *
    */
-  def graphExample() {
+  def graphExample(): Unit = {
     // our example graph will be 5x5
     implicit val dim = Dim(5)
 
@@ -515,7 +515,7 @@ object KleeneDemo {
     println("path exprs:\n%s" format expred.kstar.show)
   }
 
-  def pathExample() {
+  def pathExample(): Unit = {
     // our example graph will be 5x5
     implicit val dim = Dim(6)
 
@@ -578,7 +578,7 @@ object KleeneDemo {
     println("least-cost via evalExpr:\n" + leastCostExprs.show)
   }
 
-  def solvingExample() {
+  def solvingExample(): Unit = {
     // our example matrix is 2x2
     implicit val dim = Dim(2)
 
@@ -592,7 +592,7 @@ object KleeneDemo {
     println("2x2 inverse:\n" + inverse(m).show)
   }
 
-  def languageExample() {
+  def languageExample(): Unit = {
     val bit = Language(Stream(Stream('0'), Stream('1')))
     val lang1 = bit.pow(4)
     val lang2 = bit.kstar
@@ -600,7 +600,7 @@ object KleeneDemo {
     println(lang2.wss.take(10).map(_.take(10).mkString + "...").toList)
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     graphExample()
     pathExample()
     solvingExample()

--- a/examples/src/main/scala/spire/example/loops.scala
+++ b/examples/src/main/scala/spire/example/loops.scala
@@ -4,19 +4,19 @@ import spire.implicits._
 import scala.annotation.tailrec
 
 class Loops {
-  def nested {
+  def nested(): Unit = {
     cfor(0)(_ < 5, _ + 1) {
       y => cfor(0)(_ < 3, _ + 1) { x =>
         println((x, y))
       }
     }
   }
-  
-  def simple {
+
+  def simple(): Unit = {
     cfor(0)(_ < 10, _ + 1) { i => println(i) }
   }
 
-  def simplew {
+  def simplew(): Unit = {
     var i = 0
     while (i < 10) {
       println(i)
@@ -24,8 +24,8 @@ class Loops {
     }
   }
 
-  def simplet {
-    @tailrec def loop(i: Int) {
+  def simplet(): Unit = {
+    @tailrec def loop(i: Int): Unit = {
       if (i < 10) {
         println(i)
         loop(i + 1)

--- a/examples/src/main/scala/spire/example/mandelbrot.scala
+++ b/examples/src/main/scala/spire/example/mandelbrot.scala
@@ -22,7 +22,7 @@ object MandelbrotDemo {
   /**
    * Print an ASCII approximation of the 4x4 box from -2-2i to 2+2i.
    */
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val res = 26 // number of iterations to try before including pt in the set
     val rows = if (args.isEmpty) 20 else args(0).toInt // rows to print
     val cols = rows * 2 // cols to print. most fonts are roughly 1:2

--- a/examples/src/main/scala/spire/example/randomforest.scala
+++ b/examples/src/main/scala/spire/example/randomforest.scala
@@ -31,8 +31,7 @@ object RandomForestExample extends App {
   testRegression[Array[Double], Double](DataSet.MPG, RandomForestOptions(numPointsSample = Some(200), numTrees = Some(50)))
 
 
-  def testClassification[V, @spec(Double) F, K](dataset: DataSet[V, F, K], opts: RandomForestOptions)(implicit
-      order: Order[F], classTagV: ClassTag[V], classTagK: ClassTag[K], real: IsReal[F]) {
+  def testClassification[V, @spec(Double) F, K](dataset: DataSet[V, F, K], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagK: ClassTag[K], real: IsReal[F]): Unit = {
 
     println(s"\n${dataset.describe}\n")
     println(s"Cross-validating ${dataset.name} with random forest classification...")
@@ -42,8 +41,7 @@ object RandomForestExample extends App {
     println("... accuracy of %.2f%%\n" format (real.toDouble(accuracy) * 100))
   }
 
-  def testRegression[V, @spec(Double) F](dataset: DataSet[V, F, F], opts: RandomForestOptions)(implicit
-      order: Order[F], classTagV: ClassTag[V], classTagF: ClassTag[F], real: IsReal[F]) {
+  def testRegression[V, @spec(Double) F](dataset: DataSet[V, F, F], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagF: ClassTag[F], real: IsReal[F]): Unit = {
 
     println(s"\n${dataset.describe}\n")
     println(s"Cross-validating ${dataset.name} with random forest regression...")

--- a/examples/src/main/scala/spire/example/simplification.scala
+++ b/examples/src/main/scala/spire/example/simplification.scala
@@ -20,7 +20,7 @@ import scala.collection.generic.CanBuildFrom
  */
 object Simplification {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     if (args.isEmpty) {
       println("usage: %s [nrat | rats | nprime | primes | snap] [number]")
     } else {
@@ -185,9 +185,9 @@ trait BigStream[A] extends Iterable[A] with IterableLike[A, BigStream[A]] { self
 
   def iterator: Iterator[A] = new Iterator[A] {
     var stream = self
-  
+
     def hasNext: Boolean = !stream.isEmpty
-  
+
     def next: A = if (stream.isEmpty) {
       throw new NoSuchElementException
     } else {
@@ -197,7 +197,7 @@ trait BigStream[A] extends Iterable[A] with IterableLike[A, BigStream[A]] { self
     }
   }
 
-  override def foreach[U](f: A => U) {
+  override def foreach[U](f: A => U): Unit = {
     @tailrec
     def loop(stream: BigStream[A]): Unit = if (!stream.isEmpty) {
       f(stream.head)

--- a/macros/src/main/scala/spire/macros/Syntax.scala
+++ b/macros/src/main/scala/spire/macros/Syntax.scala
@@ -1,6 +1,6 @@
 package spire.macros
 
-import spire.macros.compat.{termName, freshTermName, resetLocalAttrs, Context}
+import spire.macros.compat.{termName, freshTermName, resetLocalAttrs, Context, setOrig}
 
 import scala.language.higherKinds
 
@@ -21,7 +21,7 @@ object Ops extends machinist.Ops {
       ("$qmark$qmark$bar$plus$bar$greater", "actlIsDefined"),
       ("$less$bar$plus$bar$qmark", "partialActr"),
       ("$less$bar$plus$bar$qmark$qmark", "actrIsDefined"),
-      
+
       // square root
       (uesc('√'), "sqrt"),
 
@@ -88,7 +88,8 @@ class InlineUtil[C <: Context with Singleton](val c: C) {
         case Ident(_) if tree.symbol == symbol =>
           value
         case tt: TypeTree if tt.original != null =>
-          super.transform(TypeTree().setOriginal(transform(tt.original)))
+          //super.transform(TypeTree().setOriginal(transform(tt.original)))
+          super.transform(setOrig(c)(TypeTree(), transform(tt.original)))
         case _ =>
           super.transform(tree)
       }

--- a/macros/src/main/scala_2.10/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.10/spire/macros/compat.scala
@@ -15,4 +15,7 @@ object compat {
 
   def resetLocalAttrs[C <: Context](c: C)(t: c.Tree) =
     c.resetLocalAttrs(t)
+
+  def setOrig[C <: Context](c: C)(tt: c.TypeTree, t: c.Tree) =
+    tt.setOriginal(t)
 }

--- a/macros/src/main/scala_2.10/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.10/spire/macros/compat.scala
@@ -16,6 +16,6 @@ object compat {
   def resetLocalAttrs[C <: Context](c: C)(t: c.Tree) =
     c.resetLocalAttrs(t)
 
-  def setOrig[C <: Context](c: C)(tt: c.TypeTree, t: c.Tree) =
+  def setOrig[C <: Context](c: C)(tt: c.universe.TypeTree, t: c.Tree) =
     tt.setOriginal(t)
 }

--- a/macros/src/main/scala_2.11/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.11/spire/macros/compat.scala
@@ -15,4 +15,7 @@ object compat {
 
   def resetLocalAttrs[C <: Context](c: C)(t: c.Tree) =
     c.untypecheck(t)
+
+  def setOrig[C <: Context](c: C)(tt: c.universe.TypeTree, t: c.Tree) =
+    c.universe.internal.setOriginal(tt, t)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -65,15 +65,19 @@ object MyBuild extends Build {
     ),
 
     scalacOptions ++= Seq(
-      //"-no-specialization", // use this to build non-specialized jars
       "-Yinline-warnings",
       "-deprecation",
+      "-encoding", "UTF-8", // yes, this is 2 args
+      "-feature",
       "-unchecked",
+      //"-Xfatal-warnings", // inliner warnings mean we leave this off
+      "-Xlint",
+      "-Xfuture",
+      "-Yno-adapted-args",
       "-optimize",
       "-language:experimental.macros",
       "-language:higherKinds",
-      "-language:implicitConversions",
-      "-feature"
+      "-language:implicitConversions"
     ),
 
     resolvers += Resolver.sonatypeRepo("snapshots"),

--- a/tests/src/test/scala/spire/CforTest.scala
+++ b/tests/src/test/scala/spire/CforTest.scala
@@ -8,13 +8,13 @@ import collection.mutable
 
 class CforTest extends FunSuite {
   test("simple cfor") {
-    val l = mutable.ListBuffer[Int]()    
-    cfor(0)(_ < 5, _ + 1) { x => 
+    val l = mutable.ListBuffer[Int]()
+    cfor(0)(_ < 5, _ + 1) { x =>
       l.append(x)
     }
     assert(l.toSeq === Seq(0,1,2,3,4))
   }
-  
+
   test("nested cfor") {
     val s = mutable.Set[Int]()
     cfor(0)(_ < 10, _ + 1) { x =>
@@ -24,18 +24,18 @@ class CforTest extends FunSuite {
     }
     assert(s.toSeq.sorted === (10 to 99))
   }
-  
+
   test("symbol collision cfor") {
     val b = mutable.ArrayBuffer.empty[Int]
     cfor(0)(_ < 3, _ + 1) { x =>
-      cfor(0)(_ < 2, _ + 1) { y => 
+      cfor(0)(_ < 2, _ + 1) { y =>
         val x = y
         b += x
       }
     }
     assert(b.toList === List(0, 1, 0, 1, 0, 1))
   }
-  
+
   test("functions with side effects in cfor") {
     val b = mutable.ArrayBuffer.empty[Int]
     var v = 0
@@ -71,7 +71,7 @@ class CforTest extends FunSuite {
     def run(
         test: => (Int => Boolean),
         incr: => (Int => Int),
-        body: => (Int => Unit)) {
+        body: => (Int => Unit)): Unit = {
       cfor(0)(test, incr)(body)
     }
     run(
@@ -87,7 +87,7 @@ class CforTest extends FunSuite {
     assert(v === 111, s"v == $v")
     assert(b.toList === List(0, 1, 2), s"b.toList == ${b.toList}")
   }
-  
+
   test("capture value in closure") {
     val b1 = collection.mutable.ArrayBuffer[() => Int]()
     cfor(0)(_ < 3, _ + 1) { x =>
@@ -101,7 +101,7 @@ class CforTest extends FunSuite {
     }
     assert(b1.map(_.apply).toList === b2.map(_.apply).toList)
   }
-  
+
   test("capture value in inner class") {
     val b = collection.mutable.ArrayBuffer[Int]()
     cfor(0)(_ < 3, _ + 1) { x => {

--- a/tests/src/test/scala/spire/algebra/NRootTest.scala
+++ b/tests/src/test/scala/spire/algebra/NRootTest.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 
 
 class NRootTest extends FunSuite {
-  def testIntegralNRoot[A: Numeric: ClassTag] {
+  def testIntegralNRoot[A: Numeric: ClassTag]: Unit = {
     val cls = implicitly[ClassTag[A]].runtimeClass.getSimpleName
     test("Integral NRoot (%s)" format cls) {
       val one = Rig[A].one
@@ -27,7 +27,7 @@ class NRootTest extends FunSuite {
   def eps(x: BigDecimal): BigDecimal =
     x.round(DECIMAL1) * BigDecimal(1, x.mc.getPrecision - 1)
 
-  def checkNRoot(x: BigDecimal, n: Int) {
+  def checkNRoot(x: BigDecimal, n: Int): Unit = {
     import spire.implicits._
 
     val y = x nroot n

--- a/tests/src/test/scala/spire/algebra/RingTest.scala
+++ b/tests/src/test/scala/spire/algebra/RingTest.scala
@@ -22,7 +22,7 @@ class RingTest extends FunSuite {
    *
    *   a=-3  b=3  c=-9
    */
-  def runWith[@spec A:Ring:ClassTag](cls:String)(a:A, b:A, c:A) {
+  def runWith[@spec A:Ring:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
 
     val m = implicitly[ClassTag[A]]
 

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -16,7 +16,7 @@ import java.math.MathContext
 
 
 class SignedTest extends FunSuite {
-  def runWith[@spec(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A) {
+  def runWith[@spec(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A): Unit = {
     val m = implicitly[ClassTag[A]]
 
     //// the name to use for this A

--- a/tests/src/test/scala/spire/math/CooperativeEqualityTest.scala
+++ b/tests/src/test/scala/spire/math/CooperativeEqualityTest.scala
@@ -93,7 +93,7 @@ class CooperativeEqualityTest extends FunSuite {
   testEquals(Algebraic(3), "Algebraic", Real(3), "Real")
   testEquals(Real(3), "Real", Real(3), "Real")
 
-  def testComplex[A: ConvertableFrom](a: A, name: String) {
+  def testComplex[A: ConvertableFrom](a: A, name: String): Unit = {
     testEquals(a, name, Complex(a.toFloat), "Complex[Float]")
     testEquals(a, name, Complex(a.toDouble), "Complex[Double]")
     // testEquals(a, name, Complex(a.toBigDecimal), "Complex[BigDecimal]")
@@ -113,7 +113,7 @@ class CooperativeEqualityTest extends FunSuite {
   testComplex(Algebraic(3), "Algebraic")
   testComplex(Real(3), "Real")
 
-  def testQuaternion[A: ConvertableFrom](a: A, name: String) {
+  def testQuaternion[A: ConvertableFrom](a: A, name: String): Unit = {
     testEquals(a, name, Quaternion(a.toFloat), "Quaternion[Float]")
     testEquals(a, name, Quaternion(a.toDouble), "Quaternion[Double]")
     // testEquals(a, name, Quaternion(a.toBigDecimal), "Quaternion[BigDecimal]")

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -339,7 +339,7 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
 
   val tries = 100
 
-  def testUnop(f: Interval[Rational] => Interval[Rational])(g: Rational => Rational) {
+  def testUnop(f: Interval[Rational] => Interval[Rational])(g: Rational => Rational): Unit = {
     forAll { (a: Interval[Rational]) =>
       val c: Interval[Rational] = f(a)
       sample(a, tries).foreach { x =>
@@ -350,7 +350,7 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
     }
   }
 
-  def testBinop(f: (Interval[Rational], Interval[Rational]) => Interval[Rational])(g: (Rational, Rational) => Rational) {
+  def testBinop(f: (Interval[Rational], Interval[Rational]) => Interval[Rational])(g: (Rational, Rational) => Rational): Unit = {
     forAll { (a: Interval[Rational], b: Interval[Rational]) =>
       val c: Interval[Rational] = f(a, b)
       sample(a, tries).zip(sample(b, tries)).foreach { case (x, y) =>
@@ -470,7 +470,7 @@ class IntervalIteratorCheck extends PropSpec with Matchers with GeneratorDrivenP
 
       val num = ((num0 & 255) % 13) + 1
 
-      def testEndpoints(interval: Interval[Rational], step: Rational, hasLower: Boolean, hasUpper: Boolean) {
+      def testEndpoints(interval: Interval[Rational], step: Rational, hasLower: Boolean, hasUpper: Boolean): Unit = {
         val ns = interval.iterator(step).toSet
         ns(x) shouldBe hasLower
         ns(y) shouldBe hasUpper

--- a/tests/src/test/scala/spire/math/LiteralsTest.scala
+++ b/tests/src/test/scala/spire/math/LiteralsTest.scala
@@ -39,9 +39,9 @@ class LiteralsTest extends FunSuite {
   test("int operators") {
     import spire.syntax.std.int._
     import spire.syntax.nroot._
-    assert(5 ** 2 === 25)
-    assert(5 /~ 2 === 2)
-    assert(5 /% 2 === (2, 1))
+    assert((5 ** 2) === 25)
+    assert((5 /~ 2) === 2)
+    assert((5 /% 2) === ((2, 1)))
     assert(25.sqrt === 5)
   }
 

--- a/tests/src/test/scala/spire/math/NaturalTest.scala
+++ b/tests/src/test/scala/spire/math/NaturalTest.scala
@@ -50,7 +50,7 @@ class NaturalTest extends PropSpec with Matchers with GeneratorDrivenPropertyChe
 
   property("x /% y") {
     forAll { (x: N, y: Positive[BigInt]) =>
-      Natural(x.num) /% Natural(y.num) shouldBe (Natural(x.num / y.num), Natural(x.num % y.num))
+      (Natural(x.num) /% Natural(y.num)) shouldBe ((Natural(x.num / y.num), Natural(x.num % y.num)))
     }
   }
 

--- a/tests/src/test/scala/spire/math/NumericTest.scala
+++ b/tests/src/test/scala/spire/math/NumericTest.scala
@@ -21,7 +21,7 @@ class NumericTest extends FunSuite {
    *
    *   a=-3  b=3  c=9
    */
-  def runWith[@spec A:Numeric:ClassTag](cls:String)(a:A, b:A, c:A) {
+  def runWith[@spec A:Numeric:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
 
     // the name to use for this A
     //val cls = implicitly[ClassTag[A]].erasure.getSimpleName

--- a/tests/src/test/scala/spire/math/PolynomialSamplingCheck.scala
+++ b/tests/src/test/scala/spire/math/PolynomialSamplingCheck.scala
@@ -27,7 +27,7 @@ class PolynomialSamplingCheck extends PropSpec with Matchers with GeneratorDrive
   runDense[Rational]("rational")
   runSparse[Rational]("rational")
 
-  def runDense[A: Arbitrary: Eq: Field: ClassTag](typ: String) {
+  def runDense[A: Arbitrary: Eq: Field: ClassTag](typ: String): Unit = {
     implicit val arb: Arbitrary[Polynomial[A]] = Arbitrary(for {
       ts <- arbitrary[List[Term[A]]]
     } yield {
@@ -36,7 +36,7 @@ class PolynomialSamplingCheck extends PropSpec with Matchers with GeneratorDrive
     runTest[A](s"$typ/dense")
   }
 
-  def runSparse[A: Arbitrary: Eq: Field: ClassTag](typ: String) {
+  def runSparse[A: Arbitrary: Eq: Field: ClassTag](typ: String): Unit = {
     implicit val arb: Arbitrary[Polynomial[A]] = Arbitrary(for {
       ts <- arbitrary[List[Term[A]]]
     } yield {
@@ -45,27 +45,27 @@ class PolynomialSamplingCheck extends PropSpec with Matchers with GeneratorDrive
     runTest[A](s"$typ/sparse")
   }
 
-  def runTest[A: Eq: Field: ClassTag](name: String)(implicit arb: Arbitrary[Polynomial[A]], arb2: Arbitrary[A]) {
+  def runTest[A: Eq: Field: ClassTag](name: String)(implicit arb: Arbitrary[Polynomial[A]], arb2: Arbitrary[A]): Unit = {
     type P = Polynomial[A]
 
     val zero = Polynomial.zero[A]
     val one = Polynomial.one[A]
 
-    def testUnop(f: P => P)(g: A => A) {
+    def testUnop(f: P => P)(g: A => A): Unit = {
       forAll { (x: P, a: A) =>
         val z = f(x)
         g(x(a)) shouldBe z(a)
       }
     }
 
-    def testBinop(f: (P, P) => P)(g: (A, A) => A) {
+    def testBinop(f: (P, P) => P)(g: (A, A) => A): Unit = {
       forAll { (x: P, y: P, a: A) =>
         val z = f(x, y)
         g(x(a), y(a)) shouldBe z(a)
       }
     }
 
-    def testBinopNonzero(f: (P, P) => P)(g: (A, A) => A) {
+    def testBinopNonzero(f: (P, P) => P)(g: (A, A) => A): Unit = {
       forAll { (x: P, y: P, a: A) =>
         if (!y.isZero && y(a) != Field[A].zero) {
           val z = f(x, y)

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -64,7 +64,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
   // runDense[BigDecimal]("decimal")(arbitraryBigDecimal, sbd, fbd, cbd)
   // runSparse[BigDecimal]("decimal")(arbitraryBigDecimal, sbd, fbd, cbd)
 
-  def runDense[A: Arbitrary: Eq: Field: ClassTag](typ: String) {
+  def runDense[A: Arbitrary: Eq: Field: ClassTag](typ: String): Unit = {
     implicit val arb: Arbitrary[Polynomial[A]] = Arbitrary(for {
       ts <- arbitrary[List[Term[A]]]
     } yield {
@@ -73,7 +73,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     runTest[A](s"$typ/dense")
   }
 
-  def runSparse[A: Arbitrary: Eq: Field: ClassTag](typ: String) {
+  def runSparse[A: Arbitrary: Eq: Field: ClassTag](typ: String): Unit = {
     implicit val arb: Arbitrary[Polynomial[A]] = Arbitrary(for {
       ts <- arbitrary[List[Term[A]]]
     } yield {
@@ -82,7 +82,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     runTest[A](s"$typ/sparse")
   }
 
-  def runTest[A: Eq: Field: ClassTag](name: String)(implicit arb: Arbitrary[Polynomial[A]], arb2: Arbitrary[A]) {
+  def runTest[A: Eq: Field: ClassTag](name: String)(implicit arb: Arbitrary[Polynomial[A]], arb2: Arbitrary[A]): Unit = {
     type P = Polynomial[A]
 
     val zero = Polynomial.zero[A]
@@ -164,7 +164,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
 
   property("terms") {
     forAll { (t: Term[Rational]) =>
-      t.toTuple shouldBe (t.exp, t.coeff)
+      t.toTuple shouldBe ((t.exp, t.coeff))
       t.isIndexZero shouldBe (t.exp == 0)
       forAll { (x: Rational) =>
         t.eval(x) shouldBe t.coeff * x.pow(t.exp.toInt)
@@ -225,7 +225,7 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     }
   }
 
-  def gcdTest(x: Polynomial[Rational], y: Polynomial[Rational]) {
+  def gcdTest(x: Polynomial[Rational], y: Polynomial[Rational]): Unit = {
     if (!x.isZero || !y.isZero) {
       val gcd = spire.math.gcd[Polynomial[Rational]](x, y)
       if (!gcd.isZero) {

--- a/tests/src/test/scala/spire/math/QuaternionCheck.scala
+++ b/tests/src/test/scala/spire/math/QuaternionCheck.scala
@@ -105,7 +105,7 @@ class QuaternionCheck extends PropSpec with Matchers with GeneratorDrivenPropert
 
   import spire.compat.ordering
 
-  def dumpDiff(label: String, base: H, gen: H) {
+  def dumpDiff(label: String, base: H, gen: H): Unit = {
     println(s"$label $base $gen")
     val (gr, gi, gj, gk) = (gen.r, gen.i, gen.j, gen.k)
     val (br, bi, bj, bk) = (base.r, base.i, base.j, base.k)

--- a/tests/src/test/scala/spire/math/SafeLongTest.scala
+++ b/tests/src/test/scala/spire/math/SafeLongTest.scala
@@ -79,13 +79,13 @@ class SafeLongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCh
         val sy = SafeLong(y)
         sx /% sy shouldBe x /% y
         sx /% y shouldBe x /% y
-        sx /% sy shouldBe (invariant(sx / sy), invariant(sx % sy))
+        sx /% sy shouldBe ((invariant(sx / sy), invariant(sx % sy)))
       }
     }
 
-    smin /% SafeLong(-1) shouldBe (-smin, zero)
-    smin /% -1L shouldBe (-smin, zero)
-    smin /% BigInt(-1) shouldBe (-smin, zero)
+    (smin /% SafeLong(-1)) shouldBe ((-smin, zero))
+    (smin /% -1L) shouldBe ((-smin, zero))
+    (smin /% BigInt(-1)) shouldBe ((-smin, zero))
   }
 
   property("x ** y") {
@@ -221,7 +221,7 @@ class SafeLongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCh
     smin % (-smin) shouldBe zero
 
     // quotmod
-    smin /% (-smin) shouldBe (SafeLong.minusOne, zero)
+    smin /% (-smin) shouldBe ((SafeLong.minusOne, zero))
 
     // gcd
     smin gcd smin shouldBe firstBig

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -17,52 +17,52 @@ import org.scalatest.FunSuite
  */
 class TypeclassExistenceTest extends FunSuite {
 
-  def hasRig[A](implicit rig: Rig[A] = null, m: ClassTag[A]) {
+  def hasRig[A](implicit rig: Rig[A] = null, m: ClassTag[A]): Unit = {
     assert(rig != null, "Expected implicit Rig[%s] instance, but it was not found." format m)
   }
 
-  def hasRing[A](implicit ring: Ring[A] = null, m: ClassTag[A]) {
+  def hasRing[A](implicit ring: Ring[A] = null, m: ClassTag[A]): Unit = {
     assert(ring != null, "Expected implicit Ring[%s] instance, but it was not found." format m)
   }
    
-  def hasEuclideanRing[A](implicit e: EuclideanRing[A] = null, m: ClassTag[A]) {
+  def hasEuclideanRing[A](implicit e: EuclideanRing[A] = null, m: ClassTag[A]): Unit = {
     assert(e!= null, "Expected implicit EuclideanRing[%s] instance, but it was not found." format m)
   }
 
-  def hasField[A](implicit f: Field[A] = null, m: ClassTag[A]) {
+  def hasField[A](implicit f: Field[A] = null, m: ClassTag[A]): Unit = {
     assert(f != null, "Expected implicit Field[%s] instance, but it was not found." format m)
   }
 
-  def hasNumeric[A](implicit n: Numeric[A] = null, m: ClassTag[A]) {
+  def hasNumeric[A](implicit n: Numeric[A] = null, m: ClassTag[A]): Unit = {
     assert(n != null, "Expected implicit Numeric[%s] instance, but it was not found." format m)
   }
    
-  def hasFractional[A](implicit f: Fractional[A] = null, m: ClassTag[A]) {
+  def hasFractional[A](implicit f: Fractional[A] = null, m: ClassTag[A]): Unit = {
     assert(f != null, "Expected implicit Fractional[%s] instance, but it was not found." format m)
   }
  
-  def hasOrder[A](implicit ev: Order[A] = null, m: ClassTag[A]) {
+  def hasOrder[A](implicit ev: Order[A] = null, m: ClassTag[A]): Unit = {
     assert(ev != null, "Expected implicit Order[%s] instance, but it was not found." format m)
   }
   
-  def hasEq[A](implicit ev: Eq[A] = null, m: ClassTag[A]) {
+  def hasEq[A](implicit ev: Eq[A] = null, m: ClassTag[A]): Unit = {
     assert(ev != null, "Expected implicit Eq[%s] instance, but it was not found." format m)
   }
  
-  def hasConvertableFrom[A](implicit ev: ConvertableFrom[A] = null, m: ClassTag[A]) {
+  def hasConvertableFrom[A](implicit ev: ConvertableFrom[A] = null, m: ClassTag[A]): Unit = {
     assert(ev != null, "Expected implicit ConvertableFrom[%s] instance, but it was not found." format m)
   }
   
-  def hasConvertableTo[A](implicit ev: ConvertableTo[A] = null, m: ClassTag[A]) {
+  def hasConvertableTo[A](implicit ev: ConvertableTo[A] = null, m: ClassTag[A]): Unit = {
     assert(ev != null, "Expected implicit ConvertableTo[%s] instance, but it was not found." format m)
   }
 
-  def hasNRoot[A](implicit ev: NRoot[A] = null, m: ClassTag[A]) {
+  def hasNRoot[A](implicit ev: NRoot[A] = null, m: ClassTag[A]): Unit = {
     assert(ev != null, "Expected implicit NRoot[%s] instance, but it was not found." format m)
   }
 
   test("Numeric is ConvertableTo") {
-    def check[A: Numeric : ClassTag] {
+    def check[A: Numeric : ClassTag]: Unit = {
       hasConvertableTo[A]
     }
 
@@ -70,7 +70,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Numeric is ConvertableFrom") {
-    def check[A: Numeric : ClassTag] {
+    def check[A: Numeric : ClassTag]: Unit = {
       hasConvertableFrom[A]
     }
 
@@ -78,7 +78,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Rings are Rigs") {
-    def check[A: Ring: ClassTag] {
+    def check[A: Ring: ClassTag]: Unit = {
       hasRig[A]
     }
 
@@ -86,7 +86,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("EuclideanRings are Rings") {
-    def check[A: EuclideanRing: ClassTag] {
+    def check[A: EuclideanRing: ClassTag]: Unit = {
       hasRing[A]
     }
 
@@ -94,7 +94,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Fields are EuclideanRings") {
-    def check[A: Field: ClassTag] {
+    def check[A: Field: ClassTag]: Unit = {
       hasEuclideanRing[A]
     }
 
@@ -102,7 +102,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Numerics have Order, NRoot, and are Rigs") {
-    def check[A: Numeric: ClassTag] {
+    def check[A: Numeric: ClassTag]: Unit = {
       hasRig[A]
       hasOrder[A]
       hasNRoot[A]
@@ -112,7 +112,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Fractional have Order, NRoot and are Fields") {
-    def check[A: Fractional: ClassTag] {
+    def check[A: Fractional: ClassTag]: Unit = {
       hasOrder[A]
       hasEuclideanRing[A]
       hasField[A]
@@ -235,7 +235,7 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("NRoot[Rational] requires implicit ApproximationContext") {
-    def check[A](implicit e: NRoot[A] = null) {
+    def check[A](implicit e: NRoot[A] = null): Unit = {
       assert(e == null)
     }
 

--- a/tests/src/test/scala/spire/math/fpf/MaybeDoubleTest.scala
+++ b/tests/src/test/scala/spire/math/fpf/MaybeDoubleTest.scala
@@ -57,7 +57,7 @@ class MaybeDoubleTest extends FunSuite {
     assert(md.error > 0.0)
   }
 
-  def assertAlmostEqual(a: MaybeDouble, x: Double) {
+  def assertAlmostEqual(a: MaybeDouble, x: Double): Unit = {
     assert(a.approx - a.error <= x && x <= a.approx + a.error)
   }
 

--- a/tests/src/test/scala/spire/math/real/BubbleUpDivsTest.scala
+++ b/tests/src/test/scala/spire/math/real/BubbleUpDivsTest.scala
@@ -7,14 +7,14 @@ import org.scalatest.FunSuite
 
 
 class BubbleUpDivsTest extends FunSuite {
-  def hasRootDiv(a: Algebraic) {
+  def hasRootDiv(a: Algebraic): Unit = {
     assert(a match {
         case Div(_, _) => true
         case _ => false
       }, "Root Algebraic expr is not a Div")
   }
 
-  def hasOneDiv(a: Algebraic) {
+  def hasOneDiv(a: Algebraic): Unit = {
     assert(countDivs(a) == 1, "Algebraic has more than 1 Div in expr")
   }
 
@@ -29,7 +29,7 @@ class BubbleUpDivsTest extends FunSuite {
     case BigIntLit(_) => 0
   }
 
-  def assertDivBubbledUp(a: Algebraic) {
+  def assertDivBubbledUp(a: Algebraic): Unit = {
     hasOneDiv(a)
     hasRootDiv(a)
   }

--- a/tests/src/test/scala/spire/random/GaussianTest.scala
+++ b/tests/src/test/scala/spire/random/GaussianTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.FunSuite
 class GaussianTest extends FunSuite {
   import AndersonDarlingTest._
 
-  def checkGaussian[A: Field: Trig: NRoot: IsReal: ClassTag](nextGaussian: (A, A) => A) {
+  def checkGaussian[A: Field: Trig: NRoot: IsReal: ClassTag](nextGaussian: (A, A) => A): Unit = {
     val mean = Field[A].zero
     val stdDev = Field[A].one
     val xs = Array.fill(20)(nextGaussian(mean, stdDev))

--- a/tests/src/test/scala/spire/random/SamplingTest.scala
+++ b/tests/src/test/scala/spire/random/SamplingTest.scala
@@ -14,7 +14,7 @@ class SamplingTest extends PropSpec with Matchers with GeneratorDrivenPropertyCh
   val ns = range.toArray
   val gen = Gen.chooseNum(1, Size)
 
-  def verify(result: Array[Int], n: Int) {
+  def verify(result: Array[Int], n: Int): Unit = {
     result.toSet.size shouldBe n
     result.toSet.forall(range.contains) shouldBe true
   }


### PR DESCRIPTION
This commit adds several extra scalac options that will help
us catch errors. All warnings have been eliminated, and moving
forward we should prevent any new warnings from being added.

(Due to inliner warnings, which can't be suppressed, we can't
use -Xfatal-warnings, unfortunately.)

Eventually I'd like to do more static checking (and maybe
enforce some common style/idioms), but this is a good first
step.