### PR TITLE
AdditiveMonoid is sufficient for metric space identity law

### DIFF
--- a/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -61,8 +61,8 @@ trait VectorSpaceLaws[V, A] extends Laws {
     vl = _.emptyRuleSet,
     parents = Seq.empty,
     "identity" → forAll((x: V, y: V) =>
-      if (x === y) V.distance(x, y) === AdditiveMonoid[A].zero
-      else V.distance(x, y) =!= AdditiveMonoid[A].zero
+      if (x === y) V.distance(x, y) === A.zero
+      else V.distance(x, y) =!= A.zero
     ),
     "symmetric" → forAll((x: V, y: V) =>
       V.distance(x, y) === V.distance(y, x)

--- a/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -55,14 +55,14 @@ trait VectorSpaceLaws[V, A] extends Laws {
     parents = Seq(module)
   )
 
-  def metricSpace(implicit V: MetricSpace[V, A], o: Order[A], A: Rng[A]) = new SpaceProperties(
+  def metricSpace(implicit V: MetricSpace[V, A], o: Order[A], A: AdditiveMonoid[A]) = new SpaceProperties(
     name = "metric space",
     sl = _.emptyRuleSet,
     vl = _.emptyRuleSet,
     parents = Seq.empty,
     "identity" → forAll((x: V, y: V) =>
-      if (x === y) V.distance(x, y) === Rng[A].zero
-      else V.distance(x, y) =!= Rng[A].zero
+      if (x === y) V.distance(x, y) === AdditiveMonoid[A].zero
+      else V.distance(x, y) =!= AdditiveMonoid[A].zero
     ),
     "symmetric" → forAll((x: V, y: V) =>
       V.distance(x, y) === V.distance(y, x)


### PR DESCRIPTION
I have a case where it's not possible to define a Rng for the second type of a MetricSpace, but I can provide an AdditiveMonoid, which is all that's needed to define the identity law.