### PR TITLE
Feature/rational arbitrary

### DIFF
--- a/core/shared/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/shared/src/main/scala/spire/math/prime/Siever.scala
@@ -38,7 +38,7 @@ import SieveUtil._
  * will instantiate a Siever for you with reasonable parameters.
  */
 case class Siever(chunkSize: Int, cutoff: SafeLong) {
-  require(chunkSize % 480 != 0, "chunkSize must be a multiple of 480")
+  require(chunkSize % 480 == 0, "chunkSize must be a multiple of 480")
 
   val arr = BitSet.alloc(chunkSize)
   var start: SafeLong = SafeLong(0)

--- a/laws/src/main/scala/spire/laws/gen.scala
+++ b/laws/src/main/scala/spire/laws/gen.scala
@@ -36,25 +36,42 @@ object gen {
     arbitrary[Long].map(new FixedPoint(_))
 
   lazy val safeLong: Gen[SafeLong] =
-    Gen.oneOf(
-      arbitrary[Long].map(SafeLong(_)),
-      arbitrary[BigInt].map(SafeLong(_)))
+    Gen.frequency(
+      1 → SafeLong(BigInt("393050634124102232869567034555427371542904833")),
+      100 → arbitrary[Long].map(SafeLong(_)),
+      100 → arbitrary[BigInt].map(SafeLong(_)))
 
   lazy val natural: Gen[Natural] =
     Gen.oneOf(
       arbitrary[Long].map(n => Natural(n & Long.MaxValue)),
       arbitrary[BigInt].map(n => Natural(n.abs)))
 
-  lazy val rationalFromLongs: Gen[Rational] =
-    for {
-      n <- arbitrary[Long]
-      d <- arbitrary[Long].map(n => if (n == 0) 1L else n)
-    } yield Rational(n, d)
+  lazy val rational: Gen[Rational] = {
+    val rationalFromLongs: Gen[Rational] =
+      for {
+        n <- arbitrary[Long]
+        d <- arbitrary[Long].map(n => if (n == 0) 1L else n)
+      } yield Rational(n, d)
 
-  lazy val rational: Gen[Rational] =
-    Gen.oneOf(
-      rationalFromLongs,
-      arbitrary[Double].map(n => Rational(n)))
+    val rationalFromSafeLongs: Gen[Rational] =
+      for {
+        n <- safeLong
+        d <- safeLong.map(n => if (n.isZero) SafeLong.one else n)
+      } yield Rational(n, d)
+
+    val bigRational: Gen[Rational] = {
+      val m = Rational("1/393050634124102232869567034555427371542904833")
+      rationalFromSafeLongs.map(_ * m)
+    }
+
+    Gen.frequency(
+      10 → rationalFromLongs, // we keep this to make long/long rationals more frequent
+      10 → arbitrary[Double].map(n => Rational(n)),
+      1 → rationalFromSafeLongs,
+      1 → bigRational, // a rational that is guaranteed to have a big denominator
+      1 → bigRational.map(x ⇒ if(x.isZero) Rational.one else x.inverse)
+    )
+  }
 
   lazy val number: Gen[Number] =
     Gen.oneOf(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "1.2.0")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "0.7.0")
 addSbtPlugin("com.typesafe.sbt"    % "sbt-git"               % "0.8.4")
 addSbtPlugin("org.scala-js"        % "sbt-scalajs"           % "0.6.4")
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.12"

--- a/tests/src/test/scala/spire/laws/ArbTest.scala
+++ b/tests/src/test/scala/spire/laws/ArbTest.scala
@@ -1,0 +1,77 @@
+package spire.laws
+
+import scala.util.Random
+
+import org.scalacheck.Gen
+import org.scalatest.FunSuite
+import spire.math.interval._
+import spire.math.{Interval, SafeLong, Rational}
+
+class ArbTest extends FunSuite {
+
+  // params with a fixed random seed for
+  def params: Gen.Parameters = {
+    val seed = 0L
+    Gen.Parameters.default.withRng(new Random(seed))
+  }
+
+  test("arb.rational") {
+    // generate a reasonably large number of rationals and check if we get each kind of rational at least once
+    val params = this.params
+    val samples = Array.fill(100)(spire.laws.arb.rational.arbitrary(params)).flatten
+    def classify(x: Rational): String = {
+      if (x.isZero) "zero"
+      else if (x.isOne) "one"
+      else if (x.isValidLong) "long"
+      else if (x.isWhole) "big"
+      else {
+        if (x.numerator.isValidLong && x.denominator.isValidLong) {
+          if (x.numerator == 1) "1/long"
+          else "long/long"
+        } else {
+          if (x.numerator == 1) "1/big"
+          else if (x.numerator.isValidLong) "long/big"
+          else if (x.denominator.isValidLong) "big/long"
+          else "big/big"
+        }
+      }
+    }
+    val kinds = samples.map(classify).toSet
+    val expected = Set("zero", "one", "long", "big", "1/long", "1/big", "long/big", "long/long", "big/long", "big/big")
+    val missing = expected diff kinds
+    assert(missing.isEmpty)
+  }
+
+  test("arb.safeLong") {
+    val params = this.params
+    val samples = Array.fill(100)(spire.laws.arb.safeLong.arbitrary(params)).flatten
+    def classify(x: SafeLong): String = {
+      if (x.isZero) "zero"
+      else if (x.isOne) "one"
+      else if (x.isValidLong) "long"
+      else "big"
+    }
+    val kinds = samples.map(classify).distinct.sorted
+    assert(kinds.length == 4)
+  }
+
+  test("arb.interval") {
+    import spire.std.int._
+    val params = this.params
+    val samples = Array.fill(100)(spire.laws.arb.interval[Int].arbitrary(params)).flatten
+    def classify(x: Interval[Int]): String = x.fold {
+      case (Unbound(), Unbound()) ⇒ "all"
+      case (Unbound(), Open(_)) ⇒ ")"
+      case (Unbound(), Closed(_)) ⇒ "]"
+      case (Open(_), Unbound()) ⇒ "("
+      case (Closed(_), Unbound()) ⇒ "["
+      case (Open(_), Open(_)) ⇒ "()"
+      case (Open(_), Closed(_)) ⇒ "(]"
+      case (Closed(_), Open(_)) ⇒ "[)"
+      case (Closed(a), Closed(b)) ⇒ if(a!=b) "[]" else "point"
+      case _ ⇒ "empty"
+    }
+    val kinds = samples.map(classify).distinct.sorted
+    assert(kinds.length == 11)
+  }
+}

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -312,16 +312,16 @@ class RationalTest extends FunSuite {
     val y = Rational("1919191919191919191919/373737373737373737")
     val z = Rational("1/287380324068203382157064120376241062")
     assert(x.gcd(y) === z) // As confirmed by Wolfram Alpha
-//    // test gcd special cases (0 and 1)
-//    for(w ← Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
-//      val n = -w
-//      assert(Rational.zero.gcd(w) === w)
-//      assert(w.gcd(Rational.zero) === w)
-//      assert(Rational.zero.gcd(n) === w)
-//      assert(n.gcd(Rational.zero) === w)
-//      assert(Rational.one.gcd(w) === Rational.one)
-//      assert(w.gcd(Rational.one) === Rational.one)
-//    }
+    // test gcd special cases (0 and 1)
+    for(w ← Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
+      val n = -w
+      assert(Rational.zero.gcd(w) === w)
+      assert(w.gcd(Rational.zero) === w)
+      assert(Rational.zero.gcd(n) === w)
+      assert(n.gcd(Rational.zero) === w)
+      assert(Rational.one.gcd(w) === Rational.one)
+      assert(w.gcd(Rational.one) === Rational.one)
+    }
   }
 
   test("Rational(0D) is Zero") {

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -312,16 +312,16 @@ class RationalTest extends FunSuite {
     val y = Rational("1919191919191919191919/373737373737373737")
     val z = Rational("1/287380324068203382157064120376241062")
     assert(x.gcd(y) === z) // As confirmed by Wolfram Alpha
-    // test gcd special cases (0 and 1)
-    for(w ← Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
-      val n = -w
-      assert(Rational.zero.gcd(w) === w)
-      assert(w.gcd(Rational.zero) === w)
-      assert(Rational.zero.gcd(n) === w)
-      assert(n.gcd(Rational.zero) === w)
-      assert(Rational.one.gcd(w) === Rational.one)
-      assert(w.gcd(Rational.one) === Rational.one)
-    }
+//    // test gcd special cases (0 and 1)
+//    for(w ← Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
+//      val n = -w
+//      assert(Rational.zero.gcd(w) === w)
+//      assert(w.gcd(Rational.zero) === w)
+//      assert(Rational.zero.gcd(n) === w)
+//      assert(n.gcd(Rational.zero) === w)
+//      assert(Rational.one.gcd(w) === Rational.one)
+//      assert(w.gcd(Rational.one) === Rational.one)
+//    }
   }
 
   test("Rational(0D) is Zero") {

--- a/tests/src/test/scala/spire/math/prime/PrimeTest.scala
+++ b/tests/src/test/scala/spire/math/prime/PrimeTest.scala
@@ -1,0 +1,50 @@
+package spire.math.prime
+
+import spire.implicits._
+
+import org.scalatest.FunSuite
+import spire.math.SafeLong
+
+class PrimeTest extends FunSuite {
+  val largePrime = SafeLong("393050634124102232869567034555427371542904833")
+  val largeNonPrime = largePrime + 4
+  val tenPrimes = IndexedSeq(2, 3, 5, 7, 11, 13, 17, 19, 23, 29).map(x ⇒ SafeLong(x))
+  val nonPrimes = IndexedSeq(10L, 64L, 2L ** 32, 3L ** 10).map(x ⇒ SafeLong(x))
+
+  test("nth") {
+    for(i ← tenPrimes.indices)
+      assert(nth(i + 1) == tenPrimes(i))
+  }
+
+  test("isPrime") {
+    for(p ← tenPrimes)
+      assert(isPrime(p))
+    for(n ← nonPrimes)
+      assert(!isPrime(n))
+  }
+
+  test("fill") {
+    assert(fill(10).toSeq == tenPrimes)
+    assert(fill(2, 2).toSeq == tenPrimes.slice(2, 4))
+  }
+
+  test("stream") {
+    assert(stream.take(10).toSeq == tenPrimes)
+  }
+
+  test("factor") {
+    for(p ← tenPrimes) {
+      assert(factor(p) == Factors(p))
+      assert(factorPollardRho(p) == Factors(p))
+      assert(factorTrialDivision(p) == Factors(p))
+      assert(factorWheelDivision(p) == Factors(p))
+    }
+    def terms(f: Factors): Int = f.map(_._2).sum
+    for(n ← nonPrimes) {
+      assert(terms(factor(n)) > 1)
+      assert(terms(factorPollardRho(n)) > 1)
+      assert(terms(factorTrialDivision(n)) > 1)
+      assert(terms(factorWheelDivision(n)) > 1)
+    }
+  }
+}


### PR DESCRIPTION
 An attempt to improve the rational arbitrary

Also some tests for the more tricky arbitraries such as rational, safeLong
and interval. The tests check that the arbitraries generate a realistic
distribution of the possible kinds of rationals, intervals or safelongs

They are made deterministic by setting the random seed, so there should not
be any additional transient failures.

Fixes #484

This also adds some simple tests for the spire.math.prime namespace. These will have to be adapted once #489 is fixed one way or the other.