### PR TITLE
Typeclass instances for Unit

### DIFF
--- a/core/src/main/scala/spire/std/any.scala
+++ b/core/src/main/scala/spire/std/any.scala
@@ -17,3 +17,4 @@ trait AnyInstances extends BooleanInstances
     with MapInstances
     with ProductInstances
     with OptionInstances
+    with UnitInstances

--- a/core/src/main/scala/spire/std/package.scala
+++ b/core/src/main/scala/spire/std/package.scala
@@ -21,4 +21,5 @@ package object std {
   object map extends MapInstances
   object tuples extends ProductInstances
   object option extends OptionInstances
+  object unit extends UnitInstances
 }

--- a/core/src/main/scala/spire/std/unit.scala
+++ b/core/src/main/scala/spire/std/unit.scala
@@ -1,6 +1,6 @@
 package spire.std
 
-import spire.algebra.Order
+import spire.algebra.{Field, AbGroup, Order}
 
 trait UnitOrder extends Order[Unit] with Serializable {
   override def eqv(x:Unit, y:Unit): Boolean = true
@@ -15,8 +15,14 @@ trait UnitOrder extends Order[Unit] with Serializable {
   def compare(x: Unit, y: Unit): Int = 0
 }
 
+trait UnitAbGroup extends AbGroup[Unit] {
+  override def inverse(a: Unit): Unit = {}
+  override def id: Unit = {}
+  override def op(x: Unit, y: Unit): Unit = {}
+}
+
 @SerialVersionUID(0L)
-class UnitAlgebra extends UnitOrder with Serializable
+class UnitAlgebra extends UnitAbGroup with UnitOrder with Serializable
 
 trait UnitInstances {
   implicit final val UnitAlgebra = new UnitAlgebra

--- a/core/src/main/scala/spire/std/unit.scala
+++ b/core/src/main/scala/spire/std/unit.scala
@@ -1,6 +1,6 @@
 package spire.std
 
-import spire.algebra.{Field, AbGroup, Order}
+import spire.algebra.{AbGroup, Order}
 
 trait UnitOrder extends Order[Unit] with Serializable {
   override def eqv(x:Unit, y:Unit): Boolean = true

--- a/core/src/main/scala/spire/std/unit.scala
+++ b/core/src/main/scala/spire/std/unit.scala
@@ -1,0 +1,23 @@
+package spire.std
+
+import spire.algebra.Order
+
+trait UnitOrder extends Order[Unit] with Serializable {
+  override def eqv(x:Unit, y:Unit): Boolean = true
+  override def neqv(x:Unit, y:Unit): Boolean = false
+  override def gt(x: Unit, y: Unit): Boolean = false
+  override def lt(x: Unit, y: Unit): Boolean = false
+  override def gteqv(x: Unit, y: Unit): Boolean = true
+  override def lteqv(x: Unit, y: Unit): Boolean = true
+
+  override def min(x: Unit, y: Unit): Unit = {}
+  override def max(x: Unit, y: Unit): Unit = {}
+  def compare(x: Unit, y: Unit): Int = 0
+}
+
+@SerialVersionUID(0L)
+class UnitAlgebra extends UnitOrder with Serializable
+
+trait UnitInstances {
+  implicit final val UnitAlgebra = new UnitAlgebra
+}

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -112,6 +112,7 @@ class LawTests extends FunSuite with Discipline {
   }
 
   checkAll("Order[Int]", OrderLaws[Int].order)
+  checkAll("Order[Unit]", OrderLaws[Unit].order)
   checkAll("LatticePartialOrder[Int]", LatticePartialOrderLaws[Int].boundedLatticePartialOrder(intMinMaxLattice, implicitly[Order[Int]]))
 
   checkAll("Map[Int, Int]", PartialActionLaws.apply[Map[Int, Int], Seq[Int]](implicitly, Arbitrary(arbPerm.arbitrary.map(_.map)), implicitly, implicitly).groupPartialAction)

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -113,6 +113,7 @@ class LawTests extends FunSuite with Discipline {
 
   checkAll("Order[Int]", OrderLaws[Int].order)
   checkAll("Order[Unit]", OrderLaws[Unit].order)
+  checkAll("AbGroup[Unit]", GroupLaws[Unit].abGroup)
   checkAll("LatticePartialOrder[Int]", LatticePartialOrderLaws[Int].boundedLatticePartialOrder(intMinMaxLattice, implicitly[Order[Int]]))
 
   checkAll("Map[Int, Int]", PartialActionLaws.apply[Map[Int, Int], Seq[Int]](implicitly, Arbitrary(arbPerm.arbitrary.map(_.map)), implicitly, implicitly).groupPartialAction)

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -17,6 +17,10 @@ import org.scalatest.FunSuite
  */
 class TypeclassExistenceTest extends FunSuite {
 
+  def hasAbGroup[A](implicit g: AbGroup[A] = null, m: ClassTag[A]): Unit = {
+    assert(g != null, "Expected implicit AbGroup[%s] instance, but it was not found." format m)
+  }
+
   def hasRig[A](implicit rig: Rig[A] = null, m: ClassTag[A]): Unit = {
     assert(rig != null, "Expected implicit Rig[%s] instance, but it was not found." format m)
   }
@@ -125,6 +129,7 @@ class TypeclassExistenceTest extends FunSuite {
   test("Unit has Eq:Order") {
     hasEq[Unit]
     hasOrder[Unit]
+    hasAbGroup[Unit]
   }
 
   test("UByte has Eq:Order:Rig") {

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -122,6 +122,11 @@ class TypeclassExistenceTest extends FunSuite {
     check[Double]
   }
 
+  test("Unit has Eq:Order") {
+    hasEq[Unit]
+    hasOrder[Unit]
+  }
+
   test("UByte has Eq:Order:Rig") {
     hasEq[UByte]
     hasOrder[UByte]


### PR DESCRIPTION
This provides some trivial but useful typeclass instances for Unit. So far I only implemented Eq[Unit] and Order[Unit], since these are the ones that I need.

I am not sure if I did the typeclass instance machinery correctly. #315 is not implemented yet, so I just looked at some of the other classes in spire/std and tried to copy things.

Implements #463 

Review by @non @tixxit