### PR TITLE
Add qcombine method on ArrayOps and SeqOps

### DIFF
--- a/core/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/src/main/scala/spire/syntax/std/Ops.scala
@@ -5,9 +5,10 @@ import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 import scala.{specialized => sp}
 
-import spire.algebra.{AdditiveMonoid, Field, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
+import spire.algebra.{AdditiveMonoid, Field, Monoid, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}
 import spire.syntax.cfor._
+import spire.syntax.monoid._
 import spire.syntax.field._
 import spire.syntax.nroot._
 import spire.syntax.order._
@@ -84,6 +85,12 @@ final class ArrayOps[@sp A](arr: Array[A]) {
   def qproduct(implicit ev: MultiplicativeMonoid[A]): A = {
     var result = ev.one
     cfor(0)(_ < arr.length, _ + 1) { i => result *= arr(i) }
+    result
+  }
+
+  def qcombine(implicit ev: Monoid[A]): A = {
+    var result = ev.id
+    cfor(0)(_ < arr.length, _ + 1) { i => result |+|= arr(i) }
     result
   }
 
@@ -210,6 +217,9 @@ final class SeqOps[@sp A, CC[A] <: Iterable[A]](as: CC[A]) { //fixme
 
   def qproduct(implicit ev: MultiplicativeMonoid[A]): A =
     as.aggregate(ev.one)(ev.times, ev.times)
+
+  def qcombine(implicit ev: Monoid[A]): A =
+    as.aggregate(ev.id)(ev.op, ev.op)
 
   def qnorm(p: Int)(implicit ev: Field[A], s: Signed[A], nr: NRoot[A]): A =
     as.aggregate(ev.one)(_ + _.abs.pow(p), _ + _).nroot(p)


### PR DESCRIPTION
provides a generalised qsum/qproduct for when the type of monoid is irrelevant

named after the corresponding method on Monoid