### PR TITLE
This commit introduces sbt-sonatype.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,9 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
-
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.6")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("com.jsuereth"        % "sbt-pgp"               % "1.0.0")
+addSbtPlugin("com.github.gseitz"   % "sbt-release"           % "1.0.0")
+addSbtPlugin("com.eed3si9n"        % "sbt-unidoc"            % "0.3.0")
+addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"         % "0.3.2")
+addSbtPlugin("pl.project13.scala"  % "sbt-jmh"               % "0.1.6")
+addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "1.0.4")
+addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "0.7.0")


### PR DESCRIPTION
It also upgrades us to the latest sbt-release, which removes
a bunch of clunkiness from our SBT set up. We should now be
able to do non-interactive releases through Sonatype, which
makes cutting a release a much easier process.