### PR TITLE
Fix limitToInt to work around commonly-occuring case.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Rational.scala
+++ b/core/shared/src/main/scala/spire/math/Rational.scala
@@ -94,14 +94,16 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
   /**
    * Returns a `Rational` whose numerator and denominator both fit in an `Int`.
    */
-  def limitToInt: Rational = limitTo(BigInt(Int.MaxValue))
-
+  def limitToInt: Rational =
+    if (signum < 0) -(-this).limitTo(Rational.Two31m0)
+    else limitTo(Rational.Two31m1)
 
   /**
    * Returns a `Rational` whose numerator and denominator both fit in a `Long`.
    */
-  def limitToLong: Rational = limitTo(BigInt(Long.MaxValue))
-
+  def limitToLong: Rational =
+    if (signum < 0) -(-this).limitTo(Rational.Two63m0)
+    else limitTo(Rational.Two63m1)
 
   /**
    * Returns a `Rational` whose denominator and numerator are no larger than
@@ -111,24 +113,26 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
    *
    * @param max A positive integer.
    */
-  def limitTo(max: BigInt): Rational = if (this.signum < 0) {
-    -((-this).limitTo(max))
-  } else {
+  def limitTo(max: BigInt): Rational = {
     require(max > 0, "Limit must be a positive integer.")
-
-    val half = max >> 1
-    val floor = this.toBigInt
-    if (floor >= max) {
-      Rational(max)
-    } else if (floor >= (max >> 1)) {
-      Rational(floor.toLong)
-    } else if (this.compareToOne < 0) {
-      limitDenominatorTo(max)
+    if (this.signum < 0) {
+      -((-this).limitTo(max))
+    } else if (numerator < max && denominator < max) {
+      this
     } else {
-      limitDenominatorTo(max * denominator / numerator)
+      val half = max >> 1
+      val floor = this.toBigInt
+      if (floor >= max) {
+        Rational(max)
+      } else if (floor >= (max >> 1)) {
+        Rational(floor.toLong)
+      } else if (this.compareToOne < 0) {
+        limitDenominatorTo(max)
+      } else {
+        limitDenominatorTo(max * denominator / numerator)
+      }
     }
   }
-
 
   /**
    * Finds the closest `Rational` to this `Rational` whose denominator is no
@@ -200,6 +204,11 @@ object Rational extends RationalInstances {
 
   val zero: Rational = LongRational(0L, 1L)
   val one: Rational = LongRational(1L, 1L)
+
+  private[math] val Two31m1: BigInt = BigInt(Int.MaxValue)
+  private[math] val Two31m0: BigInt = -BigInt(Int.MinValue)
+  private[math] val Two63m1: BigInt = BigInt(Long.MaxValue)
+  private[math] val Two63m0: BigInt = -BigInt(Long.MinValue)
 
   private[math] def toDouble(n: SafeLong, d: SafeLong): Double = n.signum match {
     case 0 => 0.0

--- a/tests/src/test/scala/spire/math/RationalCheck.scala
+++ b/tests/src/test/scala/spire/math/RationalCheck.scala
@@ -62,4 +62,11 @@ class RationalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
       Rational(n).toDouble == n
     }
   }
+
+  property("limitToInt does not change small Rationals") {
+    forAll { (n: Int, d: Int) =>
+      val r = Rational(n, if (d < 1) 1 else d)
+      r.limitToInt shouldBe r
+    }
+  }
 }

--- a/tests/src/test/scala/spire/math/RealCheck.scala
+++ b/tests/src/test/scala/spire/math/RealCheck.scala
@@ -233,4 +233,10 @@ class RealCheck extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
   //     }
   //   }
   // }
+
+  property("x.pow(k) = x.fpow(k)") {
+    forAll { (x: Real, k: Byte) =>
+      x.pow(k & 0xff) shouldBe x.fpow(Rational(k & 0xff))
+    }
+  }
 }


### PR DESCRIPTION
Previously, calling Rational(3).limitToInt would invoke the
general .limitTo code which is already implicated in at
least one other bug (#393). So, this change does a very
simple check to see if limiting is even necessary before
calling into that code.

This fixes the repoted issue, namely the situation where
Rational(3).limitToInt seems to hang.

Tests are added both for the .limitToInt behavior and
also simple tests of Real#fpow.
