### PR TITLE
Coverage testing and publishing to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ scala:
   - 2.10.2
   - 2.11.6
 script:
-  sbt ++$TRAVIS_SCALA_VERSION validate
+  - if [[ "$TRAVIS_SCALA_VERSION" == "2.10.2"
+    ]]; then
+      sbt ++$TRAVIS_SCALA_VERSION validate ;
+    else
+      sbt ++$TRAVIS_SCALA_VERSION coverage validate coverageReport && bash <(curl -s https://codecov.io/bash) ;
+    fi
 notifications:
   irc:
     channels:

--- a/build.sbt
+++ b/build.sbt
@@ -270,5 +270,5 @@ lazy val scoverageSettings = Seq(
   ScoverageKeys.coverageMinimum := 40,
   ScoverageKeys.coverageFailOnMinimum := false,
   ScoverageKeys.coverageHighlighting := scalaBinaryVersion.value != "2.10",
-  ScoverageKeys.coverageExcludedPackages := ""
+  ScoverageKeys.coverageExcludedPackages := "spire\\.macros\\..*"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import sbtunidoc.Plugin.UnidocKeys._
 //import com.typesafe.sbt.pgp.PgpKeys._
 import pl.project13.scala.sbt.SbtJmh
 import ReleaseTransformations._
+import ScoverageSbtPlugin._
 
 // Projects
 
@@ -185,7 +186,7 @@ lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.2"
 
 // Project's settings
 
-lazy val spireSettings = buildSettings ++ commonSettings ++ publishSettings
+lazy val spireSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings
 
 lazy val unidocSettings = UnidocPlugin.unidocSettings ++ Seq(
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(examples, benchmark, tests)
@@ -263,4 +264,11 @@ lazy val benchmarkSettings = Seq(
 
   // enable forking in run
   fork in run := true
+)
+
+lazy val scoverageSettings = Seq(
+  ScoverageKeys.coverageMinimum := 40,
+  ScoverageKeys.coverageFailOnMinimum := false,
+  ScoverageKeys.coverageHighlighting := scalaBinaryVersion.value != "2.10",
+  ScoverageKeys.coverageExcludedPackages := ""
 )


### PR DESCRIPTION
This adds coverage testing to travis ci, and publishes the results to codecov.io.

Coverage testing is for now only run for 2.11. It might be possible to also run it for 2.10 now that I have excluded spire.macros.

@non you will have to configure your codecov.io to exclude some directories using "integration and setup/ignore files". Here is my ignore list:

```
laws/**
benchmark/**
examples/**
macros/**
_2.11/**
```