### PR TITLE
Explicit literals

### DIFF
--- a/core/shared/src/main/scala/spire/macros/Macros.scala
+++ b/core/shared/src/main/scala/spire/macros/Macros.scala
@@ -1,5 +1,6 @@
 package spire.macros
 
+import spire.algebra.{Field, Ring}
 import spire.macros.compat.Context
 import spire.math.{Rational, UByte, UShort, UInt, ULong}
 
@@ -173,5 +174,23 @@ object Macros {
     val n = java.lang.Integer.parseInt(s, base)
 
     c.Expr[Int](Literal(Constant(n)))
+  }
+
+  def intAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Ring[A]]):c.Tree = {
+    import c.universe._
+    c.prefix.tree match {
+      case Apply((_, List(Literal(Constant(0))))) => q"$ev.zero"
+      case Apply((_, List(Literal(Constant(1))))) => q"$ev.one"
+      case Apply((_, List(n))) => q"$ev.fromInt($n)"
+    }
+  }
+
+  def dblAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Field[A]]):c.Tree = {
+    import c.universe._
+    c.prefix.tree match {
+      case Apply((_, List(Literal(Constant(0.0))))) => q"$ev.zero"
+      case Apply((_, List(Literal(Constant(1.0))))) => q"$ev.one"
+      case Apply((_, List(n))) => q"$ev.fromDouble($n)"
+    }
   }
 }

--- a/core/shared/src/main/scala/spire/macros/Macros.scala
+++ b/core/shared/src/main/scala/spire/macros/Macros.scala
@@ -176,21 +176,21 @@ object Macros {
     c.Expr[Int](Literal(Constant(n)))
   }
 
-  def intAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Ring[A]]):c.Tree = {
+  def intAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Ring[A]]):c.Expr[A] = {
     import c.universe._
-    c.prefix.tree match {
+    c.Expr[A](c.prefix.tree match {
       case Apply((_, List(Literal(Constant(0))))) => q"$ev.zero"
       case Apply((_, List(Literal(Constant(1))))) => q"$ev.one"
       case Apply((_, List(n))) => q"$ev.fromInt($n)"
-    }
+    })
   }
 
-  def dblAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Field[A]]):c.Tree = {
+  def dblAs[A : c.WeakTypeTag](c:Context)(ev : c.Expr[Field[A]]):c.Expr[A]= {
     import c.universe._
-    c.prefix.tree match {
+    c.Expr[A](c.prefix.tree match {
       case Apply((_, List(Literal(Constant(0.0))))) => q"$ev.zero"
       case Apply((_, List(Literal(Constant(1.0))))) => q"$ev.one"
       case Apply((_, List(n))) => q"$ev.fromDouble($n)"
-    }
+    })
   }
 }

--- a/core/shared/src/main/scala/spire/syntax/Literals.scala
+++ b/core/shared/src/main/scala/spire/syntax/Literals.scala
@@ -64,11 +64,11 @@ class EuLiterals(s:StringContext) {
 }
 
 object primitives {
-  implicit class IntAs(val n:Int) extends AnyVal {
+  implicit class IntAs(n:Int) {
     def as[A](implicit ev:Ring[A]):A = macro Macros.intAs[A]
   }
 
-  implicit class DoubleAs(val n:Double) extends AnyVal {
+  implicit class DoubleAs(n:Double) {
     def as[A](implicit ev:Field[A]):A = macro Macros.dblAs[A]
   }
 }

--- a/core/shared/src/main/scala/spire/syntax/Literals.scala
+++ b/core/shared/src/main/scala/spire/syntax/Literals.scala
@@ -1,5 +1,7 @@
 package spire.syntax
 
+import spire.algebra.{Field, Ring}
+
 import scala.{specialized => spec}
 
 import spire.math.{Polynomial, Rational, UByte, UShort, UInt, ULong}
@@ -59,4 +61,14 @@ class EuLiterals(s:StringContext) {
   def j():Long = macro Macros.euLong
   def big():BigInt = macro Macros.euBigInt
   def dec():BigDecimal = macro Macros.euBigDecimal
+}
+
+object primitives {
+  implicit class IntAs(val n:Int) extends AnyVal {
+    def as[A](implicit ev:Ring[A]) = ev.fromInt(n)
+  }
+
+  implicit class DoubleAs(val n:Double) extends AnyVal {
+    def as[A](implicit ev:Field[A]) = ev.fromDouble(n)
+  }
 }

--- a/core/shared/src/main/scala/spire/syntax/Literals.scala
+++ b/core/shared/src/main/scala/spire/syntax/Literals.scala
@@ -65,10 +65,10 @@ class EuLiterals(s:StringContext) {
 
 object primitives {
   implicit class IntAs(val n:Int) extends AnyVal {
-    def as[A](implicit ev:Ring[A]) = ev.fromInt(n)
+    def as[A](implicit ev:Ring[A]):A = macro Macros.intAs[A]
   }
 
   implicit class DoubleAs(val n:Double) extends AnyVal {
-    def as[A](implicit ev:Field[A]) = ev.fromDouble(n)
+    def as[A](implicit ev:Field[A]):A = macro Macros.dblAs[A]
   }
 }


### PR DESCRIPTION
#512  Let me know if this is what you had in mind. I've only implemented `double`s and `int`s since those are the 'default' literal types for scala, and it looks like `Field` and `Ring` specializations are built mainly around them. I'm happy to add `long` and `float`, but I'm not sure what the from method would be for long (that doesn't truncate).