### PR TITLE
Added Merging trait and two implementations

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
@@ -1,0 +1,22 @@
+package spire.benchmark
+
+import spire.implicits._
+import spire.math.Rational
+import spire.math.BinaryMerge
+import spire.math.LinearMerge
+
+import ichi.bench.Thyme
+
+object MergeBenchmark extends App {
+
+  val th = Thyme.warmed(verbose = println)
+  // val th = new Thyme()
+
+  val ar = (0 until 1000).map(Rational.apply).toArray
+  val br = (1000 until 1001).map(Rational.apply).toArray
+  th.pbenchOffWarm("binary merge vs. linear merge (Rational)")(th.Warm(LinearMerge.merge(ar,br)))(th.Warm(BinaryMerge.merge(ar,br)))
+
+  val ai = (0 until 1000).toArray
+  val bi = (1000 until 1001).toArray
+  th.pbenchOffWarm("binary merge vs. linear merge (Int)")(th.Warm(LinearMerge.merge(ai,bi)))(th.Warm(BinaryMerge.merge(ai,bi)))
+}

--- a/core/src/main/scala/spire/math/Merging.scala
+++ b/core/src/main/scala/spire/math/Merging.scala
@@ -1,0 +1,189 @@
+package spire.math
+import spire.algebra.Order
+import scala.{specialized => spec}
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+/**
+ *  Interface for a merging strategy object.
+ */
+trait Merge extends Any {
+  def merge[@spec A: Order: ClassTag](a:Array[A], b:Array[A]): Array[A]
+}
+
+/**
+ * Abstract class that can be used to implement custom binary merges with e.g. special collision behavior or an ordering
+ * that is not defined via an Order[T] typeclass
+ */
+abstract class BinaryMerge {
+
+  private[this] final def binarySearchB(ai: Int, b0: Int, b1: Int): Int = {
+
+    @tailrec
+    def binarySearch0(low: Int, high: Int): Int =
+      if (low <= high) {
+        val mid = (low + high) >>> 1
+        val c = compare(ai, mid)
+        if (c > 0)
+          binarySearch0(mid + 1, high)
+        else if (c < 0)
+          binarySearch0(low, mid - 1)
+        else
+          mid
+      } else -(low + 1)
+    binarySearch0(b0, b1 - 1)
+  }
+
+  /**
+   * Compare element ai of the first sequence with element bi of the second sequence
+   * @param ai an index into the first sequence
+   * @param bi an index into the second sequence
+   * @return -1 if a(ai) &lt; b(bi), 0 if a(ai) == b(bi), 1 if a(ai) &gt; b(bi)
+   */
+  def compare(ai: Int, bi: Int): Int
+
+  /**
+   * Called when elements a(ai) and b(bi) are equal according to compare
+   * @param ai
+   * @param bi
+   */
+  def collision(ai: Int, bi: Int): Unit
+
+  /**
+   * Called for a subsequence of elements of a that are not overlapping any element of b
+   */
+  def fromA(a0: Int, a1: Int, bi: Int): Unit
+
+  /**
+   * Called for a subsequence of elements of b that are not overlapping any element of a
+   */
+  def fromB(ai: Int, b0: Int, b1: Int): Unit
+
+  def merge0(a0: Int, a1: Int, b0: Int, b1: Int): Unit = {
+    if (a0 == a1) {
+      if (b0 != b1)
+        fromB(a0, b0, b1)
+    } else if (b0 == b1) {
+      fromA(a0, a1, b0)
+    } else {
+      val am = (a0 + a1) / 2
+      val res = binarySearchB(am, b0, b1)
+      if (res >= 0) {
+        // same elements
+        val bm = res
+        // merge everything below a(am) with everything below the found element
+        merge0(a0, am, b0, bm)
+        // add the elements a(am) and b(bm)
+        collision(am, bm)
+        // merge everything above a(am) with everything above the found element
+        merge0(am + 1, a1, bm + 1, b1)
+      } else {
+        val bm = -res - 1
+        // merge everything below a(am) with everything below the found insertion point
+        merge0(a0, am, b0, bm)
+        // add a(am)
+        fromA(am, am + 1, bm)
+        // everything above a(am) with everything above the found insertion point
+        merge0(am + 1, a1, bm, b1)
+      }
+    }
+  }
+}
+
+/**
+ *  Merge that uses binary search to reduce the number of comparisons
+ *
+ *  This can be orders of magnitude quicker than a linear merge for types that have a relatively expensive comparison
+ *  operation (e.g. Rational, BigInt, tuples) and will not be much slower than linear merge even in the worst case for
+ *  types that have a very fast comparison (e.g. Int)
+ */
+object BinaryMerge extends Merge {
+
+  def merge[@specialized T: Order: ClassTag](a: Array[T], b: Array[T]): Array[T] = {
+    new ArrayBinaryMerge(a,b).result
+  }
+
+  /*
+  private[this] def resize[T:ClassTag](x:Array[T], n: Int): Array[T] = {
+    if (n == x.length)
+      x
+    else {
+      val t = Array.ofDim[T](n)
+      System.arraycopy(x, 0, t, 0, n)
+      t
+    }
+  }*/
+
+  private class ArrayBinaryMerge[@specialized T](a: Array[T], b: Array[T])(implicit o: Order[T], c: ClassTag[T]) extends BinaryMerge {
+
+    def compare(ai: Int, bi: Int) = o.compare(a(ai), b(bi))
+
+    def fromA(a0: Int, a1: Int, bi: Int) = {
+      System.arraycopy(a, a0, r, ri, a1 - a0)
+      ri += a1 - a0
+    }
+
+    def fromB(ai: Int, b0: Int, b1: Int) = {
+      System.arraycopy(b, b0, r, ri, b1 - b0)
+      ri += b1 - b0
+    }
+
+    def collision(ai: Int, bi: Int) = {
+      r(ri) = a(ai)
+      ri += 1
+      r(ri) = b(bi)
+      ri += 1
+    }
+
+    val r = Array.ofDim[T](a.length + b.length)
+    var ri = 0
+    merge0(0, a.length, 0, b.length)
+
+    def result = r
+  }
+}
+
+/**
+ *  Simple linear merge
+ */
+object LinearMerge extends Merge {
+
+  def merge[@spec T: Order : ClassTag](a: Array[T], b: Array[T]): Array[T] = {
+    val o = implicitly[Order[T]]
+    val r = Array.ofDim[T](a.length + b.length)
+    var ri = 0
+    var ai = 0
+    var bi = 0
+    while (ai < a.length && bi < b.length) {
+      val c = o.compare(a(ai), b(bi))
+      if (c < 0) {
+        r(ri) = a(ai)
+        ri += 1
+        ai += 1
+      } else if (c > 0) {
+        r(ri) = b(bi)
+        ri += 1
+        bi += 1
+      } else {
+        r(ri) = a(ai)
+        ri += 1
+        r(ri) = b(bi)
+        ri += 1
+        ai += 1
+        bi += 1
+      }
+    }
+    while (ai < a.length) {
+      r(ri) = a(ai)
+      ri += 1
+      ai += 1
+    }
+    while (bi < b.length) {
+      r(ri) = b(bi)
+      ri += 1
+      bi += 1
+    }
+    r
+  }
+}

--- a/tests/src/test/scala/spire/math/MergingCheck.scala
+++ b/tests/src/test/scala/spire/math/MergingCheck.scala
@@ -1,0 +1,46 @@
+package spire.math
+
+import java.util.Arrays
+
+import org.scalacheck.{Arbitrary, Properties}
+import org.scalacheck.Prop._
+import spire.implicits._
+
+import scala.reflect.ClassTag
+
+object BinaryMergeCheck extends Properties("QuickArrayMerge") {
+
+  implicit val arbitraryArray = implicitly[Arbitrary[Array[Int]]]
+
+  property("merge") = forAll { (a:Array[Int], b:Array[Int]) =>
+    val r = (a ++ b)
+    Arrays.sort(a)
+    Arrays.sort(b)
+    Arrays.sort(r)
+    val order = new CountingOrder[Int]
+    val r1 = BinaryMerge.merge(a,b)(order, ClassTag.Int)
+    //    val sa = a.mkString(",")
+    //    val sb = b.mkString(",")
+    //    println(s"$sa\n$sb\n")
+    //    true
+    //    val worstCase = math.max(a.length + b.length - 1, 0)
+    //    if(order.count > worstCase) {
+    //      println(s"$worstCase ${order.count}")
+    //    }
+    r1.corresponds(r)(_ == _)
+  }
+
+  property("merge order") = forAll { (a:Array[Int], b:Array[Int]) =>
+    val r = (a ++ b)
+    Arrays.sort(a)
+    Arrays.sort(b)
+    Arrays.sort(r)
+    val o1 = new CountingOrder[Int]
+    val r1 = BinaryMerge.merge(a,b)(o1, ClassTag.Int)
+    val o2 = new CountingOrder[Int]
+    val r2 = BinaryMerge.merge(b,a)(o2, ClassTag.Int)
+    val worstCase = math.max(a.length + b.length - 1, 0)
+    // println(s"${o1.count} ${o2.count} $worstCase")
+    r1.corresponds(r2)(_ == _)
+  }
+}

--- a/tests/src/test/scala/spire/math/MergingTest.scala
+++ b/tests/src/test/scala/spire/math/MergingTest.scala
@@ -1,0 +1,39 @@
+package spire.math
+
+import spire.implicits._
+import org.scalatest.FunSuite
+import spire.algebra.Order
+
+import scala.reflect.ClassTag
+
+class CountingOrder[T:Order] extends Order[T] {
+  val wrapped = implicitly[Order[T]]
+  var count = 0
+
+  override def compare(x: T, y: T): Int = {
+    count += 1
+    wrapped.compare(x, y)
+  }
+}
+
+class MergingTest extends FunSuite {
+
+  test("binary merge") {
+    val a = Array.range(0,100).map(_ * 2)
+    val b = Array.range(1,100).map(_ * 2)
+    val o = new CountingOrder[Int]
+    val r = BinaryMerge.merge(a,b)(o, ClassTag.Int)
+    assert(r.sorted.corresponds(r)(_ == _))
+    assert(o.count < 200)
+  }
+
+  test("linear merge") {
+    val a = Array.range(0,100).map(_ * 2)
+    val b = Array.range(1,100).map(_ * 3)
+    val o = new CountingOrder[Int]
+    val r1 = LinearMerge.merge(a,b)(o, ClassTag.Int)
+    val r2 = LinearMerge.merge(b,a)(o, ClassTag.Int)
+    assert(r1.sorted.corresponds(r1)(_ == _))
+    assert(r2.sorted.corresponds(r2)(_ == _))
+  }
+}


### PR DESCRIPTION
This is an algorithm to merge two arrays with a minimum number of comparisons. It is usually faster than the naive linear merge implementation even for types with a cheap compare operation such as Int, because it copies large segments using System.arraycopy. For types with a comparatively expensive comparison operation, such as Rational or String, the gain is even larger.

This also adds tests and checks. Test coverage for the new code should be 100%
There is also a small Thyme-based benchmark that shows the advantage over a linear merge. I am not sure what is the best place to put thyme-based benchmarks.