### PR TITLE
Use BigDecimal arithmetic in BigDecimalRootRefinement.

### DIFF
--- a/core/src/main/scala/spire/math/poly/Roots.scala
+++ b/core/src/main/scala/spire/math/poly/Roots.scala
@@ -105,7 +105,7 @@ private[poly] class BigDecimalSimpleRoots(
         value.toBigDecimal(scale, RoundingMode.HALF_EVEN)
       case Bounded(lb, ub, _) =>
         new BigDecimal(
-          BigDecimalRootRefinement(zpoly, lb, ub, scale).approximateValue,
+          BigDecimalRootRefinement(poly, lb, ub, scale).approximateValue,
           MathContext.UNLIMITED
         )
       case _ =>


### PR DESCRIPTION
This gets rid of `BigInt` and `Rational` arithmetic used in `BigDecimalRootRefinement`. The main worry being that very large/small exponents would force us to use a lot of memory unncessarily by forcing them to `BigInt`s or `Rational`s.

This is a partial fix for #431 - which handles the refinement side (but not isolation).