### PR TITLE
New spire.stats package

### DIFF
--- a/core/src/main/scala/spire/stats/Distribution.scala
+++ b/core/src/main/scala/spire/stats/Distribution.scala
@@ -1,0 +1,33 @@
+package spire.stats.distribution
+
+import spire.random.Generator
+
+trait Distribution[A] {
+
+  /** Function used to transform the values drawn from a Generator according to this probability distribution function
+    */
+  private[stats] val transform: (Generator => A)
+}
+
+trait ContinuousDistribution[A] extends Distribution[A] {
+
+  /** Returns the probability density function (pdf) of this distribution at the value x
+    */
+  def pdf(x: A): A
+
+  /** Returns the cumulative distribution function (cdf) of this distribution at the value x
+    */
+  def cdf(x: A): A
+}
+
+trait DiscreteDistribution[A] extends Distribution[A] {
+
+  /** Returns the probability mass function (pmf) of this distribution at the value x
+    */
+  def pmf(x: A): A
+
+  /** Returns the cumulative distribution function (cdf) of this distribution at the value x
+    */
+  def cdf(x: A): A
+}
+

--- a/core/src/main/scala/spire/stats/Distribution.scala
+++ b/core/src/main/scala/spire/stats/Distribution.scala
@@ -31,3 +31,16 @@ trait DiscreteDistribution[A] extends Distribution[A] {
   def cdf(x: A): A
 }
 
+// Should a method that returns the next random value based on a
+// specified type be included in the Generator class itself?
+object RichGenerator {
+  import scala.reflect.runtime.universe._
+
+  implicit class RichGenerator(gen: Generator) {
+    def next0[A : TypeTag](): A = typeOf[A] match {
+      case t if t =:= typeOf[Double] => gen.nextDouble.asInstanceOf[A]
+      case _ => ???
+    }
+  }
+}
+

--- a/core/src/main/scala/spire/stats/Exponential.scala
+++ b/core/src/main/scala/spire/stats/Exponential.scala
@@ -1,0 +1,52 @@
+package spire.stats.distribution
+
+import scala.reflect.runtime.universe._
+import spire.algebra._
+import spire.random.Generator
+import spire.random.Ziggurat
+
+trait ExponentialDistribution[A] extends ContinuousDistribution[A] {
+  val mode: A
+  val rate: A
+}
+
+object Exponential {
+  def Standard[A: Field: Trig: IsReal: TypeTag](): ExponentialDistribution[A] = new StandardExponentialDistributionImpl[A]()
+
+  def apply[A: Field: Trig: IsReal: TypeTag](mode: A, rate: A): ExponentialDistribution[A] = new ExponentialDistributionImpl[A](mode, rate)
+
+  class StandardExponentialDistributionImpl[A: Field: Trig: IsReal: TypeTag] extends ExponentialDistribution[A] {
+    import spire.math._
+    import spire.syntax.field._
+    import spire.syntax.isReal._
+
+    val mode = Field[A].zero
+    val rate = Field[A].one
+
+    private[stats] val transform: (Generator => A) = (gen => Field[A].fromDouble(Ziggurat.rexp(gen)))
+
+    def pdf(x: A): A = x match {
+      case x if (x < Field[A].zero) => Field[A].zero
+      case _ => exp(-x)
+    }
+
+    def cdf(x: A): A = x match {
+      case x if (x < Field[A].zero) => Field[A].zero
+      case _ => Field[A].one - exp(-x)
+    }
+  }
+
+  class ExponentialDistributionImpl[A: Field: Trig: IsReal: TypeTag](val mode: A, val rate: A) extends ExponentialDistribution[A] {
+    import spire.syntax.field._
+
+    val family = new LocationScaleFamily[A] {
+      val stdDist = Standard[A]
+      val location = mode
+      val scale = Field[A].one / rate
+    }
+    private[stats] val transform = family.transform
+    def pdf(x: A) = family.pdf(x)
+    def cdf(x: A) = family.cdf(x)
+  }
+}
+

--- a/core/src/main/scala/spire/stats/LocationScaleFamily.scala
+++ b/core/src/main/scala/spire/stats/LocationScaleFamily.scala
@@ -1,0 +1,27 @@
+package spire.stats.distribution
+
+import spire.algebra._
+import spire.random.Generator
+import spire.syntax.field._
+
+/** In a location-scale family a general distribution can be written as
+  * a function of the standard distribution (zero location and unit
+  * scale) and its own location and scale.
+  *
+  * @see [[http://en.wikipedia.org/wiki/Location-scale_family]]
+  */
+abstract class LocationScaleFamily[A: Field] {
+  val stdDist: ContinuousDistribution[A]
+  val location: A
+  val scale: A
+
+  def pdf(x: A): A =
+    Field[A].one / scale * stdDist.pdf((x - location) / scale)
+
+  def cdf(x: A): A =
+    stdDist.cdf((x - location) / scale)
+
+  lazy val transform: (Generator => A) =
+    stdDist.transform andThen (_ * scale + location)
+}
+

--- a/core/src/main/scala/spire/stats/Normal.scala
+++ b/core/src/main/scala/spire/stats/Normal.scala
@@ -1,0 +1,57 @@
+package spire.stats.distribution
+
+import scala.reflect.runtime.universe._
+import spire.algebra._
+import spire.random.Generator
+import spire.random.Ziggurat
+
+trait NormalDistribution[A] extends ContinuousDistribution[A] {
+  val mean: A
+  val stdDev: A
+}
+
+object Normal {
+  def Standard[A: Field: Trig: IsReal: TypeTag](): NormalDistribution[A] = new StandardNormalDistributionImpl[A]()
+
+  def apply[A: Field: Trig: IsReal: TypeTag](min: A, max: A): NormalDistribution[A] = new NormalDistributionImpl[A](min, max)
+
+  class StandardNormalDistributionImpl[A: Field: Trig: IsReal: TypeTag] extends NormalDistribution[A] {
+    import spire.math._
+    import spire.syntax.field._
+    import spire.syntax.trig._
+    import spire.syntax.isReal._
+
+    val mean = Field[A].zero
+    val stdDev = Field[A].one
+
+    private[stats] val transform: (Generator => A) = (gen => Field[A].fromDouble(Ziggurat.rnor(gen)))
+
+    def pdf(x: A): A = {
+      exp(-0.5 * x * x) / sqrt(2 * pi)
+    }
+
+    def cdf(x: A): A = {
+      0.5 * (1 + erf(x / sqrt(2)))
+    }
+
+    private def erf(x: A): A = if (x.signum < 0) {
+      -erf(-x)
+    } else {
+      val t = 1 / (1 + 0.3275911 * x)
+      val y = t * (0.254829592 + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))))
+      1 - y * (-x * x).exp()
+    }
+  }
+
+  class NormalDistributionImpl[A: Field: Trig: IsReal: TypeTag](val mean: A, val stdDev: A) extends NormalDistribution[A] {
+    val family = new LocationScaleFamily[A] {
+      val stdDist = Standard[A]
+      val location = mean
+      val scale = stdDev
+    }
+    private[stats] val transform = family.transform
+    def pdf(x: A) = family.pdf(x)
+    def cdf(x: A) = family.cdf(x)
+  }
+}
+

--- a/core/src/main/scala/spire/stats/RandomVariable.scala
+++ b/core/src/main/scala/spire/stats/RandomVariable.scala
@@ -1,0 +1,40 @@
+package spire.stats
+
+import scala.reflect.ClassTag
+import spire.random.Generator
+import spire.stats.distribution.Distribution
+
+sealed abstract class RandomVariable[A] {
+
+  /** Generates a random number according to this variable's probability distribution function
+    */
+  def observe(gen: Generator): A
+
+  /** Generates an array of random numbers according to this variable's probability distribution function
+    */
+  def observeMany(gen: Generator, count: Int)(implicit ev: ClassTag[A]): Array[A] = {
+    val arr = Array.ofDim[A](count)
+    fill(gen, arr)
+    
+    arr
+  }
+
+  /** Fills an array of random numbers according to this variable's probability distribution function
+    */
+  def fill(gen: Generator, arr: Array[A]): Unit = {
+    var i = 0
+    while (i < arr.length) {
+      arr(i) = observe(gen)
+      i += 1
+    }
+  }
+}
+
+object RandomVariable {
+  def apply[A](distribution: Distribution[A]) = new RandomVariableWithDistribution(distribution)
+}
+
+class RandomVariableWithDistribution[A](distribution: Distribution[A]) extends RandomVariable[A] {
+  def observe(gen: Generator) = distribution.transform(gen)
+}
+

--- a/core/src/main/scala/spire/stats/Uniform.scala
+++ b/core/src/main/scala/spire/stats/Uniform.scala
@@ -11,9 +11,33 @@ trait UniformDistribution[A] extends ContinuousDistribution[A] {
 }
 
 object Uniform {
-  def Standard[A: Field: IsReal: TypeTag](): UniformDistribution[A] = new StandardUniformDistributionImpl[A]()
+  def Standard[A: Field: IsReal: TypeTag: StandardBuilder](): UniformDistribution[A] = implicitly[StandardBuilder[A]].apply()
 
-  def apply[A: Field: IsReal: TypeTag](min: A, max: A): UniformDistribution[A] = new UniformDistributionImpl[A](min, max)
+  def apply[A: Field: IsReal: TypeTag: Builder](min: A, max: A): UniformDistribution[A] = implicitly[Builder[A]].apply(min, max)
+
+  abstract class StandardBuilder[A: Field: IsReal: TypeTag] {
+    def apply(): UniformDistribution[A]
+  }
+
+  abstract class Builder[A: Field: IsReal: TypeTag] {
+    def apply(min: A, max: A): UniformDistribution[A]
+  }
+
+  object StandardBuilder {
+    import spire.std.double._
+
+    implicit val doubleBuilder = new StandardBuilder[Double] {
+      def apply() = new StandardUniformDistributionImpl()
+    }
+  }
+
+  object Builder {
+    import spire.std.double._
+
+    implicit val doubleBuilder = new Builder[Double] {
+      def apply(min: Double, max: Double) = new UniformDistributionImpl(min, max)
+    }
+  }
 
   class StandardUniformDistributionImpl[A: Field: IsReal: TypeTag] extends UniformDistribution[A] {
     import spire.syntax.isReal._
@@ -36,7 +60,7 @@ object Uniform {
     }
   }
 
-  class UniformDistributionImpl[A: Field: IsReal: TypeTag](val min: A, val max: A) extends UniformDistribution[A] {
+  class UniformDistributionImpl[A: Field: IsReal: TypeTag: StandardBuilder](val min: A, val max: A) extends UniformDistribution[A] {
     import spire.syntax.field._
 
     val family = new LocationScaleFamily[A] {

--- a/core/src/main/scala/spire/stats/test/AndersonDarling.scala
+++ b/core/src/main/scala/spire/stats/test/AndersonDarling.scala
@@ -1,0 +1,44 @@
+package spire.stats.test
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+import spire.algebra._
+import spire.stats.distribution._
+
+object AndersonDarling {
+  import spire.syntax.field._
+  import spire.syntax.trig._
+  import spire.syntax.isReal._
+  import spire.syntax.std.array._
+
+  def apply[A: Field: Trig: IsReal: ClassTag, B <: ContinuousDistribution[A]](xs: Array[A], dist: B): (A, Seq[A], Seq[A]) = {
+    val cxs = xs.clone
+
+    @tailrec def loop(sum: A, i: Int, a: A, b: A): A = if (i < cxs.length) {
+      val y = dist.cdf(cxs(i))
+      val k = a * y.log + b * (1 - y).log
+      loop(sum + k, i + 1, a + 2, b - 2)
+    } else sum
+
+    cxs.qsort
+    val n = Field[A].fromInt(cxs.length)
+    val sum = loop(Field[A].zero, 0, Field[A].one, 2 * n - 1)
+    val statistic = -n - sum / n
+    val significanceLevels = Seq(0.15, 0.10, 0.05, 0.025, 0.01).map(Field[A].fromDouble)
+    val criticalValues = Seq(1.610, 1.933, 2.492, 3.070, 3.857).map(Field[A].fromDouble)
+    
+    (statistic, significanceLevels, criticalValues)
+  }
+
+  def rejectedAt[A: Field: Trig: IsReal: ClassTag, B <: ContinuousDistribution[A]](xs: Array[A], dist: B, significanceLevel: A): Boolean = {
+    val (statistic, significanceLevels, criticalValues) = apply(xs, dist)
+    
+    val res = (significanceLevels zip criticalValues).find { case (sl, _) => sl == significanceLevel }
+
+    res match {
+      case Some((_, cv)) => statistic > cv
+      case _ => ???
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/ExponentialRandomVariableSpec.scala
+++ b/tests/src/test/scala/spire/stats/ExponentialRandomVariableSpec.scala
@@ -1,0 +1,37 @@
+package spire.stats
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class ExponentialRandomVariableSpec extends WordSpec with Matchers  {
+
+  val srv = RandomVariable(distribution.Exponential.Standard[Double])
+
+  "A random variable with normal distribution" should {
+    val dist = distribution.Exponential[Double](1.0, 0.5)
+    val grv = RandomVariable(dist)
+
+    info("as a member of a location-scale family")
+    "observe values equal to standard distribution's values scaled and shifted" in {
+      val gen1 = spire.random.rng.Lcg64.fromTime(42L)
+      val gen2 = spire.random.rng.Lcg64.fromTime(42L)
+
+      val result = grv.observeMany(gen1, 20)
+      val expected = srv.observeMany(gen2, 20).map(_ * 2 + 1)
+
+      result should equal (expected)
+    }
+
+    "observe values according to its probability distribution function" in {
+      val gen = spire.random.rng.Lcg64.fromTime(42L)
+      val ys = grv.observeMany(gen, 20)
+
+      val rejected = test.AndersonDarling.rejectedAt(ys, dist, 0.05)
+
+      rejected should equal (false)
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/ExponentialSpec.scala
+++ b/tests/src/test/scala/spire/stats/ExponentialSpec.scala
@@ -1,0 +1,128 @@
+package spire.stats.distribution
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class ExponentialSpec extends WordSpec with Matchers with TableDrivenPropertyChecks {
+
+  "A standard exponential distribution (mode == 0 and rate == 1)" should {
+    val standard = Exponential.Standard[Double]
+
+    "have pdf equals to exp(-x) for x >= 0" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          ( 0.0, 1.000000000),
+          ( 1.0, 0.367879441),
+          ( 2.0, 0.135335283),
+          ( 3.0, 0.049787068)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have pdf equals to 0 for x < 0" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          (-3.0, 0.0),
+          (-2.0, 0.0),
+          (-1.0, 0.0)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to (1 - exp(-x)) for x >= 0" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 0.0, 0.000000000),
+          ( 1.0, 0.632120559),
+          ( 2.0, 0.864664717),
+          ( 3.0, 0.950212932)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to 0 for x < 0" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          (-3.0, 0.0),
+          (-2.0, 0.0),
+          (-1.0, 0.0)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf +- 1e-5)
+      }
+    }
+  }
+
+  "An exponential distribution with mode == 1 and rate == 0.5" should {
+    val general = Exponential[Double](1.0, 0.5)
+
+    info("for z = (x - mode) * rate")
+    "have pdf equals to exp(-z) for z >= 0" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          ( 1.0, 0.500000000),
+          ( 3.0, 0.183939720),
+          ( 5.0, 0.067667641),
+          ( 7.0, 0.024893534)
+        )
+      forAll(pdfs) { (z: Double, pdf: Double) =>
+        general.pdf(z) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have pdf equals to 0 for z < 0" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          (-5.0, 0.0),
+          (-3.0, 0.0),
+          (-1.0, 0.0)
+        )
+      forAll(pdfs) { (z: Double, pdf: Double) =>
+        general.pdf(z) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to (1 - exp(-z)) for z >= 0" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 1.0, 0.000000000),
+          ( 3.0, 0.632120559),
+          ( 5.0, 0.864664717),
+          ( 7.0, 0.950212932)
+        )
+      forAll(cdfs) { (z: Double, cdf: Double) =>
+        general.cdf(z) should equal (cdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to 0 for z < 0" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          (-5.0, 0.0),
+          (-3.0, 0.0),
+          (-1.0, 0.0)
+        )
+      forAll(cdfs) { (z: Double, cdf: Double) =>
+        general.cdf(z) should equal (cdf +- 1e-5)
+      }
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/NormalRandomVariableSpec.scala
+++ b/tests/src/test/scala/spire/stats/NormalRandomVariableSpec.scala
@@ -1,0 +1,37 @@
+package spire.stats
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class NormalRandomVariableSpec extends WordSpec with Matchers {
+
+  val srv = RandomVariable(distribution.Normal.Standard[Double])
+
+  "A random variable with normal distribution" should {
+    val dist = distribution.Normal[Double](1.0, 2.0)
+    val grv = RandomVariable(dist)
+
+    info("as a member of a location-scale family")
+    "observe values equal to standard distribution's values scaled and shifted" in {
+      val gen1 = spire.random.rng.Lcg64.fromTime(42L)
+      val gen2 = spire.random.rng.Lcg64.fromTime(42L)
+
+      val result = grv.observeMany(gen1, 20)
+      val expected = srv.observeMany(gen2, 20).map(_ * 2 + 1)
+
+      result should equal (expected)
+    }
+
+    "observe values according to its probability distribution function" in {
+      val gen = spire.random.rng.Lcg64.fromTime(42L)
+      val ys = grv.observeMany(gen, 20)
+
+      val rejected = test.AndersonDarling.rejectedAt(ys, dist, 0.05)
+
+      rejected should equal (false)
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/NormalSpec.scala
+++ b/tests/src/test/scala/spire/stats/NormalSpec.scala
@@ -1,0 +1,88 @@
+package spire.stats.distribution
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class NormalSpec extends WordSpec with Matchers with TableDrivenPropertyChecks {
+
+  "A standard normal distribution (mean == 0 and stdDev == 1)" should {
+    val standard = Normal.Standard[Double]
+
+    "have pdf equals to phi(x)" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          (-3.0, 0.00443),
+          (-2.0, 0.05399),
+          (-1.0, 0.24197),
+          ( 0.0, 0.39894),
+          ( 1.0, 0.24197),
+          ( 2.0, 0.05399),
+          ( 3.0, 0.00443)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to Phi(x)" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          (-3.0, 0.00135),
+          (-2.0, 0.02275),
+          (-1.0, 0.15866),
+          ( 0.0, 0.50000),
+          ( 1.0, 0.84134),
+          ( 2.0, 0.97725),
+          ( 3.0, 0.99865)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf +- 1e-5)
+      }
+    }
+  }
+
+  "A normal distribution with mean == 1 and stdDev == 2" should {
+    val general = Normal[Double](1.0, 2.0)
+
+    info("for z = (x - mean) / stdDev")
+    "have pdf equals to phi(z) / stdDev" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          (-5.0, 0.00222),
+          (-3.0, 0.02700),
+          (-1.0, 0.12099),
+          ( 1.0, 0.19947),
+          ( 3.0, 0.12099),
+          ( 5.0, 0.02700),
+          ( 7.0, 0.00222)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        general.pdf(x) should equal (pdf +- 1e-5)
+      }
+    }
+
+    "have cdf equals to Phi(z)" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          (-5.0, 0.00135),
+          (-3.0, 0.02275),
+          (-1.0, 0.15866),
+          ( 1.0, 0.50000),
+          ( 3.0, 0.84134),
+          ( 5.0, 0.97725),
+          ( 7.0, 0.99865)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        general.cdf(x) should equal (cdf +- 1e-5)
+      }
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/UniformRandomVariableSpec.scala
+++ b/tests/src/test/scala/spire/stats/UniformRandomVariableSpec.scala
@@ -1,0 +1,50 @@
+package spire.stats
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class UniformRandomVariableSpec extends WordSpec with Matchers {
+
+  val srv = RandomVariable(distribution.Uniform.Standard[Double])
+
+  "A random variable with standard uniform distribution" should {
+    "observe values equal to underlying generator's values" in {
+      val gen1 = spire.random.rng.Lcg64.fromTime(42L)
+      val gen2 = spire.random.rng.Lcg64.fromTime(42L)
+
+      val result = srv.observeMany(gen1, 20)
+      val expected = Array.fill(20)(gen2.nextDouble)
+
+      result should equal (expected)
+    }
+  }
+
+  "A random variable with uniform distribution" should {
+    val dist = distribution.Uniform[Double](1.0, 3.0)
+    val grv = RandomVariable(dist)
+
+    info("as a member of a location-scale family")
+    "observe values equal to standard distribution's values scaled and shifted" in {
+      val gen1 = spire.random.rng.Lcg64.fromTime(42L)
+      val gen2 = spire.random.rng.Lcg64.fromTime(42L)
+
+      val result = grv.observeMany(gen1, 20)
+      val expected = srv.observeMany(gen2, 20).map(_ * 2 + 1)
+
+      result should equal (expected)
+    }
+
+    "observe values according to its probability distribution function" in {
+      val gen = spire.random.rng.Lcg64.fromTime(42L)
+      val ys = grv.observeMany(gen, 20)
+
+      val rejected = test.AndersonDarling.rejectedAt(ys, dist, 0.05)
+
+      rejected should equal (false)
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/UniformSpec.scala
+++ b/tests/src/test/scala/spire/stats/UniformSpec.scala
@@ -1,0 +1,139 @@
+package spire.stats.distribution
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class UniformSpec extends WordSpec with Matchers with TableDrivenPropertyChecks {
+
+  "A standard uniform distribution (min == 0 and max == 1)" should {
+    val standard = Uniform.Standard[Double]
+
+    "have pdf equals to 1 for 0 <= x <= 1" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          ( 0.0, 1.0),
+          ( 0.5, 1.0),
+          ( 1.0, 1.0)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf)
+      }
+    }
+
+    "have pdf equals to 0 for x < 0 or 1 < x" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          (-0.5, 0.0),
+          ( 1.5, 0.0)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf)
+      }
+    }
+
+    "have cdf equals to 0 for x <= 0" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          (-0.5, 0.0),
+          ( 0.0, 0.0)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+
+    "have cdf equals to x for 0 <= x <= 1" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 0.5, 0.5)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+
+    "have cdf equals to 1 for 1 <= x" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 1.0, 1.0),
+          ( 1.5, 1.0)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+  }
+
+  "An uniform distribution with min == 1 and max == 3" should {
+    val standard = Uniform[Double](1.0, 3.0)
+
+    "have pdf equals to (1 / (max - min)) for min <= x <= max" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          ( 1.0, 0.5),
+          ( 2.0, 0.5),
+          ( 3.0, 0.5)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf)
+      }
+    }
+
+    "have pdf equals to 0 for x < min or max < x" in {
+      val pdfs =
+        Table(
+          ("x", "pdf"),
+          ( 0.5, 0.0),
+          ( 3.5, 0.0)
+        )
+      forAll(pdfs) { (x: Double, pdf: Double) =>
+        standard.pdf(x) should equal (pdf)
+      }
+    }
+
+    "have cdf equals to 0 for x <= min" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 0.5, 0.0),
+          ( 1.0, 0.0)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+
+    "have cdf equals to (x - a) / (b - a) for min <= x <= max" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 2.0, 0.5)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+
+    "have cdf equals to 1 for max <= x" in {
+      val cdfs =
+        Table(
+          ("x", "cdf"),
+          ( 3.0, 1.0),
+          ( 3.5, 1.0)
+        )
+      forAll(cdfs) { (x: Double, cdf: Double) =>
+        standard.cdf(x) should equal (cdf)
+      }
+    }
+  }
+}
+

--- a/tests/src/test/scala/spire/stats/test/AndersonDarlingTestSpec.scala
+++ b/tests/src/test/scala/spire/stats/test/AndersonDarlingTestSpec.scala
@@ -1,0 +1,50 @@
+package spire.stats.test
+
+import spire.std.double._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class AndersonDarlingSpec extends WordSpec with Matchers {
+
+  "The Anderson–Darling test" should {
+    "calculate a statistic that quantifies if the values were drawn from a standard uniform distribution" in {
+      val dist = spire.stats.distribution.Uniform.Standard[Double]
+      val n = 5
+      val ys = Array(0.3, 0.1, 0.9, 0.5, 0.7)
+      val lncdfs = Array(-2.302585093, -1.203972804, -0.693147181, -0.356674944, -0.105360516)
+      val ln1cdfs = lncdfs.reverse
+
+      val expected = -n - (1.0 / n) * (
+        1 * lncdfs(0) + 9 * ln1cdfs(0) +
+        3 * lncdfs(1) + 7 * ln1cdfs(1) +
+        5 * lncdfs(2) + 5 * ln1cdfs(2) +
+        7 * lncdfs(3) + 3 * ln1cdfs(3) +
+        9 * lncdfs(4) + 1 * ln1cdfs(4)
+      )
+
+      val (result, _, _) = AndersonDarling(ys, dist)
+
+      result should equal (expected +- 1e-8)
+    }
+
+    "calculate a statistic that quantifies if the values were drawn from a normal distribution" in {
+      // from: D'Agostino, Stephens. (1986). "Goodness-of-fit-techniques."
+      val chickData: Array[Double] = Array(
+        156,162,168,182,186,
+        190,190,196,202,210,
+        214,220,226,230,230,
+        236,236,242,246,270
+      )
+
+      val dist = spire.stats.distribution.Normal(200.0, 35.0)
+
+      val expected = 1.0169
+
+      val (result, _, _) = AndersonDarling(chickData, dist)
+
+      result should equal (expected +- 1e-4)
+    }
+  }
+}
+


### PR DESCRIPTION
Hi,
I thought about an alternate proposal for the `random` package as seen in #214.
In the present structure, `random.Dist` is a way of producing arbitrary values from a `Generator`. However a probability distribution should be a way of assign a probability to each measurable subset of the possible outcomes of a random experiment [1], i.e. you should be able to ask it for pdf, cdf, mean etc. The mechanism for production of values according to a probability distribution function should in reality be a random variable [2].
With the proposed separation it should be possible to characterize a probability distribution and still be able to modify the production of values from the `Generator` (the role of `random.Dist` would basically go to `stats.RandomVariable`).
`stats.Distribution` and `stats.RandomVariable` would be immutable.
Maybe it's possible to have some random variable `Z` to be a combination of random variables `X` and `Y`, as `Z = X + Y`.
Anyway I made a few scratches but I would like your blessing ;) to see if this is a good strategy.

[1] http://en.wikipedia.org/wiki/Probability_distribution
[2] http://en.wikipedia.org/wiki/Random_variable
