### PR TITLE
Replace x -> y with (x, y).

### DIFF
--- a/core/src/main/scala/spire/algebra/free/FreeAbGroup.scala
+++ b/core/src/main/scala/spire/algebra/free/FreeAbGroup.scala
@@ -109,7 +109,7 @@ object FreeAbGroup { companion =>
   final def id[A]: FreeAbGroup[A] = new FreeAbGroup(Map.empty)
 
   final def apply[A](a: A): FreeAbGroup[A] = lift(a)
-  final def lift[A](a: A): FreeAbGroup[A] = new FreeAbGroup[A](Map(a -> 1))
+  final def lift[A](a: A): FreeAbGroup[A] = new FreeAbGroup[A](Map((a, 1)))
 
   implicit def FreeAbGroupGroup[A]: AbGroup[FreeAbGroup[A]] = new AbGroup[FreeAbGroup[A]] {
     def id: FreeAbGroup[A] = companion.id

--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -57,21 +57,21 @@ object Polynomial extends PolynomialInstances {
   def zero[@spec(Double) C: Eq: Semiring: ClassTag]: Polynomial[C] =
     PolySparse.zero[C]
   def constant[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
-    if (c === Semiring[C].zero) zero[C] else Polynomial(Map(0 -> c))
+    if (c === Semiring[C].zero) zero[C] else Polynomial(Map((0, c)))
   def linear[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
-    if (c === Semiring[C].zero) zero[C] else Polynomial(Map(1 -> c))
+    if (c === Semiring[C].zero) zero[C] else Polynomial(Map((1, c)))
   def linear[@spec(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
-    Polynomial(Map(1 -> c1, 0 -> c0))
+    Polynomial(Map((1, c1), (0, c0)))
   def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
-    Polynomial(Map(1 -> c1, 0 -> c0))
+    Polynomial(Map((1, c1), (0, c0)))
   def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
-    if (c === Semiring[C].zero) zero[C] else Polynomial(Map(2 -> c))
+    if (c === Semiring[C].zero) zero[C] else Polynomial(Map((2, c)))
   def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c2: C, c1: C, c0: C): Polynomial[C] =
-    Polynomial(Map(2 -> c2, 1 -> c1, 0 -> c0))
+    Polynomial(Map((2, c2), (1, c1), (0, c0)))
   def cubic[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
-    if (c === Semiring[C].zero) zero[C] else Polynomial(Map(3 -> c))
+    if (c === Semiring[C].zero) zero[C] else Polynomial(Map((3, c)))
   def cubic[@spec(Double) C: Eq: Semiring: ClassTag](c3: C, c2: C, c1: C, c0: C): Polynomial[C] =
-    Polynomial(Map(3 -> c3, 2 -> c2, 1 -> c1, 0 -> c0))
+    Polynomial(Map((3, c3), (2, c2), (1, c1), (0, c0)))
   def one[@spec(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
     constant(Rig[C].one)
   def x[@spec(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =

--- a/core/src/main/scala/spire/math/poly/SpecialPolynomials.scala
+++ b/core/src/main/scala/spire/math/poly/SpecialPolynomials.scala
@@ -22,16 +22,17 @@ object SpecialPolynomials {
   // Legendre recurrence function
   private[this] def legendreFn[C: Eq: ClassTag](implicit f: Field[C]): (Polynomial[C], Polynomial[C], Int) => Polynomial[C] =
     (pn: Polynomial[C], pnm1: Polynomial[C], n: Int) => {
-      val a = Polynomial(Map(0 -> f.fromInt(1) / f.fromInt(n + 1)))
-      val b = Polynomial(Map(1 -> f.fromInt(2 * n + 1)))
-      val c = Polynomial(Map(0 -> -f.fromInt(n)))
+      val a = Polynomial(Map((0, f.fromInt(1) / f.fromInt(n + 1))))
+      val b = Polynomial(Map((1, f.fromInt(2 * n + 1))))
+      val c = Polynomial(Map((0, -f.fromInt(n))))
       a * (b * pn + c * pnm1)
     }
 
   // Laguerre recurrence function
   private[this] def laguerreFn[C: Eq: ClassTag](implicit f: Field[C]): (Polynomial[C], Polynomial[C], Int) => Polynomial[C] =
     (pn: Polynomial[C], pnm1: Polynomial[C], n: Int) => {
-      Polynomial(Map(0 -> f.one / f.fromInt(n + 1))) * (Polynomial(Map(0 -> f.fromInt(2 * n + 1), 1 -> -f.one)) * pn - pnm1 * Polynomial(Map(0 -> f.fromInt(n))))
+      Polynomial(Map((0, f.one / f.fromInt(n + 1)))) *
+      (Polynomial(Map((0, f.fromInt(2 * n + 1)), (1, -f.one))) * pn - pnm1 * Polynomial(Map((0, f.fromInt(n)))))
     }
 
   // Chebyshev recurrence function
@@ -52,7 +53,7 @@ object SpecialPolynomials {
 
   // Laguerre polynomials
   def laguerres[C: Eq: ClassTag](num: Int)(implicit f: Field[C]): Stream[Polynomial[C]] =
-    hornerScheme(Polynomial.one[C], Polynomial(Map(0 -> f.one, 1 -> -f.one)), laguerreFn[C]).take(num)
+    hornerScheme(Polynomial.one[C], Polynomial(Map((0, f.one), (1, -f.one))), laguerreFn[C]).take(num)
 
   // Chebyshev polynomials of the first kind
   def chebyshevsFirstKind[C: Ring: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =

--- a/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
+++ b/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
@@ -25,7 +25,7 @@ final class MapIntIntGroup extends Group[Map[Int, Int]] {
       case (prevMap, preimage) =>
         val imageX = x.getOrElse(preimage, preimage)
         val image = y.getOrElse(imageX, imageX)
-        if (preimage != image) prevMap + (preimage -> image) else prevMap
+        if (preimage != image) prevMap + ((preimage, image)) else prevMap
     }
   }
   def inverse(a: Map[Int, Int]): Map[Int, Int] = a.map(_.swap).toMap

--- a/scalacheck-binding/src/main/scala/spire/laws/SpireArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/spire/laws/SpireArbitrary.scala
@@ -159,7 +159,7 @@ object SpireArbitrary {
       images(j) = i
     }
     Perm((Map.empty[Int, Int] /: images.zipWithIndex) {
-      case (prevMap, (preimage, image)) if preimage != image => prevMap + (preimage -> image)
+      case (prevMap, (preimage, image)) if preimage != image => prevMap + ((preimage, image))
       case (prevMap, _) => prevMap
     })
   })


### PR DESCRIPTION
The "could not inline @inline-marked method ->$extension" message
is getting a bit old, and there's really no reason we need to be
using it.

For now, I left a few uses in the tests, but I would be happy to
remove those too.