### PR TITLE
Remove ApproximationContext[Rational] and all uses.

### DIFF
--- a/core/src/main/scala/spire/math/ApproximationContext.scala
+++ b/core/src/main/scala/spire/math/ApproximationContext.scala
@@ -1,6 +1,6 @@
 package spire.math
 
 case class ApproximationContext[A](error: A)
-object ApproximationContext {
-  implicit def rational2error(q: Rational) = ApproximationContext(q)
-}
+// object ApproximationContext {
+//   implicit def rational2error(q: Rational) = ApproximationContext(q)
+// }

--- a/core/src/main/scala/spire/math/ApproximationContext.scala
+++ b/core/src/main/scala/spire/math/ApproximationContext.scala
@@ -1,6 +1,0 @@
-package spire.math
-
-case class ApproximationContext[A](error: A)
-// object ApproximationContext {
-//   implicit def rational2error(q: Rational) = ApproximationContext(q)
-// }

--- a/core/src/main/scala/spire/math/Convertable.scala
+++ b/core/src/main/scala/spire/math/Convertable.scala
@@ -457,7 +457,7 @@ private[math] trait ConvertableFromAlgebraic extends ConvertableFrom[Algebraic] 
   def toBigInt(a: Algebraic): BigInt = a.toBigInt
   // TODO: Figure out how to deal with variable approximability.
   def toBigDecimal(a: Algebraic): BigDecimal = a.toBigDecimal(java.math.MathContext.DECIMAL128)
-  def toRational(a: Algebraic): Rational = a.toRational(ApproximationContext(Rational(1L, 100000000000000000L)))
+  def toRational(a: Algebraic): Rational = a.toRational
   def toAlgebraic(a: Algebraic): Algebraic = a
   def toReal(a: Algebraic): Real = Real(a.toRational) //FIXME
   def toNumber(a: Algebraic): Number = Number(a.toRational)

--- a/core/src/main/scala/spire/math/FixedPoint.scala
+++ b/core/src/main/scala/spire/math/FixedPoint.scala
@@ -20,16 +20,16 @@ case class FixedScale(denom: Int) {
 /**
  * FixedPoint is a value class that provides fixed point arithmetic
  * operations (using an implicit denominator) to unboxed Long values.
- * 
+ *
  * Working with FixedPoint values is similar to other fractional
  * types, except that most operations require an implicit FixedScale
  * instance (which provides the denominator).
- * 
+ *
  * For example:
- * 
+ *
  * // interpret FixedPoint(n) as n/1000
  * implicit val scale = FixedScale(1000)
- * 
+ *
  * // these three values are equivalent
  * val a = FixedPoint("12.345")            // decimal repr
  * val b = FixedPoint(Rational(2469, 200)) // fraction repr
@@ -244,9 +244,13 @@ class FixedPoint(val long: Long) extends AnyVal { lhs =>
   def fpow(k: FixedPoint)(implicit scale: FixedScale): FixedPoint = {
     val r = this.toRational
     val g = k.long gcd scale.denom
-    val n = (k.long / g).toInt //FIXME
-    val d = (scale.denom / g).toInt // FIXME
-    FixedPoint(Real(r ** n).nroot(d).toRational)
+    val n = (k.long / g)
+    val d = (scale.denom / g)
+    if (n.isValidInt && d.isValidInt) {
+      FixedPoint(Real(r ** n.toInt).nroot(d.toInt).toRational)
+    } else {
+      throw new ArithmeticException(s"exponent $r is too complex")
+    }
   }
 
   override def toString: String = long.toString + "/?"

--- a/core/src/main/scala/spire/math/Fractional.scala
+++ b/core/src/main/scala/spire/math/Fractional.scala
@@ -9,16 +9,12 @@ import java.lang.Math
 trait Fractional[@spec(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]
 
 object Fractional {
-  private val ratCtx = ApproximationContext(Rational(1, 1000000000))
-
   implicit final val FloatIsFractional = new FloatIsFractional
   implicit final val DoubleIsFractional = new DoubleIsFractional
   implicit final val BigDecimalIsFractional = new BigDecimalIsFractional
   implicit final val AlgebraicIsFractional = new AlgebraicIsFractional
   implicit final val NumberIsFractional = new NumberIsFractional
-
-  implicit def RationalIsFractional(implicit ctx: ApproximationContext[Rational] = ratCtx) =
-    new RationalIsFractional
+  implicit final val RationalIsFractional = new RationalIsFractional
 
   @inline final def apply[A](implicit ev:Fractional[A]) = ev
 }
@@ -50,11 +46,13 @@ with BigDecimalIsReal with Serializable {
   override def toDouble(n: BigDecimal): Double = n.toDouble
 }
 
-@SerialVersionUID(0L)
-private[math] class RationalIsFractional(implicit val context: ApproximationContext[Rational])
-extends Fractional[Rational] with RationalIsField with RationalIsNRoot
-with ConvertableFromRational with ConvertableToRational
-with RationalIsReal with Serializable {
+@SerialVersionUID(1L)
+private[math] class RationalIsFractional extends Fractional[Rational]
+    with RationalIsField
+    with RationalApproximateNRoot
+    with ConvertableFromRational with ConvertableToRational
+    with RationalIsReal with Serializable {
+
   override def fromInt(n: Int): Rational = Rational(n)
   override def fromDouble(n: Double): Rational = Rational(n)
   override def toDouble(n: Rational): Double = n.toDouble

--- a/core/src/main/scala/spire/math/Numeric.scala
+++ b/core/src/main/scala/spire/math/Numeric.scala
@@ -2,6 +2,8 @@ package spire.math
 
 import spire.algebra.{AdditiveAbGroup, IsReal, MultiplicativeAbGroup, Order, NRoot, Ring, Trig}
 import spire.std._
+import spire.std.double._
+import spire.syntax.nroot._
 
 import scala.{specialized => spec}
 
@@ -28,11 +30,7 @@ object Numeric {
   implicit final val BigDecimalIsNumeric: Numeric[BigDecimal] = new BigDecimalIsNumeric
   implicit final val AlgebraicIsNumeric: Numeric[Algebraic] = new AlgebraicIsNumeric
   implicit final val RealIsNumeric: Numeric[Real] = new RealIsNumeric
-
-  private val defaultApprox = ApproximationContext(Rational(1, 1000000000))
-
-  implicit def RationalIsNumeric(implicit ctx: ApproximationContext[Rational] = defaultApprox): Numeric[Rational] =
-    new RationalIsNumeric
+  implicit final val RationalIsNumeric: Numeric[Rational] = new RationalIsNumeric
 
   implicit def complexIsNumeric[A: Fractional: Trig: IsReal] = new ComplexIsNumeric
 
@@ -113,10 +111,15 @@ with BigDecimalIsReal with Serializable {
 }
 
 @SerialVersionUID(0L)
-private[math] class RationalIsNumeric(implicit val context: ApproximationContext[Rational])
-extends Numeric[Rational] with RationalIsField with RationalIsNRoot
-with ConvertableFromRational with ConvertableToRational
-with RationalIsReal with Serializable {
+private[math] class RationalIsNumeric
+    extends Numeric[Rational]
+    with RationalIsField
+    with RationalApproximateNRoot
+    with ConvertableFromRational
+    with ConvertableToRational
+    with RationalIsReal
+    with Serializable {
+
   override def toDouble(n: Rational): Double = n.toDouble
   override def fromInt(n: Int): Rational = Rational(n)
   override def fromDouble(n: Double): Rational = Rational(n)

--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -137,7 +137,7 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
     @tailrec
     def closest(l: Rational, u: Rational): Rational = {
       val mediant = Rational(l.numerator + u.numerator, l.denominator + u.denominator)
-    
+
       if (mediant.denominator > limit) {
         if ((this - l).abs > (u - this).abs) u else l
       } else if (mediant == this) {
@@ -167,7 +167,7 @@ object Rational extends RationalInstances {
 
   val zero: Rational = LongRational(0L, 1L)
   val one: Rational = LongRational(1L, 1L)
-  
+
   def apply(n: SafeLong, d: SafeLong): Rational = {
     if (d.signum < 0) return apply(-n, -d)
     val g = n gcd d

--- a/core/src/main/scala/spire/math/algebraic/BigDecimalApprox.scala
+++ b/core/src/main/scala/spire/math/algebraic/BigDecimalApprox.scala
@@ -2,7 +2,7 @@ package spire.math.algebraic
 
 import spire.algebra.Sign
 import spire.algebra.Sign.{ Positive, Negative, Zero }
-import spire.math.{Approximation, ApproximationContext, Fractional, Rational}
+import spire.math.{Approximation, Fractional, Rational}
 
 import java.math.MathContext
 
@@ -91,7 +91,7 @@ trait BigDecimalApprox[A <: BigDecimalApprox[A]] extends RealLike[A] with Separa
     case Neg(a) => f.negate(a.simulate[B])
   }
 
-  def toRational(implicit ac: ApproximationContext[Rational] = ApproximationContext(Rational(1L, 10000000000000000L))): Rational = simulate[Rational]
+  def toRational: Rational = simulate[Rational]
 
   def isWhole: Boolean = (this % IntLit(1)).sign == Zero
 

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -210,8 +210,6 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Everybody is Numeric") {
-    implicit val ac = ApproximationContext(Rational(1, 100))
-
     hasNumeric[Int]
     hasNumeric[Long]
     hasNumeric[BigInt]
@@ -223,8 +221,6 @@ class TypeclassExistenceTest extends FunSuite {
   }
 
   test("Float, Double, Rational, BigDecimal, and Algebraic are Fractional") {
-    implicit val ac = ApproximationContext(Rational(1, 100))
-
     hasFractional[Float]
     hasFractional[Double]
     hasFractional[BigDecimal]

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -194,13 +194,11 @@ class TypeclassExistenceTest extends FunSuite {
     hasNRoot[BigDecimal]
   }
 
-  test("Rational is FieldWithNRoot") {
-    implicit val ac = ApproximationContext(Rational(1, 100))
+  test("Rational is Field") {
     hasEq[Rational]
     hasRing[Rational]
     hasEuclideanRing[Rational]
     hasField[Rational]
-    hasNRoot[Rational]
   }
 
   test("Algebraic is FieldWithNRoot") {


### PR DESCRIPTION
This commit tears out support for NRoot[Rational] using
implicit ApproximationContext[Rational] instances. Now
that we have Algebraic and Real, we don't need to support
this case.

We do still have Numeric[Rational] and Fractional[Rational],
but those just use Double approximations. Users who require
more precision can reach for Real or Algebraic.

Fixes #392.