### PR TITLE
Consistent unsigned unary negate

### DIFF
--- a/core/src/main/scala/spire/math/UInt.scala
+++ b/core/src/main/scala/spire/math/UInt.scala
@@ -36,7 +36,7 @@ class UInt(val signed: Int) extends AnyVal {
   def >= (that: UInt): Boolean = this.toLong >= that.toLong
   def > (that: UInt): Boolean = this.toLong > that.toLong
 
-  def unary_- : UInt = UInt(this.signed)
+  def unary_- : UInt = UInt(-this.signed)
 
   def + (that: UInt): UInt = UInt(this.signed + that.signed)
   def - (that: UInt): UInt = UInt(this.signed - that.signed)

--- a/core/src/main/scala/spire/math/ULong.scala
+++ b/core/src/main/scala/spire/math/ULong.scala
@@ -80,7 +80,7 @@ class ULong(val signed: Long) extends AnyVal {
   @inline final def >= (that: ULong): Boolean = that <= this
   @inline final def > (that: ULong): Boolean = that < this
 
-  final def unary_- : ULong = ULong(this.signed)
+  final def unary_- : ULong = ULong(-this.signed)
 
   final def + (that: ULong): ULong = ULong(this.signed + that.signed)
   final def - (that: ULong): ULong = ULong(this.signed - that.signed)

--- a/tests/src/test/scala/spire/math/UnsignedTest.scala
+++ b/tests/src/test/scala/spire/math/UnsignedTest.scala
@@ -82,6 +82,10 @@ class ULongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
     }
   }
 
+  property("n + (-n) == 0") {
+    forAll { (n: ULong) => n + (-n) == zero shouldBe true }
+  }
+
   property("a < b") {
     forAll { (a: ULong, b: ULong) => a < b shouldBe a.toBigInt < b.toBigInt }
   }
@@ -190,6 +194,10 @@ class UIntTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
     }
   }
 
+  property("n + (-n) == 0") {
+    forAll { (n: UInt) => n + (-n) == zero shouldBe true }
+  }
+
   property("a < b") {
     forAll { (a: UInt, b: UInt) => a < b shouldBe a.toLong < b.toLong }
   }
@@ -278,6 +286,10 @@ class UShortTest extends PropSpec with Matchers with GeneratorDrivenPropertyChec
     }
   }
 
+  property("n + (-n) == 0") {
+    forAll { (n: UShort) => n + (-n) == zero shouldBe true }
+  }
+
   property("a < b") {
     forAll { (a: UShort, b: UShort) => a < b shouldBe a.toLong < b.toLong }
   }
@@ -364,6 +376,10 @@ class UByteTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
     forAll { (n: UByte) =>
       whenever (n != UByte.MaxValue) { n + one > n shouldBe true }
     }
+  }
+
+  property("n + (-n) == 0") {
+    forAll { (n: UByte) => n + (-n) == zero shouldBe true }
   }
 
   property("a < b") {

--- a/tests/src/test/scala/spire/math/UnsignedTest.scala
+++ b/tests/src/test/scala/spire/math/UnsignedTest.scala
@@ -83,7 +83,7 @@ class ULongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
   }
 
   property("n + (-n) == 0") {
-    forAll { (n: ULong) => n + (-n) == zero shouldBe true }
+    forAll { (n: ULong) => n + (-n) shouldBe zero }
   }
 
   property("a < b") {
@@ -195,7 +195,7 @@ class UIntTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
   }
 
   property("n + (-n) == 0") {
-    forAll { (n: UInt) => n + (-n) == zero shouldBe true }
+    forAll { (n: UInt) => n + (-n) shouldBe zero }
   }
 
   property("a < b") {
@@ -287,7 +287,7 @@ class UShortTest extends PropSpec with Matchers with GeneratorDrivenPropertyChec
   }
 
   property("n + (-n) == 0") {
-    forAll { (n: UShort) => n + (-n) == zero shouldBe true }
+    forAll { (n: UShort) => n + (-n) shouldBe zero }
   }
 
   property("a < b") {
@@ -379,7 +379,7 @@ class UByteTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
   }
 
   property("n + (-n) == 0") {
-    forAll { (n: UByte) => n + (-n) == zero shouldBe true }
+    forAll { (n: UByte) => n + (-n) shouldBe zero }
   }
 
   property("a < b") {


### PR DESCRIPTION
Currently `unary_-` of the Unsigned classes is not consistently defined, i.e. not all four classes have the same behaviour:
- [`UByte`](https://github.com/non/spire/blob/master/core/src/main/scala/spire/math/UByte.scala#L49) and [`UShort`](https://github.com/non/spire/blob/master/core/src/main/scala/spire/math/UShort.scala#L40) implement it by interpeting it as two's complement:

    ```scala
    def unary_- : U = U(-this.signed)
    ```
- [`UInt`](https://github.com/non/spire/blob/master/core/src/main/scala/spire/math/UInt.scala#L39) and [`ULong`](https://github.com/non/spire/blob/master/core/src/main/scala/spire/math/ULong.scala#L83) implement it by returning the same value:

    ```scala
    def unary_- : U = U(this.signed)
    ```

I fixed this by changing `UInt` and `ULong`'s implementation to match those of `UByte` and `UShort`. Additionally, I added test cases that check if `n + (-n) == 0` for all Unsigned classes.