### PR TITLE
Remove === and =!= methods

### DIFF
--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -150,7 +150,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
   def isZero: Boolean = signum == 0
 
   override def equals(that: Any): Boolean = that match {
-    case (that: Algebraic) => this === that
+    case (that: Algebraic) => this.compare(that) == 0
     case (that: Real) => this.toReal == that
     case (that: Number) => this.compare(Algebraic(that.toBigDecimal)) == 0
     case (that: Rational) => this.compare(Algebraic(that)) == 0
@@ -166,12 +166,6 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     }
     case _ => unifiedPrimitiveEquals(that)
   }
-
-  def ===(that: Algebraic): Boolean =
-    this.compare(that) == 0
-
-  def =!=(that: Algebraic): Boolean =
-    !(this === that)
 
   override def hashCode: Int = if (isWhole && isValidLong) {
     unifiedPrimitiveHashcode

--- a/core/shared/src/main/scala/spire/math/Complex.scala
+++ b/core/shared/src/main/scala/spire/math/Complex.scala
@@ -331,18 +331,12 @@ final case class Complex[@spec(Float, Double) T](real: T, imag: T)
 
   // not typesafe, so this is the best we can do :(
   override def equals(that: Any): Boolean = that match {
-    case that: Complex[_]    => this === that
+    case that: Complex[_]    => real == that.real && imag == that.imag
     case that: Quaternion[_] =>
       real == that.r && imag == that.i && anyIsZero(that.j) && anyIsZero(that.k)
     case that =>
       anyIsZero(imag) && real == that
   }
-
-  def ===(that: Complex[_]): Boolean =
-    real == that.real && imag == that.imag
-
-  def =!=(that: Complex[_]): Boolean =
-    !(this === that)
 
   override def toString: String = s"($real + ${imag}i)"
 

--- a/core/shared/src/main/scala/spire/math/Jet.scala
+++ b/core/shared/src/main/scala/spire/math/Jet.scala
@@ -485,16 +485,11 @@ final case class Jet[@sp(Float, Double) T](real: T, infinitesimal: Array[T])
   }
 
   override def equals(that: Any): Boolean = that match {
-    case that: Jet[_] => this === that
+    case that: Jet[_] =>
+      real == that.real && dimension == that.dimension &&
+      infinitesimal.zip(that.infinitesimal).forall{ case (x, y) => x == y }
     case that         => isReal && real == that
   }
-
-  def ===(that: Jet[_]): Boolean =
-    real == that.real && dimension == that.dimension &&
-      infinitesimal.zip(that.infinitesimal).forall{ case (x, y) => x == y }
-
-  def =!=(that: Jet[_]): Boolean =
-    !(this === that)
 
   override def toString: String = {
     "(%s + [%s]h)".format(real.toString, infinitesimal.mkString(", "))

--- a/core/shared/src/main/scala/spire/math/Natural.scala
+++ b/core/shared/src/main/scala/spire/math/Natural.scala
@@ -226,7 +226,7 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
   }
 
   final override def equals(rhs: Any): Boolean = rhs match {
-    case rhs: Natural => this === rhs
+    case rhs: Natural => (lhs compare rhs) == 0
     case rhs: UInt => (lhs compare rhs) == 0
     case rhs: BigInt => lhs.toBigInt == rhs
     case rhs: SafeLong => SafeLong(lhs.toBigInt) == rhs
@@ -239,12 +239,6 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
     case rhs: Quaternion[_] => rhs == lhs
     case that => unifiedPrimitiveEquals(that)
   }
-
-  def ===(rhs: Natural): Boolean =
-    (lhs compare rhs) == 0
-
-  def =!=(rhs: Natural): Boolean =
-    !(this === rhs)
 
   def <(rhs: Natural): Boolean = (lhs compare rhs) < 0
   def <=(rhs: Natural): Boolean = (lhs compare rhs) <= 0

--- a/core/shared/src/main/scala/spire/math/Number.scala
+++ b/core/shared/src/main/scala/spire/math/Number.scala
@@ -92,9 +92,6 @@ sealed trait Number extends ScalaNumericConversions with Serializable {
   def pow(rhs: Number): Number
   final def **(rhs: Number): Number = pow(rhs)
 
-  def ===(rhs: Number): Boolean
-  def =!=(rhs: Number): Boolean = !(this === rhs)
-
   def compare(rhs: Number): Int
   def min(rhs: Number): Number = if (this < rhs) this else rhs
   def max(rhs: Number): Number = if (this > rhs) this else rhs
@@ -156,14 +153,9 @@ private[math] case class IntNumber(n: SafeLong) extends Number { lhs =>
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: Number => this === that
-      case that => n == that
-    }
-
-  def ===(that: Number): Boolean =
-    that match {
       case IntNumber(n2) => n == n2
-      case that => that === this
+      case that: Number => that == this
+      case that => n == that
     }
 
   def unary_- : Number = Number(-n)
@@ -308,15 +300,10 @@ private[math] case class FloatNumber(n: Double) extends Number { lhs =>
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: Number => this === that
-      case that => n == that
-    }
-
-  def ===(that: Number): Boolean =
-    that match {
       case FloatNumber(n2) => n == n2
       case IntNumber(m) => m == m.toDouble.toLong && m == n
-      case _ => that == this
+      case that:Number => that == this
+      case that => n == that
     }
 
   def unary_- : Number = Number(-n)
@@ -463,16 +450,11 @@ private[math] case class DecimalNumber(n: BigDecimal) extends Number { lhs =>
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: Number => this === that
-      case that => that == n
-    }
-
-  def ===(that: Number): Boolean =
-    that match {
       case DecimalNumber(n2) => n == n2
       case IntNumber(m) => n == m.toBigDecimal
       case FloatNumber(m) => n == m
       case RationalNumber(m) => m == n
+      case that => that == n
     }
 
   def unary_- : Number = Number(-n)
@@ -545,16 +527,11 @@ private[math] case class RationalNumber(n: Rational) extends Number { lhs =>
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: Number => this === that
-      case that => n == that
-    }
-
-  def ===(that: Number): Boolean =
-    that match {
       case RationalNumber(n2) => n == n2
       case IntNumber(m) => n == m.toBigDecimal
       case FloatNumber(m) => n == m
       case DecimalNumber(m) => n == m
+      case that => n == that
     }
 
   def unary_- : Number = Number(-n)

--- a/core/shared/src/main/scala/spire/math/Quaternion.scala
+++ b/core/shared/src/main/scala/spire/math/Quaternion.scala
@@ -110,18 +110,13 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
 
   // not typesafe, so this is the best we can do :(
   override def equals(that: Any): Boolean = that match {
-    case that: Quaternion[_] => this === that
+    case that: Quaternion[_] =>
+      r == that.r && i == that.i && j == that.j && k == that.k
     case that: Complex[_] =>
       r == that.real && i == that.imag && anyIsZero(j) && anyIsZero(k)
     case that =>
       sillyIsReal && r == that
   }
-
-  def ===(that: Quaternion[_]): Boolean =
-    r == that.r && i == that.i && j == that.j && k == that.k
-
-  def =!=(that: Quaternion[_]): Boolean =
-    !(this === that)
 
   def isZero(implicit o: IsReal[A]): Boolean = r.isSignZero && i.isSignZero && j.isSignZero && k.isSignZero
   def isReal(implicit o: IsReal[A]): Boolean = i.isSignZero && j.isSignZero && k.isSignZero

--- a/core/shared/src/main/scala/spire/math/Real.scala
+++ b/core/shared/src/main/scala/spire/math/Real.scala
@@ -54,15 +54,9 @@ sealed trait Real extends ScalaNumber with ScalaNumericConversions { x =>
   override def hashCode(): Int = toRational.hashCode
 
   override def equals(y: Any): Boolean = y match {
-    case y: Real => this === y
+    case y: Real => (x compare y) == 0
     case y => toRational.equals(y)
   }
-
-  def ===(y: Real): Boolean =
-    (x compare y) == 0
-
-  def =!=(y: Real): Boolean =
-    !(this === y)
 
   def compare(y: Real): Int = (x, y) match {
     case (Exact(nx), Exact(ny)) => nx compare ny
@@ -550,7 +544,7 @@ trait RealIsFractional extends Fractional[Real] with Order[Real] with Signed[Rea
   def abs(x: Real): Real = x.abs
   def signum(x: Real): Int = x.signum
 
-  override def eqv(x: Real, y: Real): Boolean = x === y
+  override def eqv(x: Real, y: Real): Boolean = (x compare y) == 0
   def compare(x: Real, y: Real): Int = x compare y
 
   def zero: Real = Real.zero

--- a/core/shared/src/main/scala/spire/math/SafeLong.scala
+++ b/core/shared/src/main/scala/spire/math/SafeLong.scala
@@ -84,12 +84,6 @@ sealed abstract class SafeLong extends ScalaNumber with ScalaNumericConversions 
       case SafeLongBigInteger(n) => lhs ^ n
     }
 
-  def ===(that: SafeLong): Boolean =
-    this == that
-
-  def =!=(that: SafeLong): Boolean =
-    !(this === that)
-
   def +(rhs: Long): SafeLong
   def -(rhs: Long): SafeLong
   def *(rhs: Long): SafeLong

--- a/core/shared/src/main/scala/spire/math/UByte.scala
+++ b/core/shared/src/main/scala/spire/math/UByte.scala
@@ -41,9 +41,6 @@ class UByte(val signed: Byte) extends AnyVal with scala.math.ScalaNumericAnyConv
   def == (that: UByte): Boolean = this.signed == that.signed
   def != (that: UByte): Boolean = this.signed != that.signed
 
-  def ===(that: UByte): Boolean = this.signed == that.signed
-  def =!=(that: UByte): Boolean = this.signed != that.signed
-
   def <= (that: UByte): Boolean = this.toInt <= that.toInt
   def < (that: UByte): Boolean = this.toInt < that.toInt
   def >= (that: UByte): Boolean = this.toInt >= that.toInt

--- a/core/shared/src/main/scala/spire/math/UInt.scala
+++ b/core/shared/src/main/scala/spire/math/UInt.scala
@@ -31,9 +31,6 @@ class UInt(val signed: Int) extends AnyVal {
   def == (that: UInt): Boolean = this.signed == that.signed
   def != (that: UInt): Boolean = this.signed != that.signed
 
-  def ===(that: UInt): Boolean = this.signed == that.signed
-  def =!=(that: UInt): Boolean = this.signed != that.signed
-
   def <= (that: UInt): Boolean = this.toLong <= that.toLong
   def < (that: UInt): Boolean = this.toLong < that.toLong
   def >= (that: UInt): Boolean = this.toLong >= that.toLong

--- a/core/shared/src/main/scala/spire/math/ULong.scala
+++ b/core/shared/src/main/scala/spire/math/ULong.scala
@@ -68,9 +68,6 @@ class ULong(val signed: Long) extends AnyVal {
   final def == (that: ULong): Boolean = this.signed == that.signed
   final def != (that: ULong): Boolean = this.signed != that.signed
 
-  final def === (that: ULong): Boolean = this.signed == that.signed
-  final def =!= (that: ULong): Boolean = this.signed != that.signed
-
   final def <= (that: ULong): Boolean = if (this.signed >= 0L)
     this.signed <= that.signed || that.signed < 0L
   else

--- a/core/shared/src/main/scala/spire/math/UShort.scala
+++ b/core/shared/src/main/scala/spire/math/UShort.scala
@@ -32,9 +32,6 @@ class UShort(val signed: Char) extends AnyVal {
   def == (that: UShort): Boolean = this.signed == that.signed
   def != (that: UShort): Boolean = this.signed != that.signed
 
-  def ===(that: UShort): Boolean = this.signed == that.signed
-  def =!=(that: UShort): Boolean = this.signed != that.signed
-
   def <= (that: UShort): Boolean = this.signed <= that.signed
   def < (that: UShort): Boolean = this.signed < that.signed
   def >= (that: UShort): Boolean = this.signed >= that.signed

--- a/extras/src/main/scala/spire/math/FixedPoint.scala
+++ b/extras/src/main/scala/spire/math/FixedPoint.scala
@@ -41,10 +41,6 @@ class FixedPoint(val long: Long) extends AnyVal { lhs =>
     if (long != Long.MinValue) new FixedPoint(-long)
     else throw new FixedPointOverflow(long)
 
-  def === (rhs: FixedPoint): Boolean = lhs.long == rhs.long
-
-  def =!= (rhs: FixedPoint): Boolean = !(this === rhs)
-
   def != (rhs: FixedPoint): Boolean = lhs.long != rhs.long
 
   def abs: FixedPoint =

--- a/tests/src/test/scala/spire/math/SafeLongTest.scala
+++ b/tests/src/test/scala/spire/math/SafeLongTest.scala
@@ -5,10 +5,6 @@ import spire.algebra._
 import spire.util.Opt
 
 class SafeLongTest extends FunSuite {
-  test("===") {
-    assert(SafeLong.one === SafeLong.one)
-    assert(!(SafeLong.one =!= SafeLong.one))
-  }
   test("getLong") {
     assert(SafeLong.one.getLong == Opt(1L))
     assert(SafeLong.safe64.getLong == Opt.empty[Long])


### PR DESCRIPTION
Remove === and =!= methods, since they are better handled by the === macro now

The only case that is a bit more complex is the Number hierarchy. Tests pass, but I would not be surprised if this was not properly covered. So review by @non @tixxit 
