### PR TITLE
Type aliases

### DIFF
--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
@@ -1,8 +1,8 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import java.util.concurrent.TimeUnit
 
-import scala.{specialized => spec}
 
 import org.openjdk.jmh.annotations._
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/AddBenchmarks.scala
@@ -14,7 +14,7 @@ import spire.math._
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 class AddBenchmarks {
 
-  def addGeneric[@spec(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
+  def addGeneric[@sp(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/ComplexState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/ComplexState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations._
 import spire.math.Complex

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/DoubleState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/DoubleState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations.{Scope, Setup, State}
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FastComplexState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FastComplexState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations.{Scope, Setup, State}
 import spire.math.FastComplex

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FloatState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/FloatState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations.{Scope, Setup, State}
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/IntState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/IntState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations.{Scope, Setup, State}
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/LongState.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/LongState.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import org.openjdk.jmh.annotations.{Scope, Setup, State}
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/RationalBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/RationalBenchmarks.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/SafeLongBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/SafeLongBenchmarks.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StateSupport.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StateSupport.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import spire.benchmark.FixtureSupport
 

--- a/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StrictEqBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/spire/benchmark/jmh/StrictEqBenchmarks.scala
@@ -1,4 +1,5 @@
-package spire.benchmark.jmh
+package spire
+package benchmark.jmh
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -19,7 +19,7 @@ import java.math.BigInteger
 object AddBenchmarks extends MyRunner(classOf[AddBenchmarks])
 
 class AddBenchmarks extends MyBenchmark with BenchmarkData {
-  def addGeneric[@spec(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
+  def addGeneric[@sp(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length

--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 
 import spire.algebra._

--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 

--- a/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
@@ -34,7 +34,7 @@ class AnyValAddBenchmarks extends MyBenchmark {
     doubles = init(size)(nextDouble)
   }
 
-  def addGeneric[@spec(Byte, Short, Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
+  def addGeneric[@sp(Byte, Short, Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length

--- a/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
@@ -1,6 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
@@ -33,7 +33,7 @@ class AnyValSubtractBenchmarks extends MyBenchmark {
     doubles = init(size)(nextDouble)
   }
 
-  def subtractGeneric[@spec(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
+  def subtractGeneric[@sp(Int, Long, Float, Double) A:Ring](data:Array[A]):A = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length

--- a/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
@@ -1,6 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -55,7 +55,7 @@ class ArrayOrderBenchmarks extends MyBenchmark {
     x.length - y.length
   }
 
-  def indirectAdd[@spec(Int) A: ClassTag: Ring](x: Array[A], y: Array[A]): Array[A] =
+  def indirectAdd[@sp(Int) A: ClassTag: Ring](x: Array[A], y: Array[A]): Array[A] =
     spire.std.ArraySupport.plus(x, y)
 
   def directAdd(x: Array[Int], y: Array[Int]): Array[Int] = {

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -1,7 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 import scala.util.Random

--- a/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/BigIntRational.scala
+++ b/benchmark/src/main/scala/spire/benchmark/BigIntRational.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 object BigIntRational {
   val Zero = new BigIntRational(0, 1)

--- a/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
@@ -1,7 +1,5 @@
-package spire.benchmark
-
-import scala.{specialized => spec}
-import scala.annotation.tailrec
+package spire
+package benchmark
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.util.Random
 import spire.macros.Checked

--- a/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
@@ -29,7 +29,7 @@ class ComplexAddBenchmarks extends MyBenchmark {
     fcs = init(size)(FloatComplex(nextFloat(), nextFloat()))
   }
 
-  def addGeneric[@spec(Float) A:Ring](data:Array[A]):A = {
+  def addGeneric[@sp(Float) A:Ring](data:Array[A]):A = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length

--- a/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
@@ -1,6 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 
 import spire.algebra._

--- a/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 

--- a/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
@@ -120,7 +120,7 @@ class FibBenchmarks extends MyBenchmark {
     a + b + c + d
   }
 
-  def scalaGenFib[@spec(Int, Long) A](n: Int)(implicit r: Rig[A]): A = {
+  def scalaGenFib[@sp(Int, Long) A](n: Int)(implicit r: Rig[A]): A = {
     @tailrec def loop(n :Int, a: A, b: A): A =
       if (n == 0) a else loop(n - 1, b, a + b)
     loop(n, r.zero, r.one)

--- a/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
@@ -1,8 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.math.Complex
 
-import scala.reflect.ClassTag
 
 import spire.algebra.Order
 

--- a/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import com.google.caliper.Param
 

--- a/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
@@ -1,7 +1,5 @@
-package spire.benchmark
-
-import scala.{specialized => spec}
-import scala.annotation.tailrec
+package spire
+package benchmark
 
 import scala.util.Random
 

--- a/benchmark/src/main/scala/spire/benchmark/LongRational.scala
+++ b/benchmark/src/main/scala/spire/benchmark/LongRational.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.implicits._
 

--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.algebra._
 import spire.implicits._

--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -6,7 +6,6 @@ import spire.implicits._
 import com.google.caliper.{ Runner, SimpleBenchmark, Param }
 
 import scala.util.Random._
-import scala.annotation.tailrec
 
 object MapSemigroupBenchmarks extends MyRunner(classOf[MapSemigroupBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.implicits._
 import spire.math.Rational

--- a/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
@@ -1,7 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 import scala.util.Random

--- a/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 
 import spire.math._

--- a/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 

--- a/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
@@ -1,6 +1,5 @@
 package spire.benchmark
 
-import scala.reflect.ClassTag
 
 import spire.implicits._
 

--- a/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 
 import spire.implicits._

--- a/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
@@ -1,6 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
 import scala.util.Random
 import Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -1,9 +1,8 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import scala.reflect.ClassTag
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.util.Random
 
 import spire.math._

--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -1,6 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
 import scala.reflect.ClassTag
 
 import spire.implicits._

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import spire.implicits._
 import spire.math._

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -81,7 +81,7 @@ class RexBenchmarks extends MyBenchmark with BenchmarkData {
     ai(k)
   }
 
-  def nearlyMaxG[@spec A: Numeric: ClassTag](a: Array[A], k: Int, start: Int = 0, end: Int = -1): A = {
+  def nearlyMaxG[@sp A: Numeric: ClassTag](a: Array[A], k: Int, start: Int = 0, end: Int = -1): A = {
     val i0 = if (start >= 0) start else a.length + start
     val i1 = if (end >= 0) end else a.length + end + 1
     val ai = new Array[A](max(k, 0) + 1)

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -72,7 +72,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
     while (i < len) { cs(i) = as(i) + bs(i); i += 1 }
   }
 
-  def doPairwiseSpire[@spec(Int) A:Ring](as:Array[A], bs: Array[A], cs: Array[A]): Unit = {
+  def doPairwiseSpire[@sp(Int) A:Ring](as:Array[A], bs: Array[A], cs: Array[A]): Unit = {
     import spire.implicits._
     var i = 0
     val len = as.length
@@ -99,7 +99,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
     t
   }
 
-  def doIncrementSpire[@spec(Int) A:Ring:Order](start: A, n: A) = {
+  def doIncrementSpire[@sp(Int) A:Ring:Order](start: A, n: A) = {
     import spire.implicits._
     val ev = Ring[A]
     var t = start
@@ -142,7 +142,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
     (zmin, zmax)
   }
 
-  def doMinMaxSpire[@spec(Int) A:Ring:Order](ns: Array[A]) = {
+  def doMinMaxSpire[@sp(Int) A:Ring:Order](ns: Array[A]) = {
     import spire.implicits._
 
     var zmin = ns(0)
@@ -182,12 +182,12 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
     while (i < len) { cs(i) = gcdGeneric(as(i), bs(i)); i += 1 }
   }
 
-  @tailrec final def gcdSpire[@spec(Int) A](a: A, b: A)(implicit ev1:EuclideanRing[A], ev2:Eq[A]): A = {
+  @tailrec final def gcdSpire[@sp(Int) A](a: A, b: A)(implicit ev1:EuclideanRing[A], ev2:Eq[A]): A = {
     import spire.implicits._
     if (a % b === ev1.zero) b else gcdSpire(b, a % b)
   }
 
-  def doGcdSpire[@spec(Int) A:EuclideanRing:Eq](as: Array[A], bs: Array[A], cs: Array[A]) = {
+  def doGcdSpire[@sp(Int) A:EuclideanRing:Eq](as: Array[A], bs: Array[A], cs: Array[A]) = {
     var i = 0
     val len = as.length
     while (i < len) { cs(i) = gcdSpire(as(i), bs(i)); i += 1 }
@@ -209,7 +209,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
     while (i < len) { cs(i) = as(i) * n / d; i += 1}
   }
 
-  def doScaleSpire[@spec(Int) A:EuclideanRing](as: Array[A], n: A, d: A, cs: Array[A]) = {
+  def doScaleSpire[@sp(Int) A:EuclideanRing](as: Array[A], n: A, d: A, cs: Array[A]) = {
     import spire.implicits._
     var i = 0
     val len = as.length
@@ -224,7 +224,7 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
 //}
 //
 //object Spire {
-//  @tailrec final def gcd[@spec(Int) A: Integral](a: A, b: A): A =
+//  @tailrec final def gcd[@sp(Int) A: Integral](a: A, b: A): A =
 //    if (a % b === Integral[A].zero) b else gcd(b, a % b)
 //}
 //

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -1,7 +1,5 @@
-package spire.benchmark
-
-import scala.{specialized => spec}
-import scala.annotation.tailrec
+package spire
+package benchmark
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
@@ -1,7 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 import scala.util.Random

--- a/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
@@ -1,4 +1,5 @@
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.math.prime._
 import scala.util.{Success, Try}

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -19,7 +19,7 @@ import com.google.caliper.Param
 
 object SortingBenchmarks extends MyRunner(classOf[SortingBenchmarks])
 
-final class FakeComplex[@spec(Float, Double) T](val real:T, val imag:T)(implicit f:Fractional[T], t:Trig[T]) extends Ordered[FakeComplex[T]] {
+final class FakeComplex[@sp(Float, Double) T](val real:T, val imag:T)(implicit f:Fractional[T], t:Trig[T]) extends Ordered[FakeComplex[T]] {
   def compare(b: FakeComplex[T]): Int = {
     if (f.lt(real, b.real)) -1
     else if (f.gt(real, b.real)) 1

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -1,7 +1,6 @@
 package spire
 package benchmark
 
-import scala.reflect.ClassTag
 
 import scala.util.Random
 import Random._

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -1,7 +1,6 @@
-package spire.benchmark
+package spire
+package benchmark
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 import scala.util.Random

--- a/benchmark/src/main/scala/spire/benchmark/ZigguratBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ZigguratBenchmarks.scala
@@ -12,7 +12,8 @@
 \************************************************************************/
 
 
-package spire.benchmark
+package spire
+package benchmark
 
 import spire.implicits._
 

--- a/core/shared/src/main/scala/spire/algebra/Action.scala
+++ b/core/shared/src/main/scala/spire/algebra/Action.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A (left) semigroup/monoid/group action of `G` on `P` is simply the implementation of

--- a/core/shared/src/main/scala/spire/algebra/Action.scala
+++ b/core/shared/src/main/scala/spire/algebra/Action.scala
@@ -10,7 +10,7 @@ package algebra
  *
  * 2. `id |+|> p === p` for all `p` in `P` (if `id` is defined)
  */
-trait LeftAction[@spec(Int) P, G] extends Any {
+trait LeftAction[@sp(Int) P, G] extends Any {
   def actl(g: G, p: P): P
 }
 
@@ -26,7 +26,7 @@ object LeftAction {
  *
  * 2. `p <|+| id === p` for all `p` in `P` (if `id` is defined)
  */
-trait RightAction[@spec(Int) P, G] extends Any {
+trait RightAction[@sp(Int) P, G] extends Any {
   def actr(p: P, g: G): P
 }
 
@@ -54,7 +54,7 @@ object RightAction {
   *
   * 5. `g |+|> p === p <|+| g.inverse`.
   */
-trait Action[@spec(Int) P, G] extends Any with LeftAction[P, G] with RightAction[P, G]
+trait Action[@sp(Int) P, G] extends Any with LeftAction[P, G] with RightAction[P, G]
 
 object Action {
   @inline def apply[P, G](G: Action[P, G]): Action[P, G] = G
@@ -62,7 +62,7 @@ object Action {
   @inline def multiplicative[P, G](G: MultiplicativeAction[P, G]): Action[P, G] = G.multiplicative
 }
 
-trait AdditiveAction[@spec(Int) P, G] extends Any { self =>
+trait AdditiveAction[@sp(Int) P, G] extends Any { self =>
   def additive: Action[P, G] = new Action[P, G] {
     def actl(g: G, p: P): P = self.gplusl(g, p)
     def actr(p: P, g: G): P = self.gplusr(p, g)
@@ -72,7 +72,7 @@ trait AdditiveAction[@spec(Int) P, G] extends Any { self =>
   def gplusr(p: P, g: G): P
 }
 
-trait MultiplicativeAction[@spec(Int) P, G] extends Any { self =>
+trait MultiplicativeAction[@sp(Int) P, G] extends Any { self =>
   def multiplicative: Action[P, G] = new Action[P, G] {
     def actl(g: G, p: P): P = self.gtimesl(g, p)
     def actr(p: P, g: G): P = self.gtimesr(p, g)

--- a/core/shared/src/main/scala/spire/algebra/Additive.scala
+++ b/core/shared/src/main/scala/spire/algebra/Additive.scala
@@ -37,7 +37,7 @@ object Additive {
   }
 }
 
-trait AdditiveSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def additive: Semigroup[A] = new Semigroup[A] {
     def op(x: A, y: A): A = plus(x, y)
   }
@@ -71,13 +71,13 @@ trait AdditiveSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends 
   def sumOption(as: TraversableOnce[A]): Option[A] = as.reduceOption(plus)
 }
 
-trait AdditiveCSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveCSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: CSemigroup[A] = new CSemigroup[A] {
     def op(x: A, y: A): A = plus(x, y)
   }
 }
 
-trait AdditiveMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: Monoid[A] = new Monoid[A] {
     def id: A = zero
     def op(x: A, y: A): A = plus(x, y)
@@ -105,14 +105,14 @@ trait AdditiveMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any
   def sum(as: TraversableOnce[A]): A = as.aggregate(zero)(plus, plus)
 }
 
-trait AdditiveCMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCSemigroup[A] {
+trait AdditiveCMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCSemigroup[A] {
   override def additive: CMonoid[A] = new CMonoid[A] {
     def id: A = zero
     def op(x: A, y: A): A = plus(x, y)
   }
 }
 
-trait AdditiveGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
+trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
   override def additive: Group[A] = new Group[A] {
     def id: A = zero
     def op(x: A, y: A): A = plus(x, y)
@@ -133,7 +133,7 @@ trait AdditiveGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any 
     else sumnAboveOne(a, n)
 }
 
-trait AdditiveAbGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCMonoid[A] {
+trait AdditiveAbGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCMonoid[A] {
   override def additive: AbGroup[A] = new AbGroup[A] {
     def id: A = zero
     def op(x: A, y: A): A = plus(x, y)

--- a/core/shared/src/main/scala/spire/algebra/Additive.scala
+++ b/core/shared/src/main/scala/spire/algebra/Additive.scala
@@ -1,7 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 
 
 object Additive {

--- a/core/shared/src/main/scala/spire/algebra/Bool.scala
+++ b/core/shared/src/main/scala/spire/algebra/Bool.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => sp}
+package spire
+package algebra
 
 import spire.algebra.lattice.Heyting
 

--- a/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
@@ -1,12 +1,11 @@
-package spire.algebra
+package spire
+package algebra
 
 import spire.std._
 
-import scala.{ specialized => spec }
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
-import scala.annotation.tailrec
 
 trait CoordinateSpace[V, @spec(Float, Double) F] extends Any with InnerProductSpace[V, F] {
   def dimensions: Int

--- a/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
@@ -5,7 +5,6 @@ import spire.std._
 
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
 
 trait CoordinateSpace[V, @sp(Float, Double) F] extends Any with InnerProductSpace[V, F] {
   def dimensions: Int

--- a/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/CoordinateSpace.scala
@@ -7,7 +7,7 @@ import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 
-trait CoordinateSpace[V, @spec(Float, Double) F] extends Any with InnerProductSpace[V, F] {
+trait CoordinateSpace[V, @sp(Float, Double) F] extends Any with InnerProductSpace[V, F] {
   def dimensions: Int
 
   def coord(v: V, i: Int): F  // = v dot axis(i)
@@ -32,11 +32,11 @@ trait CoordinateSpace[V, @spec(Float, Double) F] extends Any with InnerProductSp
 }
 
 object CoordinateSpace {
-  @inline final def apply[V, @spec(Float,Double) F](implicit V: CoordinateSpace[V, F]): CoordinateSpace[V, F] = V
+  @inline final def apply[V, @sp(Float,Double) F](implicit V: CoordinateSpace[V, F]): CoordinateSpace[V, F] = V
 
   def seq[A: Field, CC[A] <: SeqLike[A, CC[A]]](dimensions: Int)(implicit
       cbf0: CanBuildFrom[CC[A], A, CC[A]]): SeqCoordinateSpace[A, CC[A]] = new SeqCoordinateSpace[A, CC[A]](dimensions)
 
-  def array[@spec(Float, Double) A: Field: ClassTag](dimensions: Int): CoordinateSpace[Array[A], A] =
+  def array[@sp(Float, Double) A: Field: ClassTag](dimensions: Int): CoordinateSpace[Array[A], A] =
     new ArrayCoordinateSpace[A](dimensions)
 }

--- a/core/shared/src/main/scala/spire/algebra/Eq.scala
+++ b/core/shared/src/main/scala/spire/algebra/Eq.scala
@@ -6,7 +6,7 @@ package algebra
  * type. Any 2 instances `x` and `y` are equal if `eqv(x, y)` is `true`.
  * Moreover, `eqv` should form an equivalence relation.
  */
-trait Eq[@spec A] extends Any {
+trait Eq[@sp A] extends Any {
   /** Returns `true` if `x` and `y` are equivalent, `false` otherwise. */
   def eqv(x:A, y:A): Boolean
 
@@ -17,15 +17,15 @@ trait Eq[@spec A] extends Any {
    * Constructs a new `Eq` instance for type `B` where 2 elements are
    * equivalent iff `eqv(f(x), f(y))`.
    */
-  def on[@spec B](f:B => A): Eq[B] = new MappedEq(this)(f)
+  def on[@sp B](f:B => A): Eq[B] = new MappedEq(this)(f)
 }
 
-private[algebra] class MappedEq[@spec A, @spec B](eq: Eq[B])(f: A => B) extends Eq[A] {
+private[algebra] class MappedEq[@sp A, @sp B](eq: Eq[B])(f: A => B) extends Eq[A] {
   def eqv(x: A, y: A): Boolean = eq.eqv(f(x), f(x))
 }
 
 object Eq {
   def apply[A](implicit e:Eq[A]):Eq[A] = e
 
-  def by[@spec A, @spec B](f:A => B)(implicit e:Eq[B]): Eq[A] = new MappedEq(e)(f)
+  def by[@sp A, @sp B](f:A => B)(implicit e:Eq[B]): Eq[A] = new MappedEq(e)(f)
 }

--- a/core/shared/src/main/scala/spire/algebra/Eq.scala
+++ b/core/shared/src/main/scala/spire/algebra/Eq.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
  * A type class used to determine equality between 2 instances of the same

--- a/core/shared/src/main/scala/spire/algebra/EuclideanRing.scala
+++ b/core/shared/src/main/scala/spire/algebra/EuclideanRing.scala
@@ -1,7 +1,7 @@
 package spire
 package algebra
 
-trait EuclideanRing[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with CRing[A] {
+trait EuclideanRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with CRing[A] {
   def quot(a: A, b: A): A
   def mod(a: A, b: A): A
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))

--- a/core/shared/src/main/scala/spire/algebra/EuclideanRing.scala
+++ b/core/shared/src/main/scala/spire/algebra/EuclideanRing.scala
@@ -1,7 +1,5 @@
-package spire.algebra
-
-import scala.annotation.tailrec
-import scala.{specialized => spec}
+package spire
+package algebra
 
 trait EuclideanRing[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with CRing[A] {
   def quot(a: A, b: A): A

--- a/core/shared/src/main/scala/spire/algebra/Field.scala
+++ b/core/shared/src/main/scala/spire/algebra/Field.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => spec}
+package spire
+package algebra
 
 import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
 import java.lang.Long.{ numberOfTrailingZeros }

--- a/core/shared/src/main/scala/spire/algebra/Field.scala
+++ b/core/shared/src/main/scala/spire/algebra/Field.scala
@@ -4,7 +4,7 @@ package algebra
 import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
 import java.lang.Long.{ numberOfTrailingZeros }
 
-trait Field[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeAbGroup[A] {
+trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeAbGroup[A] {
 
   /**
    * This is implemented in terms of basic Field ops. However, this is

--- a/core/shared/src/main/scala/spire/algebra/Group.scala
+++ b/core/shared/src/main/scala/spire/algebra/Group.scala
@@ -5,7 +5,7 @@ package algebra
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
+trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
 
   /**
    * Return the inverse of `a`.
@@ -37,7 +37,7 @@ object Group {
 /**
  * An abelian group is a group whose operation is commutative.
  */
-trait AbGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CMonoid[A]
+trait AbGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CMonoid[A]
 
 object AbGroup {
   @inline final def apply[A](implicit ev: AbGroup[A]): AbGroup[A] = ev

--- a/core/shared/src/main/scala/spire/algebra/Group.scala
+++ b/core/shared/src/main/scala/spire/algebra/Group.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A group is a monoid where each element has an inverse.

--- a/core/shared/src/main/scala/spire/algebra/InnerProductSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/InnerProductSpace.scala
@@ -2,7 +2,7 @@ package spire
 package algebra
 
 
-trait InnerProductSpace[V, @spec(Int, Long, Float, Double) F] extends Any with VectorSpace[V, F] { self =>
+trait InnerProductSpace[V, @sp(Int, Long, Float, Double) F] extends Any with VectorSpace[V, F] { self =>
   def dot(v: V, w: V): F
 
   def normed(implicit ev: NRoot[F]): NormedVectorSpace[V, F] = new NormedInnerProductSpace[V, F] {
@@ -12,10 +12,10 @@ trait InnerProductSpace[V, @spec(Int, Long, Float, Double) F] extends Any with V
 }
 
 object InnerProductSpace {
-  @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: InnerProductSpace[V, R]): InnerProductSpace[V, R] = V
+  @inline final def apply[V, @sp(Int,Long,Float,Double) R](implicit V: InnerProductSpace[V, R]): InnerProductSpace[V, R] = V
 }
 
-private[algebra] trait NormedInnerProductSpace[V, @spec(Float, Double) F] extends Any with NormedVectorSpace[V, F] {
+private[algebra] trait NormedInnerProductSpace[V, @sp(Float, Double) F] extends Any with NormedVectorSpace[V, F] {
   def space: InnerProductSpace[V, F]
   def scalar: Field[F] = space.scalar
   def nroot: NRoot[F]

--- a/core/shared/src/main/scala/spire/algebra/InnerProductSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/InnerProductSpace.scala
@@ -1,7 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 
 trait InnerProductSpace[V, @spec(Int, Long, Float, Double) F] extends Any with VectorSpace[V, F] { self =>
   def dot(v: V, w: V): F

--- a/core/shared/src/main/scala/spire/algebra/IsReal.scala
+++ b/core/shared/src/main/scala/spire/algebra/IsReal.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 import spire.math.{ Real, Algebraic, Rational }
 

--- a/core/shared/src/main/scala/spire/algebra/IsReal.scala
+++ b/core/shared/src/main/scala/spire/algebra/IsReal.scala
@@ -7,7 +7,7 @@ import spire.math.{ Real, Algebraic, Rational }
 /**
  * A simple type class for numeric types that are a subset of the reals.
  */
-trait IsReal[@spec A] extends Any with Order[A] with Signed[A] {
+trait IsReal[@sp A] extends Any with Order[A] with Signed[A] {
 
   /**
    * Rounds `a` the nearest integer that is greater than or equal to `a`.
@@ -38,28 +38,28 @@ trait IsReal[@spec A] extends Any with Order[A] with Signed[A] {
 }
 
 object IsReal {
-  def apply[@spec A](implicit A: IsReal[A]): IsReal[A] = A
+  def apply[@sp A](implicit A: IsReal[A]): IsReal[A] = A
 }
 
-trait IsAlgebraic[@spec A] extends Any with IsReal[A] {
+trait IsAlgebraic[@sp A] extends Any with IsReal[A] {
   def toAlgebraic(a: A): Algebraic
   def toReal(a: A): Real = toAlgebraic(a).toReal
 }
 
 object IsAlgebraic {
-  def apply[@spec A](implicit A: IsAlgebraic[A]): IsAlgebraic[A] = A
+  def apply[@sp A](implicit A: IsAlgebraic[A]): IsAlgebraic[A] = A
 }
 
-trait IsRational[@spec A] extends Any with IsAlgebraic[A] {
+trait IsRational[@sp A] extends Any with IsAlgebraic[A] {
   def toRational(a: A): Rational
   def toAlgebraic(a: A): Algebraic = Algebraic(toRational(a))
 }
 
 object IsRational {
-  def apply[@spec A](implicit A: IsRational[A]): IsRational[A] = A
+  def apply[@sp A](implicit A: IsRational[A]): IsRational[A] = A
 }
 
-trait IsIntegral[@spec(Byte,Short,Int,Long) A] extends Any with IsRational[A] {
+trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsRational[A] {
   def ceil(a: A): A = a
   def floor(a: A): A = a
   def round(a: A): A = a
@@ -69,5 +69,5 @@ trait IsIntegral[@spec(Byte,Short,Int,Long) A] extends Any with IsRational[A] {
 }
 
 object IsIntegral {
-  def apply[@spec A](implicit A: IsIntegral[A]): IsIntegral[A] = A
+  def apply[@sp A](implicit A: IsIntegral[A]): IsIntegral[A] = A
 }

--- a/core/shared/src/main/scala/spire/algebra/MetricSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/MetricSpace.scala
@@ -6,27 +6,27 @@ package algebra
  * This type class models a metric space `V`. The distance between 2 points in
  * `V` is measured in `R`, which should be real (ie. `IsReal[R]` exists).
  */
-trait MetricSpace[V, @spec(Int, Long, Float, Double) R] extends Any {
+trait MetricSpace[V, @sp(Int, Long, Float, Double) R] extends Any {
   def distance(v: V, w: V): R
 }
 
 object MetricSpace extends MetricSpace0 {
-  @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: MetricSpace[V, R]): MetricSpace[V, R] = V
+  @inline final def apply[V, @sp(Int,Long,Float,Double) R](implicit V: MetricSpace[V, R]): MetricSpace[V, R] = V
 
-  def distance[V, @spec(Int,Long,Float,Double) R](v: V, w: V)(implicit
+  def distance[V, @sp(Int,Long,Float,Double) R](v: V, w: V)(implicit
     metric: MetricSpace[V, R]): R = metric.distance(v, w)
 
   /**
    * Returns `true` iff the distance between `x` and `y` is less than or equal
    * to `tolerance`.
    */
-  def closeTo[V, @spec(Int,Long,Float,Double) R](x: V, y: V, tolerance: Double)(implicit
+  def closeTo[V, @sp(Int,Long,Float,Double) R](x: V, y: V, tolerance: Double)(implicit
       R: IsReal[R], metric: MetricSpace[V, R]): Boolean =
     R.toDouble(metric.distance(x, y)) <= tolerance
 }
 
 private[algebra] trait MetricSpace0 {
-  implicit def realMetricSpace[@spec(Int,Long,Float,Double) R](implicit
+  implicit def realMetricSpace[@sp(Int,Long,Float,Double) R](implicit
       R0: IsReal[R], R1: Rng[R]): MetricSpace[R, R] = new MetricSpace[R, R] {
     def distance(v: R, w: R): R = R0.abs(R1.minus(v, w))
   }

--- a/core/shared/src/main/scala/spire/algebra/MetricSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/MetricSpace.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * This type class models a metric space `V`. The distance between 2 points in

--- a/core/shared/src/main/scala/spire/algebra/Module.scala
+++ b/core/shared/src/main/scala/spire/algebra/Module.scala
@@ -6,7 +6,7 @@ package algebra
  * A module generalizes a vector space by requiring its scalar need only form
  * a ring, rather than a field.
  */
-trait Module[V, @spec(Int,Long,Float,Double) R] extends Any with AdditiveAbGroup[V] {
+trait Module[V, @sp(Int,Long,Float,Double) R] extends Any with AdditiveAbGroup[V] {
   implicit def scalar: Rng[R]
 
   def timesl(r: R, v: V): V
@@ -14,16 +14,16 @@ trait Module[V, @spec(Int,Long,Float,Double) R] extends Any with AdditiveAbGroup
 }
 
 object Module {
-  @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: Module[V, R]): Module[V, R] = V
+  @inline final def apply[V, @sp(Int,Long,Float,Double) R](implicit V: Module[V, R]): Module[V, R] = V
 
-  implicit def IdentityModule[@spec(Int,Long,Float,Double) V](implicit ring: Ring[V]): IdentityModule[V] = {
+  implicit def IdentityModule[@sp(Int,Long,Float,Double) V](implicit ring: Ring[V]): IdentityModule[V] = {
     new IdentityModule[V] {
       val scalar = ring
     }
   }
 }
 
-private[algebra] trait IdentityModule[@spec(Int,Long,Float,Double) V] extends Any with Module[V, V] {
+private[algebra] trait IdentityModule[@sp(Int,Long,Float,Double) V] extends Any with Module[V, V] {
   def zero: V = scalar.zero
   def negate(v: V): V = scalar.negate(v)
   def plus(v: V, w: V): V = scalar.plus(v, w)

--- a/core/shared/src/main/scala/spire/algebra/Module.scala
+++ b/core/shared/src/main/scala/spire/algebra/Module.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A module generalizes a vector space by requiring its scalar need only form

--- a/core/shared/src/main/scala/spire/algebra/Monoid.scala
+++ b/core/shared/src/main/scala/spire/algebra/Monoid.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A monoid is a semigroup with an identity. A monoid is a specialization of a

--- a/core/shared/src/main/scala/spire/algebra/Monoid.scala
+++ b/core/shared/src/main/scala/spire/algebra/Monoid.scala
@@ -8,7 +8,7 @@ package algebra
  * `op(x, id) == op(id, x) == x`. For example, if we have `Monoid[String]`,
  * with `op` as string concatenation, then `id = ""`.
  */
-trait Monoid[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * Return the identity element for this monoid.
@@ -57,7 +57,7 @@ object Monoid {
  *
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CMonoid[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CSemigroup[A]
+trait CMonoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CSemigroup[A]
 
 object CMonoid {
   @inline final def apply[A](implicit ev: CMonoid[A]): CMonoid[A] = ev

--- a/core/shared/src/main/scala/spire/algebra/Multiplicative.scala
+++ b/core/shared/src/main/scala/spire/algebra/Multiplicative.scala
@@ -1,7 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 
 object Multiplicative {
   def apply[A](s: Semigroup[A]): MultiplicativeSemigroup[A] = new MultiplicativeSemigroup[A] {

--- a/core/shared/src/main/scala/spire/algebra/Multiplicative.scala
+++ b/core/shared/src/main/scala/spire/algebra/Multiplicative.scala
@@ -36,7 +36,7 @@ object Multiplicative {
   }
 }
 
-trait MultiplicativeSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def multiplicative: Semigroup[A] = new Semigroup[A] {
     def op(x: A, y: A): A = times(x, y)
   }
@@ -70,13 +70,13 @@ trait MultiplicativeSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] ex
   def prodOption(as: TraversableOnce[A]): Option[A] = as.reduceOption(times)
 }
 
-trait MultiplicativeCSemigroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeCSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def multiplicative: CSemigroup[A] = new CSemigroup[A] {
     def op(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def multiplicative: Monoid[A] = new Monoid[A] {
     def id: A = one
     def op(x: A, y: A): A = times(x, y)
@@ -101,14 +101,14 @@ trait MultiplicativeMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] exten
   def prod(as: TraversableOnce[A]): A = as.aggregate(one)(times, times)
 }
 
-trait MultiplicativeCMonoid[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCSemigroup[A] {
+trait MultiplicativeCMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCSemigroup[A] {
   override def multiplicative: CMonoid[A] = new CMonoid[A] {
     def id: A = one
     def op(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
+trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
   override def multiplicative: Group[A] = new Group[A] {
     def id: A = one
     def op(x: A, y: A): A = times(x, y)
@@ -129,7 +129,7 @@ trait MultiplicativeGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extend
     else prodnAboveOne(a, n)
 }
 
-trait MultiplicativeAbGroup[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCMonoid[A] {
+trait MultiplicativeAbGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCMonoid[A] {
   override def multiplicative: AbGroup[A] = new AbGroup[A] {
     def id: A = one
     def op(x: A, y: A): A = times(x, y)

--- a/core/shared/src/main/scala/spire/algebra/NRoot.scala
+++ b/core/shared/src/main/scala/spire/algebra/NRoot.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{specialized => spec}
 import java.math.MathContext
 
 // NOTE: fpow vs pow is a bit of a trainwreck :P

--- a/core/shared/src/main/scala/spire/algebra/NRoot.scala
+++ b/core/shared/src/main/scala/spire/algebra/NRoot.scala
@@ -17,7 +17,7 @@ import java.math.MathContext
  * computation and testing if a value is negative may not be ideal. So, do not
  * count on `ArithmeticException`s to save you from bad arithmetic!
  */
-trait NRoot[@spec(Double,Float,Int,Long) A] extends Any {
+trait NRoot[@sp(Double,Float,Int,Long) A] extends Any {
   def nroot(a: A, n: Int): A
   def sqrt(a: A): A = nroot(a, 2)
   def fpow(a:A, b:A): A
@@ -26,7 +26,7 @@ trait NRoot[@spec(Double,Float,Int,Long) A] extends Any {
 import spire.math.{ConvertableTo, ConvertableFrom, Number}
 
 object NRoot {
-  @inline final def apply[@spec(Int,Long,Float,Double) A](implicit ev:NRoot[A]): NRoot[A] = ev
+  @inline final def apply[@sp(Int,Long,Float,Double) A](implicit ev:NRoot[A]): NRoot[A] = ev
 
   /**
    * This will return the largest integer that meets some criteria. Specifically,

--- a/core/shared/src/main/scala/spire/algebra/NormedVectorSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/NormedVectorSpace.scala
@@ -17,7 +17,7 @@ import scala.collection.generic.CanBuildFrom
  * An example of a normed vector space is R^n equipped with the euclidean
  * vector length as the norm.
  */
-trait NormedVectorSpace[V, @spec(Int, Long, Float, Double) F] extends Any with VectorSpace[V, F] with MetricSpace[V, F] {
+trait NormedVectorSpace[V, @sp(Int, Long, Float, Double) F] extends Any with VectorSpace[V, F] with MetricSpace[V, F] {
   def norm(v: V): F
 
   def normalize(v: V): V = divr(v, norm(v))
@@ -25,11 +25,11 @@ trait NormedVectorSpace[V, @spec(Int, Long, Float, Double) F] extends Any with V
 }
 
 object NormedVectorSpace extends NormedVectorSpace0 with NormedVectorSpaceFunctions {
-  @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: NormedVectorSpace[V, R]): NormedVectorSpace[V, R] = V
+  @inline final def apply[V, @sp(Int,Long,Float,Double) R](implicit V: NormedVectorSpace[V, R]): NormedVectorSpace[V, R] = V
 }
 
 private[algebra] trait NormedVectorSpace0 {
-  implicit def InnerProductSpaceIsNormedVectorSpace[V, @spec(Int, Long, Float, Double) F](implicit
+  implicit def InnerProductSpaceIsNormedVectorSpace[V, @sp(Int, Long, Float, Double) F](implicit
     space: InnerProductSpace[V, F], nroot: NRoot[F]): NormedVectorSpace[V, F] = space.normed
 }
 

--- a/core/shared/src/main/scala/spire/algebra/NormedVectorSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/NormedVectorSpace.scala
@@ -1,8 +1,8 @@
-package spire.algebra
+package spire
+package algebra
 
 import spire.std._
 
-import scala.{ specialized => spec }
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 

--- a/core/shared/src/main/scala/spire/algebra/Order.scala
+++ b/core/shared/src/main/scala/spire/algebra/Order.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
   * The `Order` type class is used to define a total ordering on some type `A`.

--- a/core/shared/src/main/scala/spire/algebra/Order.scala
+++ b/core/shared/src/main/scala/spire/algebra/Order.scala
@@ -18,7 +18,7 @@ package algebra
   *
   * By the totality law, x <= y and y <= x cannot be both false.
   */
-trait Order[@spec A] extends Any with PartialOrder[A] {
+trait Order[@sp A] extends Any with PartialOrder[A] {
   self =>
 
   def partialCompare(x: A, y: A): Double = compare(x, y).toDouble
@@ -37,7 +37,7 @@ trait Order[@spec A] extends Any with PartialOrder[A] {
    * Defines an order on `B` by mapping `B` to `A` using `f` and using `A`s
    * order to order `B`.
    */
-  override def on[@spec B](f: B => A): Order[B] = new MappedOrder(this)(f)
+  override def on[@sp B](f: B => A): Order[B] = new MappedOrder(this)(f)
 
   /**
    * Defines an ordering on `A` where all arrows switch direction.
@@ -45,20 +45,20 @@ trait Order[@spec A] extends Any with PartialOrder[A] {
   override def reverse: Order[A] = new ReversedOrder(this)
 }
 
-private[algebra] class MappedOrder[@spec A, @spec B](order: Order[B])(f: A => B) extends Order[A] {
+private[algebra] class MappedOrder[@sp A, @sp B](order: Order[B])(f: A => B) extends Order[A] {
   def compare(x: A, y: A): Int = order.compare(f(x), f(y))
 }
 
-private[algebra] class ReversedOrder[@spec A](order: Order[A]) extends Order[A] {
+private[algebra] class ReversedOrder[@sp A](order: Order[A]) extends Order[A] {
   def compare(x: A, y: A): Int = order.compare(y, x)
 }
 
 object Order {
   @inline final def apply[A](implicit o: Order[A]): Order[A] = o
 
-  def by[@spec A, @spec B](f: A => B)(implicit o: Order[B]): Order[A] = o.on(f)
+  def by[@sp A, @sp B](f: A => B)(implicit o: Order[B]): Order[A] = o.on(f)
 
-  def from[@spec A](f: (A, A) => Int): Order[A] = new Order[A] {
+  def from[@sp A](f: (A, A) => Int): Order[A] = new Order[A] {
     def compare(x: A, y: A): Int = f(x, y)
   }
 

--- a/core/shared/src/main/scala/spire/algebra/PartialOrder.scala
+++ b/core/shared/src/main/scala/spire/algebra/PartialOrder.scala
@@ -21,7 +21,7 @@ package algebra
   * false     true        = 1.0     (corresponds to x > y)
   *
   */
-trait PartialOrder[@spec A] extends Any with Eq[A] {
+trait PartialOrder[@sp A] extends Any with Eq[A] {
   self =>
   /** Result of comparing `x` with `y`. Returns NaN if operands
     * are not comparable. If operands are comparable, returns a
@@ -71,7 +71,7 @@ trait PartialOrder[@spec A] extends Any with Eq[A] {
    * Defines a partial order on `B` by mapping `B` to `A` using `f` and using `A`s
    * order to order `B`.
    */
-  override def on[@spec B](f: B => A): PartialOrder[B] = new MappedPartialOrder(this)(f)
+  override def on[@sp B](f: B => A): PartialOrder[B] = new MappedPartialOrder(this)(f)
 
   /**
    * Defines a partial order on `A` where all arrows switch direction.
@@ -79,20 +79,20 @@ trait PartialOrder[@spec A] extends Any with Eq[A] {
   def reverse: PartialOrder[A] = new ReversedPartialOrder(this)
 }
 
-private[algebra] class MappedPartialOrder[@spec A, @spec B](partialOrder: PartialOrder[B])(f: A => B) extends PartialOrder[A] {
+private[algebra] class MappedPartialOrder[@sp A, @sp B](partialOrder: PartialOrder[B])(f: A => B) extends PartialOrder[A] {
   def partialCompare(x: A, y: A): Double = partialOrder.partialCompare(f(x), f(y))
 }
 
-private[algebra] class ReversedPartialOrder[@spec A](partialOrder: PartialOrder[A]) extends PartialOrder[A] {
+private[algebra] class ReversedPartialOrder[@sp A](partialOrder: PartialOrder[A]) extends PartialOrder[A] {
   def partialCompare(x: A, y: A): Double = partialOrder.partialCompare(y, x)
 }
 
 object PartialOrder {
   @inline final def apply[A](implicit po: PartialOrder[A]): PartialOrder[A] = po
 
-  def by[@spec A, @spec B](f: A => B)(implicit po: PartialOrder[B]): PartialOrder[A] = po.on(f)
+  def by[@sp A, @sp B](f: A => B)(implicit po: PartialOrder[B]): PartialOrder[A] = po.on(f)
 
-  def from[@spec A](f: (A, A) => Double): PartialOrder[A] = new PartialOrder[A] {
+  def from[@sp A](f: (A, A) => Double): PartialOrder[A] = new PartialOrder[A] {
     def partialCompare(x: A, y: A): Double = f(x, y)
   }
 
@@ -102,7 +102,7 @@ object PartialOrder {
   }
 }
 
-private[algebra] class DerivedPartialOrdering[@spec A](partialOrder: PartialOrder[A]) extends PartialOrdering[A] {
+private[algebra] class DerivedPartialOrdering[@sp A](partialOrder: PartialOrder[A]) extends PartialOrdering[A] {
   def tryCompare(x: A, y: A): Option[Int] = partialOrder.tryCompare(x, y)
   def lteq(x: A, y: A): Boolean = partialOrder.lteqv(x, y)
 }

--- a/core/shared/src/main/scala/spire/algebra/PartialOrder.scala
+++ b/core/shared/src/main/scala/spire/algebra/PartialOrder.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
   * The `PartialOrder` type class is used to define a partial ordering on some type `A`.

--- a/core/shared/src/main/scala/spire/algebra/Rig.scala
+++ b/core/shared/src/main/scala/spire/algebra/Rig.scala
@@ -5,7 +5,7 @@ package algebra
  * Rig is a ring whose additive structure doesn't have an inverse (ie. it is
  * monoid, not a group). Put another way, a Rig is a Ring without a negative.
  */
-trait Rig[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveMonoid[A] with MultiplicativeMonoid[A] {
+trait Rig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveMonoid[A] with MultiplicativeMonoid[A] {
   /**
    * This is similar to `Semigroup#pow`, except that `a pow 0` is defined to be
    * the multiplicative identity.
@@ -22,7 +22,7 @@ object Rig {
 /**
  * CRig is a Rig that is commutative under multiplication.
  */
-trait CRig[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCMonoid[A]
+trait CRig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCMonoid[A]
 
 object CRig {
   @inline final def apply[A](implicit r: CRig[A]): CRig[A] = r

--- a/core/shared/src/main/scala/spire/algebra/Rig.scala
+++ b/core/shared/src/main/scala/spire/algebra/Rig.scala
@@ -1,7 +1,5 @@
-package spire.algebra
-
-import annotation.tailrec
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
  * Rig is a ring whose additive structure doesn't have an inverse (ie. it is

--- a/core/shared/src/main/scala/spire/algebra/Ring.scala
+++ b/core/shared/src/main/scala/spire/algebra/Ring.scala
@@ -1,7 +1,5 @@
-package spire.algebra
-
-import annotation.tailrec
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
  * Ring represents a set (A) that is a group over addition (+) and a monoid

--- a/core/shared/src/main/scala/spire/algebra/Ring.scala
+++ b/core/shared/src/main/scala/spire/algebra/Ring.scala
@@ -10,7 +10,7 @@ package algebra
  * fundamental methods (zero, one and plus). Where possible, these methods
  * should be overridden by more efficient implementations.
  */
-trait Ring[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
+trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
   /**
    * Defined to be equivalent to `additive.sumn(one, n)`. That is, `n`
    * repeated summations of this ring's `one`, or `-one` if `n` is
@@ -26,7 +26,7 @@ object Ring {
 /**
  * CRing is a Ring that is commutative under multiplication.
  */
-trait CRing[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with MultiplicativeCMonoid[A]
+trait CRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with MultiplicativeCMonoid[A]
 
 object CRing {
   @inline final def apply[A](implicit r: CRing[A]): CRing[A] = r

--- a/core/shared/src/main/scala/spire/algebra/RingAlgebra.scala
+++ b/core/shared/src/main/scala/spire/algebra/RingAlgebra.scala
@@ -6,7 +6,7 @@ package algebra
  * A `RingAlgebra` is a module that is also a `Rng`. An example is the Gaussian
  * numbers.
  */
-trait RingAlgebra[V, @spec R] extends Any with Module[V, R] with Rng[V]
+trait RingAlgebra[V, @sp R] extends Any with Module[V, R] with Rng[V]
 
 object RingAlgebra {
   implicit def ZAlgebra[A](implicit vector0: Ring[A], scalar0: Ring[Int]): ZAlgebra[A] = new ZAlgebra[A] {
@@ -39,4 +39,4 @@ trait ZAlgebra[V] extends Any with RingAlgebra[V, Int] with Ring[V] {
  * A `FieldAlgebra` is a vector space that is also a `Ring`. An example is the
  * complex numbers.
  */
-trait FieldAlgebra[V, @spec(Float, Double) F] extends Any with RingAlgebra[V, F] with VectorSpace[V, F]
+trait FieldAlgebra[V, @sp(Float, Double) F] extends Any with RingAlgebra[V, F] with VectorSpace[V, F]

--- a/core/shared/src/main/scala/spire/algebra/RingAlgebra.scala
+++ b/core/shared/src/main/scala/spire/algebra/RingAlgebra.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A `RingAlgebra` is a module that is also a `Rng`. An example is the Gaussian

--- a/core/shared/src/main/scala/spire/algebra/Rng.scala
+++ b/core/shared/src/main/scala/spire/algebra/Rng.scala
@@ -1,7 +1,5 @@
-package spire.algebra
-
-import annotation.tailrec
-import scala.{specialized => spec}
+package spire
+package algebra
 
 /**
  * Rng is a ring whose multiplicative structure doesn't have an identity

--- a/core/shared/src/main/scala/spire/algebra/Rng.scala
+++ b/core/shared/src/main/scala/spire/algebra/Rng.scala
@@ -6,7 +6,7 @@ package algebra
  * (i.e. it is semigroup, not a monoid). Put another way, a Rng is a Ring
  * without an identity.
  */
-trait Rng[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveAbGroup[A]
+trait Rng[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveAbGroup[A]
 
 object Rng {
   @inline final def apply[A](implicit r:Rng[A]):Rng[A] = r

--- a/core/shared/src/main/scala/spire/algebra/Semigroup.scala
+++ b/core/shared/src/main/scala/spire/algebra/Semigroup.scala
@@ -1,7 +1,5 @@
-package spire.algebra
-
-import scala.{ specialized => spec }
-import scala.annotation.{ switch, tailrec }
+package spire
+package algebra
 
 /**
  * A semigroup is any set `A` with an associative operation (`op`).

--- a/core/shared/src/main/scala/spire/algebra/Semigroup.scala
+++ b/core/shared/src/main/scala/spire/algebra/Semigroup.scala
@@ -4,7 +4,7 @@ package algebra
 /**
  * A semigroup is any set `A` with an associative operation (`op`).
  */
-trait Semigroup[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
   def op(x: A, y: A): A
 
   /**
@@ -55,7 +55,7 @@ object Semigroup {
  *
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CSemigroup[@spec(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A]
+trait CSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A]
 
 object CSemigroup {
   @inline final def apply[A](implicit ev: CSemigroup[A]): CSemigroup[A] = ev

--- a/core/shared/src/main/scala/spire/algebra/Semiring.scala
+++ b/core/shared/src/main/scala/spire/algebra/Semiring.scala
@@ -9,7 +9,7 @@ package algebra
  * A Semiring with additive and multiplicative identities (0 and 1) is a Rig.
  * A Semiring with all of the above is a Ring.
  */
-trait Semiring[@spec(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with MultiplicativeSemigroup[A] {
+trait Semiring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with MultiplicativeSemigroup[A] {
   /**
    * Returns `a` multiplied with itself `n` times. For instance,
    * `a pow 3 === a * a * a`. Since this is a semiring, there is no notion of

--- a/core/shared/src/main/scala/spire/algebra/Semiring.scala
+++ b/core/shared/src/main/scala/spire/algebra/Semiring.scala
@@ -1,8 +1,5 @@
-package spire.algebra
-
-import annotation.tailrec
-import scala.{specialized => spec}
-
+package spire
+package algebra
 
 /**
  * Semiring is a ring without identities or an inverse. Thus, it has no

--- a/core/shared/src/main/scala/spire/algebra/Sign.scala
+++ b/core/shared/src/main/scala/spire/algebra/Sign.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 /**
  * A simple ADT representing the `Sign` of an object.

--- a/core/shared/src/main/scala/spire/algebra/Signed.scala
+++ b/core/shared/src/main/scala/spire/algebra/Signed.scala
@@ -6,7 +6,7 @@ package algebra
  * A trait for things that have some notion of sign and the ability to ensure
  * something has a positive sign.
  */
-trait Signed[@spec(Double, Float, Int, Long) A] extends Any {
+trait Signed[@sp(Double, Float, Int, Long) A] extends Any {
   /** Returns Zero if `a` is 0, Positive if `a` is positive, and Negative is `a` is negative. */
   def sign(a: A): Sign = Sign(signum(a))
 

--- a/core/shared/src/main/scala/spire/algebra/Signed.scala
+++ b/core/shared/src/main/scala/spire/algebra/Signed.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A trait for things that have some notion of sign and the ability to ensure

--- a/core/shared/src/main/scala/spire/algebra/Torsor.scala
+++ b/core/shared/src/main/scala/spire/algebra/Torsor.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => sp}
+package spire
+package algebra
 
 /**
  * A Torsor[V, R] requires an AbGroup[R] and provides Action[V, R],

--- a/core/shared/src/main/scala/spire/algebra/Trig.scala
+++ b/core/shared/src/main/scala/spire/algebra/Trig.scala
@@ -1,7 +1,7 @@
 package spire
 package algebra
 
-trait Trig[@spec(Float, Double) A] extends Any {
+trait Trig[@sp(Float, Double) A] extends Any {
   def e: A
   def pi: A
 

--- a/core/shared/src/main/scala/spire/algebra/Trig.scala
+++ b/core/shared/src/main/scala/spire/algebra/Trig.scala
@@ -1,6 +1,5 @@
-package spire.algebra
-
-import scala.{specialized => spec}
+package spire
+package algebra
 
 trait Trig[@spec(Float, Double) A] extends Any {
   def e: A

--- a/core/shared/src/main/scala/spire/algebra/VectorSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/VectorSpace.scala
@@ -1,6 +1,6 @@
-package spire.algebra
+package spire
+package algebra
 
-import scala.{ specialized => spec }
 
 /**
  * A vector space is a group `V` that can be multiplied by scalars in `F` that

--- a/core/shared/src/main/scala/spire/algebra/VectorSpace.scala
+++ b/core/shared/src/main/scala/spire/algebra/VectorSpace.scala
@@ -10,12 +10,12 @@ package algebra
  * is an identity function (`1 *: v === v`). Scalar multiplication is
  * "associative" (`x *: y *: v === (x * y) *: v`).
  */
-trait VectorSpace[V, @spec(Int, Long, Float, Double) F] extends Any with Module[V, F] {
+trait VectorSpace[V, @sp(Int, Long, Float, Double) F] extends Any with Module[V, F] {
   implicit def scalar: Field[F]
 
   def divr(v: V, f: F): V = timesl(scalar.reciprocal(f), v)
 }
 
 object VectorSpace {
-  @inline final def apply[V, @spec(Int,Long,Float,Double) R](implicit V: VectorSpace[V, R]): VectorSpace[V, R] = V
+  @inline final def apply[V, @sp(Int,Long,Float,Double) R](implicit V: VectorSpace[V, R]): VectorSpace[V, R] = V
 }

--- a/core/shared/src/main/scala/spire/algebra/free/FreeAbGroup.scala
+++ b/core/shared/src/main/scala/spire/algebra/free/FreeAbGroup.scala
@@ -1,7 +1,7 @@
-package spire.algebra
+package spire
+package algebra
 package free
 
-import scala.annotation.tailrec
 
 import spire.std.option._
 import spire.std.map._

--- a/core/shared/src/main/scala/spire/algebra/free/FreeGroup.scala
+++ b/core/shared/src/main/scala/spire/algebra/free/FreeGroup.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 package free
 
 final class FreeGroup[A] private (val terms: Vector[Either[A, A]]) extends AnyVal { lhs =>

--- a/core/shared/src/main/scala/spire/algebra/free/FreeMonoid.scala
+++ b/core/shared/src/main/scala/spire/algebra/free/FreeMonoid.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 package free
 
 final class FreeMonoid[A] private (val terms: List[A]) extends AnyVal { lhs =>

--- a/core/shared/src/main/scala/spire/algebra/lattice/Heyting.scala
+++ b/core/shared/src/main/scala/spire/algebra/lattice/Heyting.scala
@@ -1,6 +1,6 @@
-package spire.algebra.lattice
-
-import scala.{specialized => sp}
+package spire
+package algebra
+package lattice
 
 trait Heyting[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLattice[A] {
   def and(a: A, b: A): A

--- a/core/shared/src/main/scala/spire/algebra/lattice/Lattice.scala
+++ b/core/shared/src/main/scala/spire/algebra/lattice/Lattice.scala
@@ -1,10 +1,9 @@
-package spire.algebra
+package spire
+package algebra
 package lattice
 
 import spire.syntax.order._
 import spire.syntax.euclideanRing._
-
-import scala.{specialized => sp}
 
 trait JoinSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
   def join(lhs: A, rhs: A): A

--- a/core/shared/src/main/scala/spire/algebra/partial/Groupoid.scala
+++ b/core/shared/src/main/scala/spire/algebra/partial/Groupoid.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 package partial
 
 import spire.util.Opt

--- a/core/shared/src/main/scala/spire/algebra/partial/PartialAction.scala
+++ b/core/shared/src/main/scala/spire/algebra/partial/PartialAction.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 package partial
 
 import spire.util.Opt

--- a/core/shared/src/main/scala/spire/algebra/partial/Semigroupoid.scala
+++ b/core/shared/src/main/scala/spire/algebra/partial/Semigroupoid.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 package partial
 
 import spire.util.Opt

--- a/core/shared/src/main/scala/spire/macros/Auto.scala
+++ b/core/shared/src/main/scala/spire/macros/Auto.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 import language.experimental.macros
 

--- a/core/shared/src/main/scala/spire/macros/Macros.scala
+++ b/core/shared/src/main/scala/spire/macros/Macros.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 import spire.algebra.{Field, Ring}
 import spire.macros.compat.Context

--- a/core/shared/src/main/scala/spire/macros/fpf/Cmp.scala
+++ b/core/shared/src/main/scala/spire/macros/fpf/Cmp.scala
@@ -1,4 +1,5 @@
-package spire.macros.fpf
+package spire
+package macros.fpf
 
 private[spire] sealed trait Cmp
 private[spire] object Cmp {

--- a/core/shared/src/main/scala/spire/macros/fpf/Fuser.scala
+++ b/core/shared/src/main/scala/spire/macros/fpf/Fuser.scala
@@ -1,4 +1,5 @@
-package spire.macros.fpf
+package spire
+package macros.fpf
 
 import scala.language.experimental.macros
 

--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -1,11 +1,11 @@
-package spire.math
+package spire
+package math
 
 import java.lang.Long.numberOfLeadingZeros
 import java.lang.Double.{ isInfinite, isNaN }
 import java.math.{ MathContext, RoundingMode, BigInteger, BigDecimal => JBigDecimal }
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.annotation.tailrec
 import scala.math.{ ScalaNumber, ScalaNumericConversions }
 import scala.reflect.ClassTag
 

--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -7,7 +7,6 @@ import java.math.{ MathContext, RoundingMode, BigInteger, BigDecimal => JBigDeci
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.math.{ ScalaNumber, ScalaNumericConversions }
-import scala.reflect.ClassTag
 
 import spire.Platform
 import spire.algebra.{Eq, EuclideanRing, Field, IsAlgebraic, NRoot, Order, Ring, Sign, Signed}

--- a/core/shared/src/main/scala/spire/math/BitString.scala
+++ b/core/shared/src/main/scala/spire/math/BitString.scala
@@ -5,7 +5,7 @@ import spire.algebra.Bool
 
 import java.lang.Math
 
-trait BitString[@spec(Byte, Short, Int, Long) A] extends Any with Bool[A] {
+trait BitString[@sp(Byte, Short, Int, Long) A] extends Any with Bool[A] {
   def signed: Boolean
   def width: Int
   def toHexString(n: A): String

--- a/core/shared/src/main/scala/spire/math/BitString.scala
+++ b/core/shared/src/main/scala/spire/math/BitString.scala
@@ -1,8 +1,8 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.Bool
 
-import scala.{specialized => spec}
 import java.lang.Math
 
 trait BitString[@spec(Byte, Short, Int, Long) A] extends Any with Bool[A] {

--- a/core/shared/src/main/scala/spire/math/Complex.scala
+++ b/core/shared/src/main/scala/spire/math/Complex.scala
@@ -13,16 +13,16 @@ import java.lang.Math
 
 
 object Complex extends ComplexInstances {
-  def i[@spec(Float, Double) T](implicit T: Rig[T]): Complex[T] =
+  def i[@sp(Float, Double) T](implicit T: Rig[T]): Complex[T] =
     new Complex(T.zero, T.one)
 
-  def one[@spec(Float, Double) T](implicit T: Rig[T]): Complex[T] =
+  def one[@sp(Float, Double) T](implicit T: Rig[T]): Complex[T] =
     new Complex(T.one, T.zero)
 
-  def zero[@spec(Float, Double) T](implicit T: Semiring[T]): Complex[T] =
+  def zero[@sp(Float, Double) T](implicit T: Semiring[T]): Complex[T] =
     new Complex(T.zero, T.zero)
 
-  def fromInt[@spec(Float, Double) T](n: Int)(implicit f: Ring[T]): Complex[T] =
+  def fromInt[@sp(Float, Double) T](n: Int)(implicit f: Ring[T]): Complex[T] =
     new Complex(f.fromInt(n), f.zero)
 
   implicit def intToComplex(n: Int): Complex[Double] = new Complex(n.toDouble, 0.0)
@@ -38,13 +38,13 @@ object Complex extends ComplexInstances {
     new Complex(n, BigDecimal(0))
   }
 
-  def polar[@spec(Float, Double) T: Field: Trig](magnitude: T, angle: T): Complex[T] =
+  def polar[@sp(Float, Double) T: Field: Trig](magnitude: T, angle: T): Complex[T] =
     new Complex(magnitude * Trig[T].cos(angle), magnitude * Trig[T].sin(angle))
 
-  def apply[@spec(Float, Double) T: Semiring](real: T): Complex[T] =
+  def apply[@sp(Float, Double) T: Semiring](real: T): Complex[T] =
     new Complex(real, Semiring[T].zero)
 
-  def rootOfUnity[@spec(Float, Double) T](n: Int, x: Int)(implicit f: Field[T], t: Trig[T], r: IsReal[T]): Complex[T] = {
+  def rootOfUnity[@sp(Float, Double) T](n: Int, x: Int)(implicit f: Field[T], t: Trig[T], r: IsReal[T]): Complex[T] = {
     if (x == 0) return one[T]
 
     if (n % 2 == 0) {
@@ -58,7 +58,7 @@ object Complex extends ComplexInstances {
     polar(f.one, (t.pi * 2 * x) / n)
   }
 
-  def rootsOfUnity[@spec(Float, Double) T](n: Int)(implicit f: Field[T], t: Trig[T], r: IsReal[T]): Array[Complex[T]] = {
+  def rootsOfUnity[@sp(Float, Double) T](n: Int)(implicit f: Field[T], t: Trig[T], r: IsReal[T]): Array[Complex[T]] = {
     val roots = new Array[Complex[T]](n)
     var sum = one[T]
     roots(0) = sum
@@ -87,7 +87,7 @@ object Complex extends ComplexInstances {
 }
 
 @SerialVersionUID(0L)
-final case class Complex[@spec(Float, Double) T](real: T, imag: T)
+final case class Complex[@sp(Float, Double) T](real: T, imag: T)
     extends ScalaNumber with ScalaNumericConversions with Serializable { lhs =>
 
   import spire.syntax.order._
@@ -582,13 +582,13 @@ trait ComplexInstances1 extends ComplexInstances0 {
 }
 
 trait ComplexInstances extends ComplexInstances1 {
-  implicit def ComplexAlgebra[@spec(Float, Double) A: Fractional: Trig: IsReal]: ComplexAlgebra[A] =
+  implicit def ComplexAlgebra[@sp(Float, Double) A: Fractional: Trig: IsReal]: ComplexAlgebra[A] =
     new ComplexAlgebra[A]
 
   implicit def ComplexEq[A: Eq]: Eq[Complex[A]] = new ComplexEq[A]
 }
 
-private[math] trait ComplexIsRing[@spec(Float, Double) A] extends Ring[Complex[A]] {
+private[math] trait ComplexIsRing[@sp(Float, Double) A] extends Ring[Complex[A]] {
   implicit def algebra: Ring[A]
   implicit def order: IsReal[A]
 
@@ -602,7 +602,7 @@ private[math] trait ComplexIsRing[@spec(Float, Double) A] extends Ring[Complex[A
   override def fromInt(n: Int): Complex[A] = Complex.fromInt[A](n)
 }
 
-private[math] trait ComplexIsField[@spec(Float,Double) A] extends ComplexIsRing[A] with Field[Complex[A]] {
+private[math] trait ComplexIsField[@sp(Float,Double) A] extends ComplexIsRing[A] with Field[Complex[A]] {
 
   implicit def algebra: Field[A]
 
@@ -618,7 +618,7 @@ private[math] trait ComplexIsField[@spec(Float,Double) A] extends ComplexIsRing[
   }
 }
 
-private[math] trait ComplexIsTrig[@spec(Float, Double) A] extends Trig[Complex[A]] {
+private[math] trait ComplexIsTrig[@sp(Float, Double) A] extends Trig[Complex[A]] {
   implicit def algebra: Field[A]
   implicit def nroot: NRoot[A]
   implicit def trig: Trig[A]
@@ -677,15 +677,15 @@ private[math] class ComplexEq[A: Eq] extends Eq[Complex[A]] with Serializable {
 }
 
 @SerialVersionUID(1L)
-private[math] final class ComplexIsRingImpl[@spec(Float,Double) A](implicit
+private[math] final class ComplexIsRingImpl[@sp(Float,Double) A](implicit
     val algebra: Ring[A], val order: IsReal[A]) extends ComplexIsRing[A] with Serializable
 
 @SerialVersionUID(1L)
-private[math] final class ComplexIsFieldImpl[@spec(Float,Double) A](implicit
+private[math] final class ComplexIsFieldImpl[@sp(Float,Double) A](implicit
     val algebra: Field[A], val order: IsReal[A]) extends ComplexIsField[A] with Serializable
 
 @SerialVersionUID(1L)
-private[math] class ComplexAlgebra[@spec(Float, Double) A](implicit
+private[math] class ComplexAlgebra[@sp(Float, Double) A](implicit
       val algebra: Field[A], val nroot: NRoot[A], val trig: Trig[A], val order: IsReal[A])
     extends ComplexIsField[A]
     with ComplexIsTrig[A]

--- a/core/shared/src/main/scala/spire/math/Complex.scala
+++ b/core/shared/src/main/scala/spire/math/Complex.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra._
 
@@ -7,8 +8,6 @@ import spire.syntax.isReal._
 import spire.syntax.nroot._
 import spire.syntax.order._
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions, ScalaNumericAnyConversions}
 import java.lang.Math
 

--- a/core/shared/src/main/scala/spire/math/Convertable.scala
+++ b/core/shared/src/main/scala/spire/math/Convertable.scala
@@ -6,7 +6,7 @@ import java.math.MathContext
 
 import spire.algebra.{ Trig, IsReal }
 
-trait ConvertableTo[@spec A] extends Any {
+trait ConvertableTo[@sp A] extends Any {
   def fromByte(n: Byte): A
   def fromShort(n: Short): A
   def fromInt(n: Int): A
@@ -271,7 +271,7 @@ object ConvertableTo {
     new ConvertableToComplex[A] { val algebra = Integral[A] }
 }
 
-trait ConvertableFrom[@spec A] extends Any {
+trait ConvertableFrom[@sp A] extends Any {
   def toByte(a: A): Byte
   def toShort(a: A): Short
   def toInt(a: A): Int

--- a/core/shared/src/main/scala/spire/math/Convertable.scala
+++ b/core/shared/src/main/scala/spire/math/Convertable.scala
@@ -1,8 +1,8 @@
-package spire.math
+package spire
+package math
 
 import java.math.MathContext
 
-import scala.{specialized => spec}
 
 import spire.algebra.{ Trig, IsReal }
 

--- a/core/shared/src/main/scala/spire/math/FpFilter.scala
+++ b/core/shared/src/main/scala/spire/math/FpFilter.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import scala.language.experimental.macros
 

--- a/core/shared/src/main/scala/spire/math/Fractional.scala
+++ b/core/shared/src/main/scala/spire/math/Fractional.scala
@@ -6,7 +6,7 @@ import spire.std._
 
 import java.lang.Math
 
-trait Fractional[@spec(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]
+trait Fractional[@sp(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]
 
 object Fractional {
   implicit final val FloatIsFractional = new FloatIsFractional

--- a/core/shared/src/main/scala/spire/math/Fractional.scala
+++ b/core/shared/src/main/scala/spire/math/Fractional.scala
@@ -1,9 +1,9 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{Field, NRoot}
 import spire.std._
 
-import scala.{specialized => spec}
 import java.lang.Math
 
 trait Fractional[@spec(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]

--- a/core/shared/src/main/scala/spire/math/Integral.scala
+++ b/core/shared/src/main/scala/spire/math/Integral.scala
@@ -1,6 +1,5 @@
-package spire.math
-
-import scala.{specialized => sp}
+package spire
+package math
 
 import spire.algebra.{EuclideanRing, IsReal}
 import spire.std._

--- a/core/shared/src/main/scala/spire/math/Interval.scala
+++ b/core/shared/src/main/scala/spire/math/Interval.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import Predef.{any2stringadd => _, _}
 

--- a/core/shared/src/main/scala/spire/math/Jet.scala
+++ b/core/shared/src/main/scala/spire/math/Jet.scala
@@ -1,10 +1,8 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.math._
 import scala.reflect._
-import scala.{specialized => sp}
-
 import spire.algebra._
 import spire.std.ArraySupport
 import spire.syntax.isReal._

--- a/core/shared/src/main/scala/spire/math/Merging.scala
+++ b/core/shared/src/main/scala/spire/math/Merging.scala
@@ -2,7 +2,6 @@ package spire
 package math
 import spire.algebra.Order
 
-import scala.reflect.ClassTag
 
 /**
  *  Interface for a merging strategy object.

--- a/core/shared/src/main/scala/spire/math/Merging.scala
+++ b/core/shared/src/main/scala/spire/math/Merging.scala
@@ -1,8 +1,7 @@
-package spire.math
+package spire
+package math
 import spire.algebra.Order
-import scala.{specialized => spec}
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 /**

--- a/core/shared/src/main/scala/spire/math/Merging.scala
+++ b/core/shared/src/main/scala/spire/math/Merging.scala
@@ -8,7 +8,7 @@ import scala.reflect.ClassTag
  *  Interface for a merging strategy object.
  */
 trait Merge extends Any {
-  def merge[@spec A: Order: ClassTag](a:Array[A], b:Array[A]): Array[A]
+  def merge[@sp A: Order: ClassTag](a:Array[A], b:Array[A]): Array[A]
 }
 
 /**
@@ -99,7 +99,7 @@ abstract class BinaryMerge {
  */
 object BinaryMerge extends Merge {
 
-  def merge[@specialized T: Order: ClassTag](a: Array[T], b: Array[T]): Array[T] = {
+  def merge[@sp T: Order: ClassTag](a: Array[T], b: Array[T]): Array[T] = {
     new ArrayBinaryMerge(a,b).result
   }
 
@@ -148,7 +148,7 @@ object BinaryMerge extends Merge {
  */
 object LinearMerge extends Merge {
 
-  def merge[@spec T: Order : ClassTag](a: Array[T], b: Array[T]): Array[T] = {
+  def merge[@sp T: Order : ClassTag](a: Array[T], b: Array[T]): Array[T] = {
     val o = implicitly[Order[T]]
     val r = Array.ofDim[T](a.length + b.length)
     var ri = 0

--- a/core/shared/src/main/scala/spire/math/Natural.scala
+++ b/core/shared/src/main/scala/spire/math/Natural.scala
@@ -1,8 +1,7 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions}
-import scala.{specialized => spec}
 
 import spire.algebra.{IsIntegral, Order, Rig, Signed}
 

--- a/core/shared/src/main/scala/spire/math/Natural.scala
+++ b/core/shared/src/main/scala/spire/math/Natural.scala
@@ -24,7 +24,7 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
 
   def digit: UInt
 
-  def foldDigitsLeft[@spec A](a: A)(f: (A, UInt) => A): A = {
+  def foldDigitsLeft[@sp A](a: A)(f: (A, UInt) => A): A = {
     @tailrec def recur(next: Natural, sofar: A): A = next match {
       case End(d) => f(a, d)
       case Digit(d, tail) => recur(tail, f(a, d))
@@ -33,7 +33,7 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
   }
 
 
-  def foldDigitsRight[@spec A](a: A)(f: (A, UInt) => A): A =
+  def foldDigitsRight[@sp A](a: A)(f: (A, UInt) => A): A =
     reversed.foldDigitsLeft(a)(f)
 
   def getNumBits: Int = {

--- a/core/shared/src/main/scala/spire/math/Number.scala
+++ b/core/shared/src/main/scala/spire/math/Number.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 import java.lang.Math

--- a/core/shared/src/main/scala/spire/math/NumberTag.scala
+++ b/core/shared/src/main/scala/spire/math/NumberTag.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 object NumberTag {
 

--- a/core/shared/src/main/scala/spire/math/Numeric.scala
+++ b/core/shared/src/main/scala/spire/math/Numeric.scala
@@ -1,9 +1,9 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{AdditiveAbGroup, IsReal, MultiplicativeAbGroup, Order, NRoot, Ring, Trig}
 import spire.std._
 
-import scala.{specialized => spec}
 
 /**
  * TODO

--- a/core/shared/src/main/scala/spire/math/Numeric.scala
+++ b/core/shared/src/main/scala/spire/math/Numeric.scala
@@ -13,7 +13,7 @@ import spire.std._
  * 6. Start to worry about things like e.g. pow(BigInt, BigInt)
  */
 
-trait Numeric[@spec(Int,Long,Float,Double) A] extends Any with Ring[A]
+trait Numeric[@sp(Int,Long,Float,Double) A] extends Any with Ring[A]
 with AdditiveAbGroup[A] with MultiplicativeAbGroup[A] with NRoot[A]
 with ConvertableFrom[A] with ConvertableTo[A] with IsReal[A]
 

--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -1,10 +1,9 @@
-package spire.math
+package spire
+package math
 
 import scala.collection.mutable.ArrayBuilder
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import java.math.{ BigDecimal => JBigDecimal, RoundingMode, MathContext }
 

--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -3,7 +3,6 @@ package math
 
 import scala.collection.mutable.ArrayBuilder
 
-import scala.reflect.ClassTag
 
 import java.math.{ BigDecimal => JBigDecimal, RoundingMode, MathContext }
 

--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -25,7 +25,7 @@ import spire.syntax.std.seq._
 
 object Polynomial extends PolynomialInstances {
 
-  def dense[@spec(Double) C: Semiring: Eq: ClassTag](coeffs: Array[C]): PolyDense[C] = {
+  def dense[@sp(Double) C: Semiring: Eq: ClassTag](coeffs: Array[C]): PolyDense[C] = {
     var i = coeffs.length
     while (i > 0 && (coeffs(i - 1) === Semiring[C].zero)) i -= 1
     if (i == coeffs.length) {
@@ -37,45 +37,45 @@ object Polynomial extends PolynomialInstances {
     }
   }
 
-  def sparse[@spec(Double) C: Semiring: Eq: ClassTag](data: Map[Int, C]): PolySparse[C] =
+  def sparse[@sp(Double) C: Semiring: Eq: ClassTag](data: Map[Int, C]): PolySparse[C] =
     PolySparse(data)
 
-  def apply[@spec(Double) C: Semiring: Eq: ClassTag](data: Map[Int, C]): PolySparse[C] =
+  def apply[@sp(Double) C: Semiring: Eq: ClassTag](data: Map[Int, C]): PolySparse[C] =
     sparse(data)
 
-  def apply[@spec(Double) C: Semiring: Eq: ClassTag](terms: Iterable[Term[C]]): PolySparse[C] =
+  def apply[@sp(Double) C: Semiring: Eq: ClassTag](terms: Iterable[Term[C]]): PolySparse[C] =
     sparse(terms.map(_.toTuple)(collection.breakOut))
 
-  def apply[@spec(Double) C: Semiring: Eq: ClassTag](c: C, e: Int): PolySparse[C] =
+  def apply[@sp(Double) C: Semiring: Eq: ClassTag](c: C, e: Int): PolySparse[C] =
     PolySparse.safe(Array(e), Array(c))
 
   import scala.util.{Try, Success, Failure}
 
   def apply(s: String): Polynomial[Rational] = parse(s)
 
-  def zero[@spec(Double) C: Eq: Semiring: ClassTag]: Polynomial[C] =
+  def zero[@sp(Double) C: Eq: Semiring: ClassTag]: Polynomial[C] =
     PolySparse.zero[C]
-  def constant[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
+  def constant[@sp(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
     if (c === Semiring[C].zero) zero[C] else Polynomial(Map((0, c)))
-  def linear[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
+  def linear[@sp(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
     if (c === Semiring[C].zero) zero[C] else Polynomial(Map((1, c)))
-  def linear[@spec(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
+  def linear[@sp(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
     Polynomial(Map((1, c1), (0, c0)))
-  def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
+  def quadratic[@sp(Double) C: Eq: Semiring: ClassTag](c1: C, c0: C): Polynomial[C] =
     Polynomial(Map((1, c1), (0, c0)))
-  def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
+  def quadratic[@sp(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
     if (c === Semiring[C].zero) zero[C] else Polynomial(Map((2, c)))
-  def quadratic[@spec(Double) C: Eq: Semiring: ClassTag](c2: C, c1: C, c0: C): Polynomial[C] =
+  def quadratic[@sp(Double) C: Eq: Semiring: ClassTag](c2: C, c1: C, c0: C): Polynomial[C] =
     Polynomial(Map((2, c2), (1, c1), (0, c0)))
-  def cubic[@spec(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
+  def cubic[@sp(Double) C: Eq: Semiring: ClassTag](c: C): Polynomial[C] =
     if (c === Semiring[C].zero) zero[C] else Polynomial(Map((3, c)))
-  def cubic[@spec(Double) C: Eq: Semiring: ClassTag](c3: C, c2: C, c1: C, c0: C): Polynomial[C] =
+  def cubic[@sp(Double) C: Eq: Semiring: ClassTag](c3: C, c2: C, c1: C, c0: C): Polynomial[C] =
     Polynomial(Map((3, c3), (2, c2), (1, c1), (0, c0)))
-  def one[@spec(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
+  def one[@sp(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
     constant(Rig[C].one)
-  def x[@spec(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
+  def x[@sp(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
     linear(Rig[C].one)
-  def twox[@spec(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
+  def twox[@sp(Double) C: Eq: Rig: ClassTag]: Polynomial[C] =
     linear(Rig[C].one + Rig[C].one)
 
   private[this] val termRe = "([0-9]+\\.[0-9]+|[0-9]+/[0-9]+|[0-9]+)?(?:([a-z])(?:\\^([0-9]+))?)?".r
@@ -128,7 +128,7 @@ object Polynomial extends PolynomialInstances {
     (Polynomial.zero[Rational] /: ts)((a, t) => a + Polynomial(t.c, t.e))
   }
 
-  private final def split[@spec(Double) C: ClassTag](poly: Polynomial[C]): (Array[Int], Array[C]) = {
+  private final def split[@sp(Double) C: ClassTag](poly: Polynomial[C]): (Array[Int], Array[C]) = {
     val es = ArrayBuilder.make[Int]()
     val cs = ArrayBuilder.make[C]()
     poly foreach { (e, c) =>
@@ -154,7 +154,7 @@ object Polynomial extends PolynomialInstances {
   }
 }
 
-trait Polynomial[@spec(Double) C] { lhs =>
+trait Polynomial[@sp(Double) C] { lhs =>
   implicit def ct: ClassTag[C]
 
   /** Returns a polynmial that has a dense representation. */
@@ -448,7 +448,7 @@ trait Polynomial[@spec(Double) C] { lhs =>
     }
 }
 
-trait PolynomialSemiring[@spec(Double) C]
+trait PolynomialSemiring[@sp(Double) C]
 extends Semiring[Polynomial[C]] {
   implicit def scalar: Semiring[C]
   implicit def eq: Eq[C]
@@ -459,14 +459,14 @@ extends Semiring[Polynomial[C]] {
   def times(x: Polynomial[C], y: Polynomial[C]): Polynomial[C] = x * y
 }
 
-trait PolynomialRig[@spec(Double) C] extends PolynomialSemiring[C]
+trait PolynomialRig[@sp(Double) C] extends PolynomialSemiring[C]
 with Rig[Polynomial[C]] {
   implicit override val scalar: Rig[C]
 
   def one: Polynomial[C] = Polynomial.one[C]
 }
 
-trait PolynomialRng[@spec(Double) C] extends PolynomialSemiring[C]
+trait PolynomialRng[@sp(Double) C] extends PolynomialSemiring[C]
 with RingAlgebra[Polynomial[C], C] {
   implicit override val scalar: Rng[C]
 
@@ -474,14 +474,14 @@ with RingAlgebra[Polynomial[C], C] {
   def negate(x: Polynomial[C]): Polynomial[C] = -x
 }
 
-trait PolynomialRing[@spec(Double) C] extends PolynomialRng[C]
+trait PolynomialRing[@sp(Double) C] extends PolynomialRng[C]
 with Ring[Polynomial[C]] {
   implicit override val scalar: Ring[C]
 
   def one: Polynomial[C] = Polynomial.one[C]
 }
 
-trait PolynomialEuclideanRing[@spec(Double) C] extends PolynomialRing[C]
+trait PolynomialEuclideanRing[@sp(Double) C] extends PolynomialRing[C]
 with EuclideanRing[Polynomial[C]] with VectorSpace[Polynomial[C], C] {
   implicit override val scalar: Field[C]
 
@@ -496,7 +496,7 @@ with EuclideanRing[Polynomial[C]] with VectorSpace[Polynomial[C], C] {
   }
 }
 
-trait PolynomialEq[@spec(Double) C] extends Eq[Polynomial[C]] {
+trait PolynomialEq[@sp(Double) C] extends Eq[Polynomial[C]] {
   implicit def scalar: Semiring[C]
   implicit def eq: Eq[C]
   implicit def ct: ClassTag[C]
@@ -506,14 +506,14 @@ trait PolynomialEq[@spec(Double) C] extends Eq[Polynomial[C]] {
 }
 
 trait PolynomialInstances0 {
-  implicit def semiring[@spec(Double) C: ClassTag: Semiring: Eq]: PolynomialSemiring[C] =
+  implicit def semiring[@sp(Double) C: ClassTag: Semiring: Eq]: PolynomialSemiring[C] =
     new PolynomialSemiring[C] {
       val scalar = Semiring[C]
       val eq = Eq[C]
       val ct = implicitly[ClassTag[C]]
     }
 
-  implicit def eq[@spec(Double) C: ClassTag: Semiring: Eq]: PolynomialEq[C] =
+  implicit def eq[@sp(Double) C: ClassTag: Semiring: Eq]: PolynomialEq[C] =
     new PolynomialEq[C] {
       val scalar = Semiring[C]
       val eq = Eq[C]
@@ -522,14 +522,14 @@ trait PolynomialInstances0 {
 }
 
 trait PolynomialInstances1 extends PolynomialInstances0 {
-  implicit def rig[@spec(Double) C: ClassTag: Rig: Eq]: PolynomialRig[C] =
+  implicit def rig[@sp(Double) C: ClassTag: Rig: Eq]: PolynomialRig[C] =
     new PolynomialRig[C] {
       val scalar = Rig[C]
       val eq = Eq[C]
       val ct = implicitly[ClassTag[C]]
     }
 
-  implicit def rng[@spec(Double) C: ClassTag: Rng: Eq]: PolynomialRng[C] =
+  implicit def rng[@sp(Double) C: ClassTag: Rng: Eq]: PolynomialRng[C] =
     new PolynomialRng[C] {
       val scalar = Rng[C]
       val eq = Eq[C]
@@ -538,7 +538,7 @@ trait PolynomialInstances1 extends PolynomialInstances0 {
 }
 
 trait PolynomialInstances2 extends PolynomialInstances1 {
-  implicit def ring[@spec(Double) C: ClassTag: Ring: Eq]: PolynomialRing[C] =
+  implicit def ring[@sp(Double) C: ClassTag: Ring: Eq]: PolynomialRing[C] =
     new PolynomialRing[C] {
       val scalar = Ring[C]
       val eq = Eq[C]
@@ -547,7 +547,7 @@ trait PolynomialInstances2 extends PolynomialInstances1 {
 }
 
 trait PolynomialInstances3 extends PolynomialInstances2 {
-  implicit def euclideanRing[@spec(Double) C: ClassTag: Field: Eq]: PolynomialEuclideanRing[C] =
+  implicit def euclideanRing[@sp(Double) C: ClassTag: Field: Eq]: PolynomialEuclideanRing[C] =
     new PolynomialEuclideanRing[C] {
       val scalar = Field[C]
       val eq = Eq[C]

--- a/core/shared/src/main/scala/spire/math/Quaternion.scala
+++ b/core/shared/src/main/scala/spire/math/Quaternion.scala
@@ -1,11 +1,9 @@
-package spire.math
+package spire
+package math
 
 import java.lang.Math
 
-import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions}
-import scala.{specialized => sp}
-
 import spire.algebra._
 import spire.syntax.field._
 import spire.syntax.isReal._

--- a/core/shared/src/main/scala/spire/math/Rational.scala
+++ b/core/shared/src/main/scala/spire/math/Rational.scala
@@ -1,6 +1,6 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 
 import java.math.{BigDecimal => JBigDecimal, BigInteger, MathContext, RoundingMode}

--- a/core/shared/src/main/scala/spire/math/Real.scala
+++ b/core/shared/src/main/scala/spire/math/Real.scala
@@ -1,6 +1,6 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 
 import spire.algebra.{Order, Trig, Signed}

--- a/core/shared/src/main/scala/spire/math/SafeLong.scala
+++ b/core/shared/src/main/scala/spire/math/SafeLong.scala
@@ -1,11 +1,11 @@
-package spire.math
+package spire
+package math
 
 import java.math.BigInteger
 
 import spire.util.Opt
 
 import scala.math.{ScalaNumber, ScalaNumericConversions}
-import scala.annotation.tailrec
 
 import spire.macros.Checked
 

--- a/core/shared/src/main/scala/spire/math/ScalaWrappers.scala
+++ b/core/shared/src/main/scala/spire/math/ScalaWrappers.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{Eq, EuclideanRing, Field, PartialOrder, Order, Ring, Signed}
 

--- a/core/shared/src/main/scala/spire/math/Searching.scala
+++ b/core/shared/src/main/scala/spire/math/Searching.scala
@@ -1,10 +1,9 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{Order, PartialOrder}
 import spire.syntax.order._
 
-import scala.{specialized => spec}
-import scala.annotation.tailrec
 
 object Searching {
   final def search[@spec A: Order](as: Array[A], item: A): Int =

--- a/core/shared/src/main/scala/spire/math/Searching.scala
+++ b/core/shared/src/main/scala/spire/math/Searching.scala
@@ -6,10 +6,10 @@ import spire.syntax.order._
 
 
 object Searching {
-  final def search[@spec A: Order](as: Array[A], item: A): Int =
+  final def search[@sp A: Order](as: Array[A], item: A): Int =
     search(as, item, 0, as.length - 1)
 
-  final def search[@spec A: Order](as: Array[A], item: A, lower: Int, upper: Int): Int = {
+  final def search[@sp A: Order](as: Array[A], item: A, lower: Int, upper: Int): Int = {
     var first = lower
     var last = upper
     while (first <= last) {
@@ -23,10 +23,10 @@ object Searching {
     -first - 1
   }
 
-  final def search[@spec A: Order](as: IndexedSeq[A], item: A): Int =
+  final def search[@sp A: Order](as: IndexedSeq[A], item: A): Int =
     search(as, item, 0, as.length - 1)
 
-  final def search[@spec A: Order](as: IndexedSeq[A], item: A, lower: Int, upper: Int): Int = {
+  final def search[@sp A: Order](as: IndexedSeq[A], item: A, lower: Int, upper: Int): Int = {
     var first = lower
     var last = upper
     while (first <= last) {

--- a/core/shared/src/main/scala/spire/math/Selection.scala
+++ b/core/shared/src/main/scala/spire/math/Selection.scala
@@ -1,7 +1,6 @@
 package spire
 package math
 
-import scala.reflect.ClassTag
 
 import spire.algebra.Order
 

--- a/core/shared/src/main/scala/spire/math/Selection.scala
+++ b/core/shared/src/main/scala/spire/math/Selection.scala
@@ -6,7 +6,7 @@ import scala.reflect.ClassTag
 import spire.algebra.Order
 
 trait Select extends Any {
-  def select[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit
+  def select[@sp A: Order: ClassTag](data: Array[A], k: Int): Unit
 }
 
 /**
@@ -15,7 +15,7 @@ trait Select extends Any {
  */
 trait SelectLike extends Any with Select {
 
-  def approxMedian[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int): A
+  def approxMedian[@sp A: Order](data: Array[A], left: Int, right: Int, stride: Int): A
 
   /**
    * Puts the k-th element of data, according to some Order, in the k-th
@@ -25,12 +25,12 @@ trait SelectLike extends Any with Select {
    * This is an in-place algorithm and is not stable and it WILL mess up the
    * order of equal elements.
    */
-  final def select[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit = {
+  final def select[@sp A: Order: ClassTag](data: Array[A], k: Int): Unit = {
     select(data, 0, data.length, 1, k)
   }
 
   // Copy of InsertSort.sort, but with a stride.
-  final def sort[@spec A](data: Array[A], left: Int, right: Int, stride: Int)(implicit o: Order[A]): Unit = {
+  final def sort[@sp A](data: Array[A], left: Int, right: Int, stride: Int)(implicit o: Order[A]): Unit = {
     var i = left
     while (i < right) {
       val item = data(i)
@@ -45,7 +45,7 @@ trait SelectLike extends Any with Select {
   }
 
   @tailrec
-  protected final def select[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int, k: Int): Unit = {
+  protected final def select[@sp A: Order](data: Array[A], left: Int, right: Int, stride: Int, k: Int): Unit = {
     val length = (right - left + stride - 1) / stride
     if (length < 10) {
       sort(data, left, right, stride)
@@ -65,7 +65,7 @@ trait SelectLike extends Any with Select {
     }
   }
 
-  final def equalSpan[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Int = {
+  final def equalSpan[@sp A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Int = {
     val m = data(offset)
     var i = offset + stride
     var len = 1
@@ -76,7 +76,7 @@ trait SelectLike extends Any with Select {
     len
   }
 
-  final def partition[@spec A](data: Array[A], left: Int, right: Int, stride: Int)(m: A)(implicit o: Order[A]): Int = {
+  final def partition[@sp A](data: Array[A], left: Int, right: Int, stride: Int)(m: A)(implicit o: Order[A]): Int = {
     var i = left  // Iterator.
     var j = left  // Pointer to first element > m.
     var k = left  // Pointer to end of equal elements.
@@ -109,7 +109,7 @@ trait SelectLike extends Any with Select {
 }
 
 trait MutatingMedianOf5 {
-  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
+  final def mo5[@sp A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
     var i0 = offset
     var i1 = offset + 1 * stride
     var i2 = offset + 2 * stride
@@ -152,7 +152,7 @@ trait HighBranchingMedianOf5 {
   // Benchmarks show that this is slightly faster than the version above.
 
   // scalastyle:off method.length
-  final def mo5[@spec A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
+  final def mo5[@sp A](data: Array[A], offset: Int, stride: Int)(implicit o: Order[A]): Unit = {
     val ai1 = data(offset)
     val ai2 = data(offset + stride)
     val ai3 = data(offset + 2 * stride)
@@ -299,7 +299,7 @@ object LinearSelect extends SelectLike with HighBranchingMedianOf5 {
   // one side. This makes this quite a bit slower in the general case (though
   // not terribly so), but doesn't suffer from bad worst-case behaviour.
 
-  final def approxMedian[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int): A = {
+  final def approxMedian[@sp A: Order](data: Array[A], left: Int, right: Int, stride: Int): A = {
     var offset = left
     var last = left + 4 * stride
     val nextStride = 5 * stride
@@ -323,7 +323,7 @@ object QuickSelect extends SelectLike with HighBranchingMedianOf5 {
   // pivot, quickly is essential. So, we have 3 cases, getting slightly smarter
   // about our pivot as the array grows.
 
-  final def approxMedian[@spec A: Order](data: Array[A], left: Int, right: Int, stride: Int): A = {
+  final def approxMedian[@sp A: Order](data: Array[A], left: Int, right: Int, stride: Int): A = {
     val length = (right - left + stride - 1) / stride
 
     if (length >= 5) {
@@ -346,12 +346,12 @@ object QuickSelect extends SelectLike with HighBranchingMedianOf5 {
 }
 
 object Selection {
-  final def select[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit =
+  final def select[@sp A: Order: ClassTag](data: Array[A], k: Int): Unit =
     quickSelect(data, k)
 
-  final def linearSelect[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit =
+  final def linearSelect[@sp A: Order: ClassTag](data: Array[A], k: Int): Unit =
     LinearSelect.select(data, k)
 
-  final def quickSelect[@spec A: Order: ClassTag](data: Array[A], k: Int): Unit =
+  final def quickSelect[@sp A: Order: ClassTag](data: Array[A], k: Int): Unit =
     QuickSelect.select(data, k)
 }

--- a/core/shared/src/main/scala/spire/math/Selection.scala
+++ b/core/shared/src/main/scala/spire/math/Selection.scala
@@ -1,8 +1,7 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import spire.algebra.Order
 

--- a/core/shared/src/main/scala/spire/math/Sorting.scala
+++ b/core/shared/src/main/scala/spire/math/Sorting.scala
@@ -1,7 +1,6 @@
 package spire
 package math
 
-import scala.reflect.ClassTag
 
 import spire.algebra.Order
 

--- a/core/shared/src/main/scala/spire/math/Sorting.scala
+++ b/core/shared/src/main/scala/spire/math/Sorting.scala
@@ -9,7 +9,7 @@ import spire.algebra.Order
  *  Interface for a sorting strategy object.
  */
 trait Sort extends Any {
-  def sort[@spec A: Order: ClassTag](data:Array[A]): Unit
+  def sort[@sp A: Order: ClassTag](data:Array[A]): Unit
 }
 
 /**
@@ -18,10 +18,10 @@ trait Sort extends Any {
  * Works for small arrays but due to O(n^2) complexity is not generally good.
  */
 object InsertionSort extends Sort {
-  final def sort[@spec A:Order:ClassTag](data:Array[A]): Unit =
+  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit =
     sort(data, 0, data.length)
 
-  final def sort[@spec A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
+  final def sort[@sp A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
 
     var i = start + 1
     while (i < end) {
@@ -47,7 +47,7 @@ object MergeSort extends Sort {
   @inline final def startWidth: Int = 8
   @inline final def startStep: Int = 16
 
-  final def sort[@spec A:Order:ClassTag](data:Array[A]): Unit = {
+  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = {
     val len = data.length
 
     if (len <= startStep) return InsertionSort.sort(data)
@@ -88,7 +88,7 @@ object MergeSort extends Sort {
    * left and right ranges of the input to merge, as well as the area of the
    * ouput to write to.
    */
-  @inline final def merge[@spec A](in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)(implicit o:Order[A]): Unit = {
+  @inline final def merge[@sp A](in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)(implicit o:Order[A]): Unit = {
 
     var ii = start
     var jj = mid
@@ -112,9 +112,9 @@ object MergeSort extends Sort {
 object QuickSort {
   @inline final def limit: Int = 16
 
-  final def sort[@spec A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length - 1)
+  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length - 1)
 
-  final def qsort[@spec A](data:Array[A], left: Int, right: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
+  final def qsort[@sp A](data:Array[A], left: Int, right: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
 
     if (right - left < limit) return InsertionSort.sort(data, left, right + 1)
 
@@ -124,7 +124,7 @@ object QuickSort {
     qsort(data, next + 1, right)
   }
 
-  final def partition[@spec A](data:Array[A], left:Int, right:Int, pivot:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
+  final def partition[@sp A](data:Array[A], left:Int, right:Int, pivot:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
 
     val value = data(pivot)
 
@@ -159,9 +159,9 @@ object QuickSort {
  * insertionSort(), which is slow except for small arrays.
  */
 object Sorting {
-  final def sort[@spec A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
+  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
 
-  final def insertionSort[@spec A:Order:ClassTag](data:Array[A]): Unit = InsertionSort.sort(data)
-  final def mergeSort[@spec A:Order:ClassTag](data:Array[A]): Unit = MergeSort.sort(data)
-  final def quickSort[@spec K:Order:ClassTag](data:Array[K]): Unit = QuickSort.sort(data)
+  final def insertionSort[@sp A:Order:ClassTag](data:Array[A]): Unit = InsertionSort.sort(data)
+  final def mergeSort[@sp A:Order:ClassTag](data:Array[A]): Unit = MergeSort.sort(data)
+  final def quickSort[@sp K:Order:ClassTag](data:Array[K]): Unit = QuickSort.sort(data)
 }

--- a/core/shared/src/main/scala/spire/math/Sorting.scala
+++ b/core/shared/src/main/scala/spire/math/Sorting.scala
@@ -1,8 +1,7 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import spire.algebra.Order
 

--- a/core/shared/src/main/scala/spire/math/Trilean.scala
+++ b/core/shared/src/main/scala/spire/math/Trilean.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.lattice.Heyting
 

--- a/core/shared/src/main/scala/spire/math/UByte.scala
+++ b/core/shared/src/main/scala/spire/math/UByte.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{IsIntegral, Order, Rig, Signed}
 

--- a/core/shared/src/main/scala/spire/math/UInt.scala
+++ b/core/shared/src/main/scala/spire/math/UInt.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{IsIntegral, Order, Rig, Signed}
 

--- a/core/shared/src/main/scala/spire/math/ULong.scala
+++ b/core/shared/src/main/scala/spire/math/ULong.scala
@@ -1,6 +1,6 @@
-package spire.math
+package spire
+package math
 
-import scala.annotation.tailrec
 
 import spire.algebra.{IsIntegral, Order, Rig, Signed}
 

--- a/core/shared/src/main/scala/spire/math/UShort.scala
+++ b/core/shared/src/main/scala/spire/math/UShort.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.{IsIntegral, Order, Rig, Signed}
 

--- a/core/shared/src/main/scala/spire/math/interval/Bound.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Bound.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 package interval
 
 import spire.syntax.order._

--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -355,26 +355,26 @@ package object math {
    * e
    */
   final def e: Double = Math.E
-  final def e[@spec(Float, Double) A](implicit ev: Trig[A]): A = ev.e
+  final def e[@sp(Float, Double) A](implicit ev: Trig[A]): A = ev.e
 
   /**
    * pi
    */
   final def pi: Double = Math.PI
-  final def pi[@spec(Float, Double) A](implicit ev: Trig[A]): A = ev.pi
+  final def pi[@sp(Float, Double) A](implicit ev: Trig[A]): A = ev.pi
 
-  final def sin[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.sin(a)
-  final def cos[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.cos(a)
-  final def tan[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.tan(a)
+  final def sin[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.sin(a)
+  final def cos[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.cos(a)
+  final def tan[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.tan(a)
 
-  final def asin[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.asin(a)
-  final def acos[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.acos(a)
-  final def atan[@spec(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.atan(a)
-  final def atan2[@spec(Float, Double) A](y: A, x: A)(implicit ev: Trig[A]): A = ev.atan2(y, x)
+  final def asin[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.asin(a)
+  final def acos[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.acos(a)
+  final def atan[@sp(Float, Double) A](a: A)(implicit ev: Trig[A]): A = ev.atan(a)
+  final def atan2[@sp(Float, Double) A](y: A, x: A)(implicit ev: Trig[A]): A = ev.atan2(y, x)
 
-  final def sinh[@spec(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.sinh(x)
-  final def cosh[@spec(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.cosh(x)
-  final def tanh[@spec(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.tanh(x)
+  final def sinh[@sp(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.sinh(x)
+  final def cosh[@sp(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.cosh(x)
+  final def tanh[@sp(Float, Double) A](x: A)(implicit ev: Trig[A]): A = ev.tanh(x)
 
   // java.lang.Math/scala.math.compatibility
   final def cbrt(x: Double): Double = Math.cbrt(x)
@@ -400,7 +400,7 @@ package object math {
   final def ulp(x: Double): Double = Math.ulp(x)
   final def ulp(x: Float): Double = Math.ulp(x)
 
-  final def hypot[@spec(Float, Double) A](x: A, y: A)
+  final def hypot[@sp(Float, Double) A](x: A, y: A)
     (implicit f: Field[A], n: NRoot[A], o: Order[A]): A = {
     import spire.implicits._
     if (x > y) x.abs * (1 + (y/x)**2).sqrt

--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -6,8 +6,6 @@ import java.math.BigInteger
 import java.math.MathContext
 import java.math.RoundingMode
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.math.ScalaNumericConversions
 
 import BigDecimal.RoundingMode.{FLOOR, HALF_UP, CEILING}

--- a/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
+++ b/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
@@ -1,7 +1,7 @@
-package spire.math
+package spire
+package math
 package poly
 
-import scala.annotation.tailrec
 
 import java.math.{ BigDecimal => JBigDecimal, RoundingMode, MathContext }
 

--- a/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
@@ -1,8 +1,8 @@
-package spire.math.poly
+package spire
+package math
+package poly
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import spire.algebra.{Eq, Field, Ring, Rng, Semiring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
@@ -2,7 +2,6 @@ package spire
 package math
 package poly
 
-import scala.reflect.ClassTag
 
 import spire.algebra.{Eq, Field, Ring, Rng, Semiring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolyDense.scala
@@ -12,7 +12,7 @@ import spire.syntax.eq._
 import spire.syntax.field._
 
 // Dense polynomials - Little Endian Coeffs e.g. x^0, x^1, ... x^n
-class PolyDense[@spec(Double) C] private[spire] (val coeffs: Array[C])
+class PolyDense[@sp(Double) C] private[spire] (val coeffs: Array[C])
     (implicit val ct: ClassTag[C]) extends Polynomial[C] { lhs =>
 
   def degree: Int = if (isZero) 0 else coeffs.length - 1

--- a/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
@@ -1,10 +1,10 @@
-package spire.math.poly
+package spire
+package math
+package poly
 
 import java.lang.Integer.{ numberOfLeadingZeros, numberOfTrailingZeros }
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import spire.algebra.{Eq, Field, Ring, Rng, Semiring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
@@ -14,7 +14,7 @@ import spire.syntax.eq._
 import spire.syntax.cfor._
 import spire.syntax.std.array._
 
-case class PolySparse[@spec(Double) C] private [spire](val exp: Array[Int], val coeff: Array[C])
+case class PolySparse[@sp(Double) C] private [spire](val exp: Array[Int], val coeff: Array[C])
     (implicit val ct: ClassTag[C]) extends Polynomial[C] { lhs =>
 
   def toDense(implicit ring: Semiring[C], eq: Eq[C]): PolyDense[C] =
@@ -194,14 +194,14 @@ case class PolySparse[@spec(Double) C] private [spire](val exp: Array[Int], val 
 
 
 object PolySparse {
-  private final def dense2sparse[@spec(Double) C: Semiring: Eq: ClassTag](poly: PolyDense[C]): PolySparse[C] = {
+  private final def dense2sparse[@sp(Double) C: Semiring: Eq: ClassTag](poly: PolyDense[C]): PolySparse[C] = {
     val cs = poly.coeffs
     val es = new Array[Int](cs.length)
     cfor(0)(_ < es.length, _ + 1) { i => es(i) = i }
     PolySparse.safe(es, cs)
   }
 
-  private[math] final def safe[@spec(Double) C: Semiring: Eq: ClassTag]
+  private[math] final def safe[@sp(Double) C: Semiring: Eq: ClassTag]
       (exp: Array[Int], coeff: Array[C]): PolySparse[C] = {
     var len = 0
     cfor(0)(_ < coeff.length, _ + 1) { i =>
@@ -229,7 +229,7 @@ object PolySparse {
     }
   }
 
-  final def apply[@spec(Double) C: Semiring: Eq: ClassTag](data: Map[Int,C]): PolySparse[C] = {
+  final def apply[@sp(Double) C: Semiring: Eq: ClassTag](data: Map[Int,C]): PolySparse[C] = {
     val data0 = data.toArray
     data0.qsortBy(_._1)
     val es = new Array[Int](data0.length)
@@ -242,7 +242,7 @@ object PolySparse {
     safe(es, cs)
   }
 
-  final def apply[@spec(Double) C: Semiring: Eq: ClassTag](poly: Polynomial[C]): PolySparse[C] = {
+  final def apply[@sp(Double) C: Semiring: Eq: ClassTag](poly: Polynomial[C]): PolySparse[C] = {
     poly match {
       case (poly: PolySparse[_]) =>
         poly
@@ -265,10 +265,10 @@ object PolySparse {
     }
   }
 
-  final def zero[@spec(Double) C: Semiring: Eq: ClassTag]: PolySparse[C] =
+  final def zero[@sp(Double) C: Semiring: Eq: ClassTag]: PolySparse[C] =
     new PolySparse(new Array[Int](0), new Array[C](0))
 
-  private final def multiplyTerm[@spec(Double) C: Semiring: Eq: ClassTag](poly: PolySparse[C], c: C, e: Int): PolySparse[C] = {
+  private final def multiplyTerm[@sp(Double) C: Semiring: Eq: ClassTag](poly: PolySparse[C], c: C, e: Int): PolySparse[C] = {
     val exp = poly.exp
     val coeff = poly.coeff
     val cs = new Array[C](coeff.length)
@@ -280,7 +280,7 @@ object PolySparse {
     new PolySparse(es, cs)
   }
 
-  private final def multiplySparse[@spec(Double) C: Semiring: Eq: ClassTag]
+  private final def multiplySparse[@sp(Double) C: Semiring: Eq: ClassTag]
       (lhs: PolySparse[C], rhs: PolySparse[C]): PolySparse[C] = {
     val lexp = lhs.exp
     val lcoeff = lhs.coeff
@@ -291,7 +291,7 @@ object PolySparse {
     sum
   }
 
-  private final def countSumTerms[@spec(Double) C]
+  private final def countSumTerms[@sp(Double) C]
       (lhs: PolySparse[C], rhs: PolySparse[C], lOffset: Int = 0, rOffset: Int = 0): Int = {
     val PolySparse(lexp, lcoeff) = lhs
     val PolySparse(rexp, rcoeff) = rhs
@@ -400,7 +400,7 @@ object PolySparse {
     loop(0, 0, 0)
   }
 
-  private final def quotmodSparse[@spec(Double) C: Field: Eq: ClassTag]
+  private final def quotmodSparse[@sp(Double) C: Field: Eq: ClassTag]
       (lhs: PolySparse[C], rhs: PolySparse[C]): (PolySparse[C], PolySparse[C]) = {
     val rdegree = rhs.degree
     val rmaxCoeff = rhs.maxOrderTermCoeff

--- a/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
@@ -4,7 +4,6 @@ package poly
 
 import java.lang.Integer.{ numberOfLeadingZeros, numberOfTrailingZeros }
 
-import scala.reflect.ClassTag
 
 import spire.algebra.{Eq, Field, Ring, Rng, Semiring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/RootFinder.scala
+++ b/core/shared/src/main/scala/spire/math/poly/RootFinder.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 package poly
 
 import java.math.MathContext

--- a/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
+++ b/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 package poly
 
 import spire.std.bigInt._

--- a/core/shared/src/main/scala/spire/math/poly/Roots.scala
+++ b/core/shared/src/main/scala/spire/math/poly/Roots.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 package poly
 
 import java.math.{ RoundingMode, MathContext }

--- a/core/shared/src/main/scala/spire/math/poly/SpecialPolynomials.scala
+++ b/core/shared/src/main/scala/spire/math/poly/SpecialPolynomials.scala
@@ -2,7 +2,6 @@ package spire
 package math
 package poly
 
-import scala.reflect.ClassTag
 
 import spire.algebra.{Eq, Field, Ring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/SpecialPolynomials.scala
+++ b/core/shared/src/main/scala/spire/math/poly/SpecialPolynomials.scala
@@ -1,8 +1,8 @@
-package spire.math.poly
+package spire
+package math
+package poly
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
-import scala.{specialized => spec}
 
 import spire.algebra.{Eq, Field, Ring}
 import spire.math.Polynomial

--- a/core/shared/src/main/scala/spire/math/poly/Term.scala
+++ b/core/shared/src/main/scala/spire/math/poly/Term.scala
@@ -1,6 +1,6 @@
-package spire.math.poly
-
-import scala.{specialized => spec}
+package spire
+package math
+package poly
 
 import spire.algebra.{Eq, Field, Order, Rig, Ring, Rng, Semiring}
 import spire.syntax.field._

--- a/core/shared/src/main/scala/spire/math/poly/Term.scala
+++ b/core/shared/src/main/scala/spire/math/poly/Term.scala
@@ -7,7 +7,7 @@ import spire.syntax.field._
 import spire.syntax.eq._
 
 // Univariate polynomial term
-case class Term[@spec(Float, Double) C](coeff: C, exp: Int) { lhs =>
+case class Term[@sp(Float, Double) C](coeff: C, exp: Int) { lhs =>
 
   def unary_-(implicit r: Rng[C]): Term[C] = Term(-coeff, exp)
 
@@ -73,11 +73,11 @@ object Term {
     def compare(x: Term[C], y: Term[C]): Int = x.exp compare y.exp
   }
 
-  def fromTuple[@spec(Float, Double) C](tpl: (Int, C)): Term[C] =
+  def fromTuple[@sp(Float, Double) C](tpl: (Int, C)): Term[C] =
     Term(tpl._2, tpl._1)
-  def zero[@spec(Float, Double) C](implicit r: Semiring[C]): Term[C] =
+  def zero[@sp(Float, Double) C](implicit r: Semiring[C]): Term[C] =
     Term(r.zero, 0)
-  def one[@spec(Float, Double) C](implicit r: Rig[C]): Term[C] =
+  def one[@sp(Float, Double) C](implicit r: Rig[C]): Term[C] =
     Term(r.one, 0)
 
   private val IsZero = "0".r

--- a/core/shared/src/main/scala/spire/math/prime/BitSet.scala
+++ b/core/shared/src/main/scala/spire/math/prime/BitSet.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.syntax.cfor._
 

--- a/core/shared/src/main/scala/spire/math/prime/FactorHeap.scala
+++ b/core/shared/src/main/scala/spire/math/prime/FactorHeap.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import SieveUtil._
 

--- a/core/shared/src/main/scala/spire/math/prime/Factors.scala
+++ b/core/shared/src/main/scala/spire/math/prime/Factors.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.algebra.Sign
 import spire.algebra.Sign.{Negative, Zero, Positive}
@@ -7,7 +8,6 @@ import spire.std.int._
 import spire.std.map._
 import spire.syntax.rng._
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 
 object Factors {

--- a/core/shared/src/main/scala/spire/math/prime/SieveSegment.scala
+++ b/core/shared/src/main/scala/spire/math/prime/SieveSegment.scala
@@ -1,6 +1,6 @@
-package spire.math.prime
+package spire
+package math.prime
 
-import scala.annotation.tailrec
 import scala.collection.mutable.{ArrayBuffer}
 import System.arraycopy
 

--- a/core/shared/src/main/scala/spire/math/prime/SieveUtil.scala
+++ b/core/shared/src/main/scala/spire/math/prime/SieveUtil.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.math.SafeLong
 

--- a/core/shared/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/shared/src/main/scala/spire/math/prime/Siever.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.math.{SafeLong, log, max}
 

--- a/core/shared/src/main/scala/spire/math/prime/package.scala
+++ b/core/shared/src/main/scala/spire/math/prime/package.scala
@@ -1,11 +1,11 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.Sign
 import spire.algebra.Sign.{Negative, Zero, Positive}
 import spire.syntax.cfor._
 import spire.syntax.nroot._
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 
 /**

--- a/core/shared/src/main/scala/spire/optional/genericEq.scala
+++ b/core/shared/src/main/scala/spire/optional/genericEq.scala
@@ -1,6 +1,6 @@
-package spire.optional
+package spire
+package optional
 
-import scala.{specialized => sp}
 import spire.algebra.Eq
 
 /**

--- a/core/shared/src/main/scala/spire/optional/intervalGeometricPartialOrder.scala
+++ b/core/shared/src/main/scala/spire/optional/intervalGeometricPartialOrder.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra._
 import spire.math.Interval

--- a/core/shared/src/main/scala/spire/optional/intervalRangedPartialOrder.scala
+++ b/core/shared/src/main/scala/spire/optional/intervalRangedPartialOrder.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra.{Order, PartialOrder}
 import spire.math.{Interval, Point}

--- a/core/shared/src/main/scala/spire/optional/intervalSubsetPartialOrder.scala
+++ b/core/shared/src/main/scala/spire/optional/intervalSubsetPartialOrder.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra.{Order, PartialOrder}
 import spire.math.Interval

--- a/core/shared/src/main/scala/spire/optional/mapIntIntPermutation.scala
+++ b/core/shared/src/main/scala/spire/optional/mapIntIntPermutation.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom

--- a/core/shared/src/main/scala/spire/optional/mapIntIntPermutation.scala
+++ b/core/shared/src/main/scala/spire/optional/mapIntIntPermutation.scala
@@ -1,7 +1,5 @@
 package spire.optional
 
-import scala.{specialized => sp}
-
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 

--- a/core/shared/src/main/scala/spire/optional/partialIterable.scala
+++ b/core/shared/src/main/scala/spire/optional/partialIterable.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import scala.collection.IterableLike
 import scala.collection.generic.CanBuildFrom

--- a/core/shared/src/main/scala/spire/optional/partialIterable.scala
+++ b/core/shared/src/main/scala/spire/optional/partialIterable.scala
@@ -1,7 +1,5 @@
 package spire.optional
 
-import scala.{specialized => sp}
-
 import scala.collection.IterableLike
 import scala.collection.generic.CanBuildFrom
 

--- a/core/shared/src/main/scala/spire/optional/powerSetPartialOrder.scala
+++ b/core/shared/src/main/scala/spire/optional/powerSetPartialOrder.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra.PartialOrder
 

--- a/core/shared/src/main/scala/spire/optional/rationalTrig.scala
+++ b/core/shared/src/main/scala/spire/optional/rationalTrig.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra.Trig
 import spire.math.Rational

--- a/core/shared/src/main/scala/spire/optional/totalFloat.scala
+++ b/core/shared/src/main/scala/spire/optional/totalFloat.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import java.lang.Math
 

--- a/core/shared/src/main/scala/spire/optional/unicode.scala
+++ b/core/shared/src/main/scala/spire/optional/unicode.scala
@@ -1,4 +1,5 @@
-package spire.optional
+package spire
+package optional
 
 import spire.algebra._
 import spire.algebra.lattice._

--- a/core/shared/src/main/scala/spire/optional/vectorOrder.scala
+++ b/core/shared/src/main/scala/spire/optional/vectorOrder.scala
@@ -1,8 +1,7 @@
-package spire.optional
+package spire
+package optional
 
 import scala.collection.SeqLike
-import scala.{specialized => sp}
-
 import spire.algebra.{ Eq, Module, Order }
 import spire.std.{ SeqVectorEq, SeqVectorOrder }
 import spire.std.{ ArrayVectorEq, ArrayVectorOrder }

--- a/core/shared/src/main/scala/spire/package.scala
+++ b/core/shared/src/main/scala/spire/package.scala
@@ -1,4 +1,6 @@
 package object spire {
-  type sp      = scala.specialized
-  type tailrec = scala.annotation.tailrec
+  type sp          = scala.specialized
+  type tailrec     = scala.annotation.tailrec
+  type ClassTag[A] = scala.reflect.ClassTag[A]
+  val ClassTag     = scala.reflect.ClassTag
 }

--- a/core/shared/src/main/scala/spire/package.scala
+++ b/core/shared/src/main/scala/spire/package.scala
@@ -1,0 +1,4 @@
+package object spire {
+  type sp      = scala.specialized
+  type tailrec = scala.annotation.tailrec
+}

--- a/core/shared/src/main/scala/spire/package.scala
+++ b/core/shared/src/main/scala/spire/package.scala
@@ -1,4 +1,5 @@
 package object spire {
   type sp      = scala.specialized
+  type spec    = scala.specialized
   type tailrec = scala.annotation.tailrec
 }

--- a/core/shared/src/main/scala/spire/package.scala
+++ b/core/shared/src/main/scala/spire/package.scala
@@ -1,5 +1,4 @@
 package object spire {
   type sp      = scala.specialized
-  type spec    = scala.specialized
   type tailrec = scala.annotation.tailrec
 }

--- a/core/shared/src/main/scala/spire/random/Dist.scala
+++ b/core/shared/src/main/scala/spire/random/Dist.scala
@@ -10,7 +10,7 @@ import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 
-trait Dist[@spec A] extends Any { self =>
+trait Dist[@sp A] extends Any { self =>
 
   def apply(gen: Generator): A
 
@@ -152,7 +152,7 @@ final class DistIterator[A](next: Dist[A], gen: Generator) extends Iterator[A] {
   final def next(): A = next(gen)
 }
 
-class DistFromGen[@spec A](f: Generator => A) extends Dist[A] {
+class DistFromGen[@sp A](f: Generator => A) extends Dist[A] {
   def apply(gen: Generator): A = f(gen)
 }
 

--- a/core/shared/src/main/scala/spire/random/Dist.scala
+++ b/core/shared/src/main/scala/spire/random/Dist.scala
@@ -8,7 +8,6 @@ import spire.math.{Complex, Interval, Natural, Rational, SafeLong, UByte, UShort
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
 
 trait Dist[@sp A] extends Any { self =>
 

--- a/core/shared/src/main/scala/spire/random/Dist.scala
+++ b/core/shared/src/main/scala/spire/random/Dist.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 
 import spire.algebra._
 import spire.syntax.all._
@@ -7,8 +8,6 @@ import spire.math.{Complex, Interval, Natural, Rational, SafeLong, UByte, UShort
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.reflect.ClassTag
 
 trait Dist[@spec A] extends Any { self =>

--- a/core/shared/src/main/scala/spire/random/Exponential.scala
+++ b/core/shared/src/main/scala/spire/random/Exponential.scala
@@ -1,6 +1,5 @@
-package spire.random
-
-import scala.{specialized => sp}
+package spire
+package random
 
 trait Exponential[@sp(Float, Double) A] extends Any {
   /**

--- a/core/shared/src/main/scala/spire/random/Gaussian.scala
+++ b/core/shared/src/main/scala/spire/random/Gaussian.scala
@@ -1,9 +1,7 @@
-package spire.random
+package spire
+package random
 
 import java.math.MathContext
-
-import scala.{specialized => sp}
-import scala.annotation.tailrec
 
 import spire.algebra.{Field, NRoot, Order, Trig}
 

--- a/core/shared/src/main/scala/spire/random/Generator.scala
+++ b/core/shared/src/main/scala/spire/random/Generator.scala
@@ -292,7 +292,7 @@ abstract class Generator {
   /**
    * Generate an Array[A] using the given Dist[A] instance.
    */
-  def generateArray[@spec A: Dist: ClassTag](n: Int): Array[A] = {
+  def generateArray[@sp A: Dist: ClassTag](n: Int): Array[A] = {
     val arr = new Array[A](n)
     fillArray(arr)
     arr
@@ -301,7 +301,7 @@ abstract class Generator {
   /**
    * Fill an Array[A] using the given Dist[A] instance.
    */
-  def fillArray[@spec A: Dist](arr: Array[A]): Unit = {
+  def fillArray[@sp A: Dist](arr: Array[A]): Unit = {
     var i = 0
     val len = arr.length
     while (i < len) {
@@ -312,7 +312,7 @@ abstract class Generator {
 
   def oneOf[A](as: A*): A = chooseFromSeq(as)(this)
 
-  def chooseFromArray[@spec A](arr: Array[A])(implicit gen: Generator): A =
+  def chooseFromArray[@sp A](arr: Array[A])(implicit gen: Generator): A =
     arr(gen.nextInt(arr.length))
 
   def chooseFromSeq[A](seq: Seq[A])(implicit gen: Generator): A =
@@ -321,7 +321,7 @@ abstract class Generator {
   def chooseFromIterable[A](as: Iterable[A])(implicit gen: Generator): A =
     as.iterator.drop(gen.nextInt(as.size)).next()
 
-  def sampleFromArray[@spec A: ClassTag](as: Array[A], size: Int)(implicit gen: Generator): Array[A] = {
+  def sampleFromArray[@sp A: ClassTag](as: Array[A], size: Int)(implicit gen: Generator): Array[A] = {
     val chosen: Array[A] = new Array[A](size)
     if (size < 1) {
       throw new IllegalArgumentException("illegal sample size (%d)" format size)
@@ -346,7 +346,7 @@ abstract class Generator {
     chosen
   }
 
-  def sampleFromTraversable[@spec A: ClassTag](as: Traversable[A], size: Int)(implicit gen: Generator): Array[A] = {
+  def sampleFromTraversable[@sp A: ClassTag](as: Traversable[A], size: Int)(implicit gen: Generator): Array[A] = {
     val chosen: Array[A] = new Array[A](size)
     var i: Int = 0
     as.foreach { a =>
@@ -364,7 +364,7 @@ abstract class Generator {
     chosen
   }
 
-  def shuffle[@spec A](as: Array[A])(implicit gen: Generator): Unit = {
+  def shuffle[@sp A](as: Array[A])(implicit gen: Generator): Unit = {
     var i: Int = as.length - 1
     while (i > 0) {
       val n: Int = gen.nextInt(i)
@@ -445,7 +445,7 @@ abstract class LongBasedGenerator extends Generator { self =>
     (nextLong >>> 32).toInt
 }
 
-trait GeneratorCompanion[G, @spec(Int, Long) S] {
+trait GeneratorCompanion[G, @sp(Int, Long) S] {
   def randomSeed(): S
 
   def fromBytes(bytes: Array[Byte]): G

--- a/core/shared/src/main/scala/spire/random/Generator.scala
+++ b/core/shared/src/main/scala/spire/random/Generator.scala
@@ -1,7 +1,6 @@
-package spire.random
+package spire
+package random
 
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.reflect.ClassTag
 
 import spire.math.{UInt, ULong}

--- a/core/shared/src/main/scala/spire/random/Generator.scala
+++ b/core/shared/src/main/scala/spire/random/Generator.scala
@@ -1,7 +1,6 @@
 package spire
 package random
 
-import scala.reflect.ClassTag
 
 import spire.math.{UInt, ULong}
 

--- a/core/shared/src/main/scala/spire/random/Random.scala
+++ b/core/shared/src/main/scala/spire/random/Random.scala
@@ -4,7 +4,6 @@ package random
 import scala.collection.mutable.{ArrayBuffer, Builder}
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
 
 sealed trait Op[+A] {
 

--- a/core/shared/src/main/scala/spire/random/Random.scala
+++ b/core/shared/src/main/scala/spire/random/Random.scala
@@ -1,10 +1,9 @@
-package spire.random
+package spire
+package random
 
 import scala.collection.mutable.{ArrayBuffer, Builder}
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.annotation.tailrec
-import scala.{specialized => spec}
 import scala.reflect.ClassTag
 
 sealed trait Op[+A] {

--- a/core/shared/src/main/scala/spire/random/Uniform.scala
+++ b/core/shared/src/main/scala/spire/random/Uniform.scala
@@ -1,6 +1,5 @@
-package spire.random
-
-import scala.{specialized => sp}
+package spire
+package random
 
 import spire.math.{Rational, UInt, ULong}
 

--- a/core/shared/src/main/scala/spire/random/Ziggurat.scala
+++ b/core/shared/src/main/scala/spire/random/Ziggurat.scala
@@ -15,7 +15,6 @@
 package spire
 package random
 
-import scala.annotation.tailrec
 
 /**
  * This is a Scala implementation of the Ziggurat algorithm for generating random variables from decreasing densities.

--- a/core/shared/src/main/scala/spire/random/rng/BurtleRot32.scala
+++ b/core/shared/src/main/scala/spire/random/rng/BurtleRot32.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import java.nio.ByteBuffer

--- a/core/shared/src/main/scala/spire/random/rng/Cmwc5.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Cmwc5.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import java.nio.ByteBuffer

--- a/core/shared/src/main/scala/spire/random/rng/DevPrng.scala
+++ b/core/shared/src/main/scala/spire/random/rng/DevPrng.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import java.io._

--- a/core/shared/src/main/scala/spire/random/rng/Lcg32.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Lcg32.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import spire.util.Pack

--- a/core/shared/src/main/scala/spire/random/rng/Lcg64.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Lcg64.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import spire.util.Pack

--- a/core/shared/src/main/scala/spire/random/rng/Marsaglia32a6.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Marsaglia32a6.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import java.nio.ByteBuffer

--- a/core/shared/src/main/scala/spire/random/rng/PcgXshRr64_32.scala
+++ b/core/shared/src/main/scala/spire/random/rng/PcgXshRr64_32.scala
@@ -4,7 +4,6 @@ package rng
 
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.annotation.tailrec
 import spire.util.Pack
 
 /**

--- a/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
+++ b/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import java.nio.ByteBuffer

--- a/core/shared/src/main/scala/spire/random/rng/Serial.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Serial.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 import spire.util.Pack

--- a/core/shared/src/main/scala/spire/random/rng/SyncGenerator.scala
+++ b/core/shared/src/main/scala/spire/random/rng/SyncGenerator.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 package rng
 
 final class SyncGenerator(gen: Generator) extends Generator {

--- a/core/shared/src/main/scala/spire/std/any.scala
+++ b/core/shared/src/main/scala/spire/std/any.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 trait AnyInstances extends BooleanInstances
     with CharInstances

--- a/core/shared/src/main/scala/spire/std/array.scala
+++ b/core/shared/src/main/scala/spire/std/array.scala
@@ -10,14 +10,14 @@ object ArraySupport {
   import spire.syntax.order._
   import spire.syntax.ring._
 
-  def eqv[@spec A: Eq](x: Array[A], y: Array[A]): Boolean = {
+  def eqv[@sp A: Eq](x: Array[A], y: Array[A]): Boolean = {
     var i = 0
     if (x.length != y.length) return false
     while (i < x.length && i < y.length && x(i) === y(i)) i += 1
     i == x.length
   }
 
-  def vectorEqv[@spec A](x: Array[A], y: Array[A])(implicit ev: Eq[A], sc: AdditiveMonoid[A]): Boolean = {
+  def vectorEqv[@sp A](x: Array[A], y: Array[A])(implicit ev: Eq[A], sc: AdditiveMonoid[A]): Boolean = {
     var i = 0
     while (i < x.length && i < y.length && x(i) === y(i)) i += 1
     while (i < x.length && x(i) === sc.zero) i += 1
@@ -25,7 +25,7 @@ object ArraySupport {
     i >= x.length && i >= y.length
   }
 
-  def compare[@spec A: Order](x: Array[A], y: Array[A]): Int = {
+  def compare[@sp A: Order](x: Array[A], y: Array[A]): Int = {
     var i = 0
     while (i < x.length && i < y.length) {
       val cmp = x(i) compare y(i)
@@ -35,7 +35,7 @@ object ArraySupport {
     x.length - y.length
   }
 
-  def vectorCompare[@spec A](x: Array[A], y: Array[A])(implicit ev: Order[A], sc: AdditiveMonoid[A]): Int = {
+  def vectorCompare[@sp A](x: Array[A], y: Array[A])(implicit ev: Order[A], sc: AdditiveMonoid[A]): Int = {
     var i = 0
     while (i < x.length && i < y.length) {
       val cmp = x(i) compare y(i)
@@ -53,14 +53,14 @@ object ArraySupport {
     0
   }
 
-  def concat[@spec A: ClassTag](x: Array[A], y: Array[A]): Array[A] = {
+  def concat[@sp A: ClassTag](x: Array[A], y: Array[A]): Array[A] = {
     val z = new Array[A](x.length + y.length)
     System.arraycopy(x, 0, z, 0, x.length)
     System.arraycopy(y, 0, z, x.length, y.length)
     z
   }
 
-  def negate[@spec(Int, Long, Float, Double) A: ClassTag: Ring](x: Array[A]): Array[A] = {
+  def negate[@sp(Int, Long, Float, Double) A: ClassTag: Ring](x: Array[A]): Array[A] = {
     val y = new Array[A](x.length)
     var i = 0
     while (i < x.length) {
@@ -70,7 +70,7 @@ object ArraySupport {
     y
   }
 
-  def plus[@spec(Int, Long, Float, Double) A: ClassTag: AdditiveMonoid](x: Array[A], y: Array[A]): Array[A] = {
+  def plus[@sp(Int, Long, Float, Double) A: ClassTag: AdditiveMonoid](x: Array[A], y: Array[A]): Array[A] = {
     val z = new Array[A](spire.math.max(x.length, y.length))
     var i = 0
     while (i < x.length && i < y.length) { z(i) = x(i) + y(i); i += 1 }
@@ -79,7 +79,7 @@ object ArraySupport {
     z
   }
 
-  def minus[@spec(Int, Long, Float, Double) A: ClassTag: AdditiveGroup](x: Array[A], y: Array[A]): Array[A] = {
+  def minus[@sp(Int, Long, Float, Double) A: ClassTag: AdditiveGroup](x: Array[A], y: Array[A]): Array[A] = {
     val z = new Array[A](spire.math.max(x.length, y.length))
     var i = 0
     while (i < x.length && i < y.length) { z(i) = x(i) - y(i); i += 1 }
@@ -88,21 +88,21 @@ object ArraySupport {
     z
   }
 
-  def timesl[@spec(Int, Long, Float, Double) A: ClassTag: MultiplicativeSemigroup](r: A, x: Array[A]): Array[A] = {
+  def timesl[@sp(Int, Long, Float, Double) A: ClassTag: MultiplicativeSemigroup](r: A, x: Array[A]): Array[A] = {
     val y = new Array[A](x.length)
     var i = 0
     while (i < y.length) { y(i) = r * x(i); i += 1 }
     y
   }
 
-  def dot[@spec(Int, Long, Float, Double) A](x: Array[A], y: Array[A])(implicit sc: Rig[A]): A = {
+  def dot[@sp(Int, Long, Float, Double) A](x: Array[A], y: Array[A])(implicit sc: Rig[A]): A = {
     var z = sc.zero
     var i = 0
     while (i < x.length && i < y.length) { z += x(i) * y(i); i += 1 }
     z
   }
 
-  def axis[@spec(Float, Double) A](dimensions: Int, i: Int)(implicit ct: ClassTag[A], sc: Rig[A]): Array[A] = {
+  def axis[@sp(Float, Double) A](dimensions: Int, i: Int)(implicit ct: ClassTag[A], sc: Rig[A]): Array[A] = {
     val v = new Array[A](dimensions)
     var j = 0
     while (j < v.length) { v(j) = sc.zero; j += 1 }
@@ -114,40 +114,40 @@ object ArraySupport {
 trait ArrayInstances0 {
   type NI0[A] = NoImplicit[VectorSpace[Array[A], A]]
 
-  implicit def ArrayModule[@spec(Int,Long,Float,Double) A: NI0: ClassTag: Ring]: Module[Array[A], A] =
+  implicit def ArrayModule[@sp(Int,Long,Float,Double) A: NI0: ClassTag: Ring]: Module[Array[A], A] =
     new ArrayModule[A]
 }
 
 trait ArrayInstances1 extends ArrayInstances0 {
   type NI1[A] = NoImplicit[NormedVectorSpace[Array[A], A]]
 
-  implicit def ArrayVectorSpace[@spec(Int,Long,Float,Double) A: NI1: ClassTag: Field]: VectorSpace[Array[A], A] =
+  implicit def ArrayVectorSpace[@sp(Int,Long,Float,Double) A: NI1: ClassTag: Field]: VectorSpace[Array[A], A] =
     new ArrayVectorSpace[A]
 
-  implicit def ArrayEq[@spec A: Eq]: Eq[Array[A]] =
+  implicit def ArrayEq[@sp A: Eq]: Eq[Array[A]] =
     new ArrayEq[A]
 }
 
 trait ArrayInstances2 extends ArrayInstances1 {
-  implicit def ArrayInnerProductSpace[@spec(Float, Double) A: Field: ClassTag]: InnerProductSpace[Array[A], A] =
+  implicit def ArrayInnerProductSpace[@sp(Float, Double) A: Field: ClassTag]: InnerProductSpace[Array[A], A] =
     new ArrayInnerProductSpace[A]
 
-  implicit def ArrayOrder[@spec A: Order]: Order[Array[A]] =
+  implicit def ArrayOrder[@sp A: Order]: Order[Array[A]] =
     new ArrayOrder[A]
 }
 
 trait ArrayInstances3 extends ArrayInstances2 {
-  implicit def ArrayNormedVectorSpace[@spec(Float, Double) A: Field: NRoot: ClassTag]: NormedVectorSpace[Array[A], A] =
+  implicit def ArrayNormedVectorSpace[@sp(Float, Double) A: Field: NRoot: ClassTag]: NormedVectorSpace[Array[A], A] =
     ArrayInnerProductSpace[A].normed
 }
 
 trait ArrayInstances extends ArrayInstances3 {
-  implicit def ArrayMonoid[@spec A: ClassTag]: Monoid[Array[A]] =
+  implicit def ArrayMonoid[@sp A: ClassTag]: Monoid[Array[A]] =
     new ArrayMonoid[A]
 }
 
 @SerialVersionUID(0L)
-private final class ArrayModule[@spec(Int,Long,Float,Double) A: ClassTag: Ring]
+private final class ArrayModule[@sp(Int,Long,Float,Double) A: ClassTag: Ring]
     (implicit nvs: NoImplicit[VectorSpace[Array[A], A]])
     extends Module[Array[A], A] with Serializable {
   def scalar: Ring[A] = Ring[A]
@@ -159,7 +159,7 @@ private final class ArrayModule[@spec(Int,Long,Float,Double) A: ClassTag: Ring]
 }
 
 @SerialVersionUID(0L)
-private final class ArrayVectorSpace[@spec(Int,Float,Long,Double) A: ClassTag: Field]
+private final class ArrayVectorSpace[@sp(Int,Float,Long,Double) A: ClassTag: Field]
     (implicit nnvs: NoImplicit[NormedVectorSpace[Array[A], A]])
     extends VectorSpace[Array[A], A] with Serializable {
   def scalar: Field[A] = Field[A]
@@ -171,13 +171,13 @@ private final class ArrayVectorSpace[@spec(Int,Float,Long,Double) A: ClassTag: F
 }
 
 @SerialVersionUID(0L)
-private final class ArrayEq[@spec(Int,Float,Long,Double) A: Eq]
+private final class ArrayEq[@sp(Int,Float,Long,Double) A: Eq]
     extends Eq[Array[A]] with Serializable {
   def eqv(x: Array[A], y: Array[A]): Boolean = ArraySupport.eqv(x, y)
 }
 
 @SerialVersionUID(0L)
-private final class ArrayInnerProductSpace[@spec(Int,Float,Long,Double) A: ClassTag: Field]
+private final class ArrayInnerProductSpace[@sp(Int,Float,Long,Double) A: ClassTag: Field]
     extends InnerProductSpace[Array[A], A] with Serializable {
   def scalar: Field[A] = Field[A]
   def zero: Array[A] = new Array[A](0)
@@ -189,21 +189,21 @@ private final class ArrayInnerProductSpace[@spec(Int,Float,Long,Double) A: Class
 }
 
 @SerialVersionUID(0L)
-private final class ArrayOrder[@spec(Int,Float,Long,Double) A: Order]
+private final class ArrayOrder[@sp(Int,Float,Long,Double) A: Order]
     extends Order[Array[A]] with Serializable {
   override def eqv(x: Array[A], y: Array[A]): Boolean = ArraySupport.eqv(x, y)
   def compare(x: Array[A], y: Array[A]): Int = ArraySupport.compare(x, y)
 }
 
 @SerialVersionUID(0L)
-private final class ArrayMonoid[@spec(Int,Float,Long,Double) A: ClassTag]
+private final class ArrayMonoid[@sp(Int,Float,Long,Double) A: ClassTag]
     extends Monoid[Array[A]] with Serializable {
   def id: Array[A] = new Array[A](0)
   def op(x: Array[A], y: Array[A]): Array[A] = ArraySupport.concat(x, y)
 }
 
 @SerialVersionUID(0L)
-class ArrayCoordinateSpace[@spec(Int,Long,Float,Double) A: ClassTag](final val dimensions: Int)(implicit val scalar: Field[A])
+class ArrayCoordinateSpace[@sp(Int,Long,Float,Double) A: ClassTag](final val dimensions: Int)(implicit val scalar: Field[A])
 extends CoordinateSpace[Array[A], A] with Serializable {
   def zero: Array[A] = new Array[A](0)
   def negate(x: Array[A]): Array[A] = ArraySupport.negate(x)
@@ -216,13 +216,13 @@ extends CoordinateSpace[Array[A], A] with Serializable {
 }
 
 @SerialVersionUID(0L)
-class ArrayVectorEq[@spec(Int,Long,Float,Double) A: Eq: AdditiveMonoid]
+class ArrayVectorEq[@sp(Int,Long,Float,Double) A: Eq: AdditiveMonoid]
 extends Eq[Array[A]] with Serializable {
   def eqv(x: Array[A], y: Array[A]): Boolean = ArraySupport.vectorEqv(x, y)
 }
 
 @SerialVersionUID(0L)
-class ArrayVectorOrder[@spec(Int,Long,Float,Double) A: Order: AdditiveMonoid]
+class ArrayVectorOrder[@sp(Int,Long,Float,Double) A: Order: AdditiveMonoid]
 extends Order[Array[A]] with Serializable {
   override def eqv(x: Array[A], y: Array[A]): Boolean = ArraySupport.vectorEqv(x, y)
 

--- a/core/shared/src/main/scala/spire/std/array.scala
+++ b/core/shared/src/main/scala/spire/std/array.scala
@@ -1,7 +1,6 @@
 package spire
 package std
 
-import scala.reflect.ClassTag
 
 import spire.algebra._
 import spire.NoImplicit

--- a/core/shared/src/main/scala/spire/std/array.scala
+++ b/core/shared/src/main/scala/spire/std/array.scala
@@ -1,6 +1,6 @@
-package spire.std
+package spire
+package std
 
-import scala.{ specialized => spec }
 import scala.reflect.ClassTag
 
 import spire.algebra._

--- a/core/shared/src/main/scala/spire/std/bigDecimal.scala
+++ b/core/shared/src/main/scala/spire/std/bigDecimal.scala
@@ -1,9 +1,9 @@
-package spire.std
+package spire
+package std
 
 import java.lang.Math
 import java.math.MathContext
 
-import scala.annotation.tailrec
 
 import BigDecimal.RoundingMode.{CEILING, FLOOR, HALF_UP}
 

--- a/core/shared/src/main/scala/spire/std/bigInt.scala
+++ b/core/shared/src/main/scala/spire/std/bigInt.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{EuclideanRing, IsIntegral, MetricSpace, NRoot, Order, Signed}
 

--- a/core/shared/src/main/scala/spire/std/bigInteger.scala
+++ b/core/shared/src/main/scala/spire/std/bigInteger.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import java.math.BigInteger
 

--- a/core/shared/src/main/scala/spire/std/boolean.scala
+++ b/core/shared/src/main/scala/spire/std/boolean.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{Bool, CRig, Eq, Order}
 

--- a/core/shared/src/main/scala/spire/std/byte.scala
+++ b/core/shared/src/main/scala/spire/std/byte.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{EuclideanRing, IsIntegral, NRoot, Order, Signed}
 import spire.math.BitString

--- a/core/shared/src/main/scala/spire/std/char.scala
+++ b/core/shared/src/main/scala/spire/std/char.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.Order
 

--- a/core/shared/src/main/scala/spire/std/double.scala
+++ b/core/shared/src/main/scala/spire/std/double.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{Field, IsRational, NRoot, Order, Signed, Trig}
 import spire.math.Rational
@@ -7,7 +8,6 @@ import java.lang.Math
 import java.lang.Long.{ numberOfTrailingZeros, numberOfLeadingZeros }
 import java.lang.Double.{ longBitsToDouble, doubleToLongBits }
 
-import scala.annotation.tailrec
 
 trait DoubleIsField extends Field[Double] {
   override def minus(a:Double, b:Double): Double = a - b

--- a/core/shared/src/main/scala/spire/std/float.scala
+++ b/core/shared/src/main/scala/spire/std/float.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{Field, IsRational, NRoot, Order, Signed, Trig}
 import spire.math.Rational
@@ -7,7 +8,6 @@ import java.lang.Math
 import java.lang.Integer.{ numberOfTrailingZeros, numberOfLeadingZeros }
 import java.lang.Float.{ intBitsToFloat, floatToIntBits }
 
-import scala.annotation.tailrec
 
 trait FloatIsField extends Field[Float] {
   override def minus(a:Float, b:Float): Float = a - b

--- a/core/shared/src/main/scala/spire/std/int.scala
+++ b/core/shared/src/main/scala/spire/std/int.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{EuclideanRing, IsIntegral, NRoot, Order, Signed}
 import spire.math.BitString

--- a/core/shared/src/main/scala/spire/std/iterable.scala
+++ b/core/shared/src/main/scala/spire/std/iterable.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom

--- a/core/shared/src/main/scala/spire/std/long.scala
+++ b/core/shared/src/main/scala/spire/std/long.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{EuclideanRing, IsIntegral, NRoot, Order, Signed}
 import spire.math.BitString

--- a/core/shared/src/main/scala/spire/std/map.scala
+++ b/core/shared/src/main/scala/spire/std/map.scala
@@ -1,9 +1,7 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra._
-
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 
 @SerialVersionUID(0L)
 class MapMonoid[K, V](implicit val scalar: Semigroup[V]) extends Monoid[Map[K, V]]

--- a/core/shared/src/main/scala/spire/std/option.scala
+++ b/core/shared/src/main/scala/spire/std/option.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra._
 import spire.algebra.{AdditiveSemigroup, AdditiveMonoid, MultiplicativeMonoid, MultiplicativeSemigroup}

--- a/core/shared/src/main/scala/spire/std/seq.scala
+++ b/core/shared/src/main/scala/spire/std/seq.scala
@@ -1,6 +1,6 @@
-package spire.std
+package spire
+package std
 
-import scala.annotation.tailrec
 import scala.collection.SeqLike
 import scala.collection.mutable.Builder
 import scala.collection.generic.CanBuildFrom

--- a/core/shared/src/main/scala/spire/std/short.scala
+++ b/core/shared/src/main/scala/spire/std/short.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{EuclideanRing, IsIntegral, NRoot, Order, Signed}
 import spire.math.BitString

--- a/core/shared/src/main/scala/spire/std/string.scala
+++ b/core/shared/src/main/scala/spire/std/string.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{MetricSpace, Monoid, Order}
 

--- a/core/shared/src/main/scala/spire/std/unit.scala
+++ b/core/shared/src/main/scala/spire/std/unit.scala
@@ -1,4 +1,5 @@
-package spire.std
+package spire
+package std
 
 import spire.algebra.{AbGroup, Order}
 

--- a/core/shared/src/main/scala/spire/syntax/Literals.scala
+++ b/core/shared/src/main/scala/spire/syntax/Literals.scala
@@ -1,8 +1,8 @@
-package spire.syntax
+package spire
+package syntax
 
 import spire.algebra.{Field, Ring}
 
-import scala.{specialized => spec}
 
 import spire.math.{Polynomial, Rational, UByte, UShort, UInt, ULong}
 import spire.macros.Macros

--- a/core/shared/src/main/scala/spire/syntax/Ops.scala
+++ b/core/shared/src/main/scala/spire/syntax/Ops.scala
@@ -1,4 +1,5 @@
-package spire.syntax
+package spire
+package syntax
 
 import spire.algebra._
 import spire.algebra.lattice._

--- a/core/shared/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/shared/src/main/scala/spire/syntax/Syntax.scala
@@ -1,4 +1,5 @@
-package spire.syntax
+package spire
+package syntax
 
 import spire.NoImplicit
 import spire.algebra._

--- a/core/shared/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/shared/src/main/scala/spire/syntax/std/Ops.scala
@@ -1,10 +1,10 @@
-package spire.syntax.std
+package spire
+package syntax
+package std
 
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
-import scala.{specialized => sp}
-
 import spire.algebra.{AdditiveMonoid, Field, Monoid, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}
 import spire.syntax.cfor._

--- a/core/shared/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/shared/src/main/scala/spire/syntax/std/Ops.scala
@@ -4,7 +4,6 @@ package std
 
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
 import spire.algebra.{AdditiveMonoid, Field, Monoid, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}
 import spire.syntax.cfor._

--- a/core/shared/src/main/scala/spire/syntax/std/Syntax.scala
+++ b/core/shared/src/main/scala/spire/syntax/std/Syntax.scala
@@ -22,11 +22,11 @@ trait BigIntSyntax {
 }
 
 trait ArraySyntax {
-  implicit def arrayOps[@spec A](lhs:Array[A]): ArrayOps[A] = new ArrayOps(lhs)
+  implicit def arrayOps[@sp A](lhs:Array[A]): ArrayOps[A] = new ArrayOps(lhs)
 }
 
 trait SeqSyntax {
-  implicit def seqOps[@spec A, CC[A] <: Iterable[A]](lhs:CC[A]): SeqOps[A, CC] = new SeqOps[A, CC](lhs)
-  implicit def indexedSeqOps[@spec A, CC[A] <: IndexedSeq[A]](lhs:CC[A]): IndexedSeqOps[A, CC] = new IndexedSeqOps[A, CC](lhs)
+  implicit def seqOps[@sp A, CC[A] <: Iterable[A]](lhs:CC[A]): SeqOps[A, CC] = new SeqOps[A, CC](lhs)
+  implicit def indexedSeqOps[@sp A, CC[A] <: IndexedSeq[A]](lhs:CC[A]): IndexedSeqOps[A, CC] = new IndexedSeqOps[A, CC](lhs)
 }
 

--- a/core/shared/src/main/scala/spire/syntax/std/Syntax.scala
+++ b/core/shared/src/main/scala/spire/syntax/std/Syntax.scala
@@ -1,7 +1,8 @@
-package spire.syntax.std
+package spire
+package syntax
+package std
 
 import spire.math.ConvertableTo
-import scala.{specialized => spec}
 
 trait IntSyntax {
   implicit def literalIntOps(n: Int): LiteralIntOps = new LiteralIntOps(n)

--- a/core/shared/src/main/scala/spire/util/Opt.scala
+++ b/core/shared/src/main/scala/spire/util/Opt.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 import spire.algebra.Eq
 import spire.syntax.eq._

--- a/core/shared/src/main/scala/spire/util/Pack.scala
+++ b/core/shared/src/main/scala/spire/util/Pack.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 import java.nio.ByteBuffer
 import scala.language.experimental.macros

--- a/core/shared/src/main/scala_2.10/spire/util/OptVersions.scala
+++ b/core/shared/src/main/scala_2.10/spire/util/OptVersions.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 trait OptVersions {
   def unapply[A](n: Opt[A]): Option[A] = n.toOption

--- a/core/shared/src/main/scala_2.11/spire/util/OptVersions.scala
+++ b/core/shared/src/main/scala_2.11/spire/util/OptVersions.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 trait OptVersions {
   // name-based extractor, cf. http://hseeberger.github.io/blog/2013/10/04/name-based-extractors-in-scala-2-dot-11/

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -1,11 +1,10 @@
-package spire.example
+package spire
+package example
 
 import spire.algebra._
 import spire.math.Rational
 import spire.implicits._
 
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 import scala.collection.IterableLike
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.{ Builder, ListBuffer }

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -13,7 +13,7 @@ import java.io.{ BufferedReader, InputStreamReader }
 
 import scala.util.Random.shuffle
 
-final class DataSet[V, @spec(Double) F, @spec(Double) K](
+final class DataSet[V, @sp(Double) F, @sp(Double) K](
     val name: String,
     val variables: List[Variable[F]],
     val space: CoordinateSpace[V, F],
@@ -81,7 +81,7 @@ object DataSet {
     (dimensions, datar.reverse)
   }
 
-  def fromResource[CC[_], @spec(Double) F, @spec(Double) K](name: String, res: String, sep: Char,
+  def fromResource[CC[_], @sp(Double) F, @sp(Double) K](name: String, res: String, sep: Char,
       variables: List[Variable[F]], out: Output[K])(
       cs: Int => CoordinateSpace[CC[F], F])(implicit
       cbf: CanBuildFrom[Nothing, F, CC[F]]): DataSet[CC[F], F, K] = {
@@ -218,7 +218,7 @@ object CrossValidation {
    * Generic cross-validator that can be provided an arbitrary method to score
    * predictor results.
    */
-  def crossValidate[V, @spec(Double) F, K](dataset: DataSet[V, F, K], k: Int = 10)(
+  def crossValidate[V, @sp(Double) F, K](dataset: DataSet[V, F, K], k: Int = 10)(
       train: CoordinateSpace[V, F] => List[(V, K)] => (V => K))(
       score: List[Result[V, K]] => F): F = {
     implicit val field = dataset.space.scalar
@@ -245,7 +245,7 @@ object CrossValidation {
    * For cross-validating classification, we use the accuracy to score the
    * predictor.
    */
-  def crossValidateClassification[V, @spec(Double) F, K](dataset: DataSet[V, F, K], k: Int = 10)(
+  def crossValidateClassification[V, @sp(Double) F, K](dataset: DataSet[V, F, K], k: Int = 10)(
       train: CoordinateSpace[V, F] => List[(V, K)] => (V => K)): F = {
     implicit val field = dataset.space.scalar
 
@@ -261,7 +261,7 @@ object CrossValidation {
   /**
    * For cross-validating regression, we use the R^2 to score the predictor.
    */
-  def crossValidateRegression[V, @spec(Double) F](dataset: DataSet[V, F, F], k: Int = 10)(
+  def crossValidateRegression[V, @sp(Double) F](dataset: DataSet[V, F, F], k: Int = 10)(
       train: CoordinateSpace[V, F] => List[(V, F)] => (V => F)): F = {
     implicit val field = dataset.space.scalar
 

--- a/examples/src/main/scala/spire/example/autoalgebra.scala
+++ b/examples/src/main/scala/spire/example/autoalgebra.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import org.apfloat._
 import org.jscience.mathematics.number.{ Rational => JRational }

--- a/examples/src/main/scala/spire/example/bigtrig.scala
+++ b/examples/src/main/scala/spire/example/bigtrig.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import spire.implicits._
 

--- a/examples/src/main/scala/spire/example/endoring.scala
+++ b/examples/src/main/scala/spire/example/endoring.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import language.implicitConversions
 

--- a/examples/src/main/scala/spire/example/finitefield.scala
+++ b/examples/src/main/scala/spire/example/finitefield.scala
@@ -1,4 +1,5 @@
-// package spire.example
+// package spire
+package example
 //
 // import shapeless.{ Field => _, _ }
 // import spire.algebra._

--- a/examples/src/main/scala/spire/example/graphing.scala
+++ b/examples/src/main/scala/spire/example/graphing.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import spire.implicits._
 import spire.math._

--- a/examples/src/main/scala/spire/example/infset.scala
+++ b/examples/src/main/scala/spire/example/infset.scala
@@ -1,4 +1,5 @@
-package spire.examples
+package spire
+package examples
 
 import spire.algebra._
 import spire.math.{Natural, UInt}

--- a/examples/src/main/scala/spire/example/kleene.scala
+++ b/examples/src/main/scala/spire/example/kleene.scala
@@ -7,7 +7,6 @@ import spire.algebra._
 import spire.std.BooleanIsRig
 import spire.implicits._
 
-import scala.reflect.ClassTag
 
 /**
  * These examples are taken from http://r6.ca/blog/20110808T035622Z.html.

--- a/examples/src/main/scala/spire/example/kleene.scala
+++ b/examples/src/main/scala/spire/example/kleene.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import Predef.{any2stringadd => _, intWrapper => _, _}
 
@@ -7,7 +8,6 @@ import spire.std.BooleanIsRig
 import spire.implicits._
 
 import scala.reflect.ClassTag
-import scala.annotation.tailrec
 
 /**
  * These examples are taken from http://r6.ca/blog/20110808T035622Z.html.

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -5,7 +5,6 @@ import spire.algebra._
 import spire.implicits._
 
 import scala.collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
 import scala.util.Random.{ nextInt, nextDouble, nextGaussian }
 
 /**

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -1,13 +1,12 @@
-package spire.example
+package spire
+package example
 
 import spire.algebra._
 import spire.implicits._
 
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
-import scala.{ specialized => spec }
 import scala.util.Random.{ nextInt, nextDouble, nextGaussian }
-import scala.annotation.tailrec
 
 /**
  * An example using `NormedVectorSpace`s to create a generic k-Means

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -20,7 +20,7 @@ object KMeansExample extends App {
    * Returns a collection of k points which are the centers of k clusters of
    * `points0`.
    */
-  def kMeans[V, @spec(Double) A, CC[V] <: Iterable[V]](points0: CC[V], k: Int)(implicit
+  def kMeans[V, @sp(Double) A, CC[V] <: Iterable[V]](points0: CC[V], k: Int)(implicit
       vs: NormedVectorSpace[V, A], order: Order[A],
       cbf: CanBuildFrom[Nothing, V, CC[V]], ct: ClassTag[V]): CC[V] = {
 
@@ -92,7 +92,7 @@ object KMeansExample extends App {
   // This method let's us generate a set of n points which are clustered around
   // k centers in d-dimensions.
 
-  def genPoints[CC[_], V, @spec(Double) A](d: Int, k: Int, n: Int)(f: Array[Double] => V)(implicit
+  def genPoints[CC[_], V, @sp(Double) A](d: Int, k: Int, n: Int)(f: Array[Double] => V)(implicit
       vs: VectorSpace[V, A], cbf: CanBuildFrom[Nothing, V, CC[V]]): CC[V] = {
 
     def randPoint(gen: => Double): V = f((1 to d).map(_ => gen)(collection.breakOut))

--- a/examples/src/main/scala/spire/example/loops.scala
+++ b/examples/src/main/scala/spire/example/loops.scala
@@ -1,7 +1,7 @@
-package spire.example
+package spire
+package example
 
 import spire.implicits._
-import scala.annotation.tailrec
 
 class Loops {
   def nested(): Unit = {

--- a/examples/src/main/scala/spire/example/mandelbrot.scala
+++ b/examples/src/main/scala/spire/example/mandelbrot.scala
@@ -1,9 +1,9 @@
-package spire.example
+package spire
+package example
 
 import spire.implicits._
 import spire.math._
 
-import scala.annotation.tailrec
 
 object MandelbrotDemo {
   /**

--- a/examples/src/main/scala/spire/example/operators.scala
+++ b/examples/src/main/scala/spire/example/operators.scala
@@ -1,4 +1,5 @@
-package spire.example
+package spire
+package example
 
 import language.implicitConversions
 

--- a/examples/src/main/scala/spire/example/randomforest.scala
+++ b/examples/src/main/scala/spire/example/randomforest.scala
@@ -30,7 +30,7 @@ object RandomForestExample extends App {
   testRegression[Array[Double], Double](DataSet.MPG, RandomForestOptions(numPointsSample = Some(200), numTrees = Some(50)))
 
 
-  def testClassification[V, @spec(Double) F, K](dataset: DataSet[V, F, K], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagK: ClassTag[K], real: IsReal[F]): Unit = {
+  def testClassification[V, @sp(Double) F, K](dataset: DataSet[V, F, K], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagK: ClassTag[K], real: IsReal[F]): Unit = {
 
     println(s"\n${dataset.describe}\n")
     println(s"Cross-validating ${dataset.name} with random forest classification...")
@@ -40,7 +40,7 @@ object RandomForestExample extends App {
     println("... accuracy of %.2f%%\n" format (real.toDouble(accuracy) * 100))
   }
 
-  def testRegression[V, @spec(Double) F](dataset: DataSet[V, F, F], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagF: ClassTag[F], real: IsReal[F]): Unit = {
+  def testRegression[V, @sp(Double) F](dataset: DataSet[V, F, F], opts: RandomForestOptions)(implicit order: Order[F], classTagV: ClassTag[V], classTagF: ClassTag[F], real: IsReal[F]): Unit = {
 
     println(s"\n${dataset.describe}\n")
     println(s"Cross-validating ${dataset.name} with random forest regression...")
@@ -71,7 +71,7 @@ case class RandomForestOptions(
  * care about. We then have a way of determining the error of some subset of
  * these outputs using the `Region`.
  */
-trait RandomForest[V, @spec(Double) F, @spec(Double) K] {
+trait RandomForest[V, @sp(Double) F, @sp(Double) K] {
   implicit def V: CoordinateSpace[V, F]
   implicit def F: Field[F] = V.scalar
   implicit def order: Order[F]
@@ -262,7 +262,7 @@ trait RandomForest[V, @spec(Double) F, @spec(Double) K] {
  * final predicted output is the average of the individual tress output (which
  * itself is just the mean of all outputs in the region the point lands in.
  */
-class RandomForestRegression[V, @spec(Double) F](implicit val V: CoordinateSpace[V, F],
+class RandomForestRegression[V, @sp(Double) F](implicit val V: CoordinateSpace[V, F],
     val order: Order[F], val vectorClassTag: ClassTag[V]) extends RandomForest[V, F, F] {
 
   // Our "disparity" measure is just the squared error of the region.
@@ -304,7 +304,7 @@ class RandomForestRegression[V, @spec(Double) F](implicit val V: CoordinateSpace
  * Within a forest, each tree casts its vote for classification of a point and
  * the majority wins. Again, ties are broken randomly (again, not really).
  */
-class RandomForestClassification[V, @spec(Double) F, K](implicit val V: CoordinateSpace[V, F],
+class RandomForestClassification[V, @sp(Double) F, K](implicit val V: CoordinateSpace[V, F],
     val order: Order[F], val vectorClassTag: ClassTag[V]) extends RandomForest[V, F, K] {
 
   // Our "disparity" measure here is the Gini index. It basically measures how
@@ -345,38 +345,38 @@ class RandomForestClassification[V, @spec(Double) F, K](implicit val V: Coordina
 
 object RandomForest {
 
-  def regression[V, @spec(Double) F](data: Array[V], out: Array[F], options: RandomForestOptions)(implicit
+  def regression[V, @sp(Double) F](data: Array[V], out: Array[F], options: RandomForestOptions)(implicit
       V: CoordinateSpace[V, F], order: Order[F], ev: ClassTag[V]): V => F = {
     val rfr = new RandomForestRegression[V, F]
     rfr(data, out, options)
   }
 
-  def regression[V, @spec(Double) F](data: Iterable[V], out: Iterable[F],
+  def regression[V, @sp(Double) F](data: Iterable[V], out: Iterable[F],
       options: RandomForestOptions)(implicit V: CoordinateSpace[V, F], order: Order[F],
       classTagV: ClassTag[V], classTagF: ClassTag[F]): V => F = {
     regression(data.toArray, out.toArray, options)
   }
 
-  def regression[V, @spec(Double) F](data: Iterable[(V, F)], options: RandomForestOptions)(implicit
+  def regression[V, @sp(Double) F](data: Iterable[(V, F)], options: RandomForestOptions)(implicit
       V: CoordinateSpace[V, F], order: Order[F],
       classTagV: ClassTag[V], classTagF: ClassTag[F]): V => F = {
     val (in, out) = data.unzip
     regression(in.toArray, out.toArray, options)
   }
 
-  def classification[V, @spec(Double) F, K](data: Array[V], out: Array[K], options: RandomForestOptions)(implicit
+  def classification[V, @sp(Double) F, K](data: Array[V], out: Array[K], options: RandomForestOptions)(implicit
       V: CoordinateSpace[V, F], order: Order[F], ev: ClassTag[V]): V => K = {
     val rfc = new RandomForestClassification[V, F, K]
     rfc(data, out, options)
   }
 
-  def classification[V, @spec(Double) F, K](data: Iterable[V], out: Iterable[K],
+  def classification[V, @sp(Double) F, K](data: Iterable[V], out: Iterable[K],
       options: RandomForestOptions)(implicit V: CoordinateSpace[V, F],
       order: Order[F], classTagV: ClassTag[V], classTagK: ClassTag[K]): V => K = {
     classification(data.toArray, out.toArray, options)
   }
 
-  def classification[V, @spec(Double) F, K](data: Iterable[(V, K)], options: RandomForestOptions)(implicit
+  def classification[V, @sp(Double) F, K](data: Iterable[(V, K)], options: RandomForestOptions)(implicit
       V: CoordinateSpace[V, F], order: Order[F],
       classTagV: ClassTag[V], classTagK: ClassTag[K]): V => K = {
     val (in, out) = data.unzip

--- a/examples/src/main/scala/spire/example/randomforest.scala
+++ b/examples/src/main/scala/spire/example/randomforest.scala
@@ -6,7 +6,6 @@ import spire.implicits._
 
 import scala.util.Random.nextInt
 
-import scala.reflect.ClassTag
 
 import CrossValidation._
 

--- a/examples/src/main/scala/spire/example/randomforest.scala
+++ b/examples/src/main/scala/spire/example/randomforest.scala
@@ -1,10 +1,9 @@
-package spire.example
+package spire
+package example
 
 import spire.algebra._
 import spire.implicits._
 
-import scala.{ specialized => spec }
-import scala.annotation.tailrec
 import scala.util.Random.nextInt
 
 import scala.reflect.ClassTag

--- a/examples/src/main/scala/spire/example/simplification.scala
+++ b/examples/src/main/scala/spire/example/simplification.scala
@@ -1,9 +1,9 @@
-package spire.example
+package spire
+package example
 
 import spire.implicits._
 import spire.math._
 
-import scala.annotation.tailrec
 import scala.collection.IterableLike
 import scala.collection.mutable.{Builder, GrowingBuilder, MapBuilder}
 import scala.collection.generic.CanBuildFrom

--- a/extras/src/main/scala/spire/math/FixedPoint.scala
+++ b/extras/src/main/scala/spire/math/FixedPoint.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 //import spire.syntax.ring._
 import spire.std.long._
@@ -9,7 +10,7 @@ import spire.syntax.convertableFrom._
 import spire.algebra.{Order, Signed}
 
 import java.math.MathContext
-import scala.{specialized => spec}
+import spire.algebra.{Order, Signed}
 
 class FixedPointOverflow(n: Long) extends Exception(n.toString)
 

--- a/extras/src/main/scala/spire/math/FixedPoint.scala
+++ b/extras/src/main/scala/spire/math/FixedPoint.scala
@@ -7,8 +7,6 @@ import spire.syntax.order._
 import spire.syntax.euclideanRing._
 import spire.syntax.convertableFrom._
 
-import spire.algebra.{Order, Signed}
-
 import java.math.MathContext
 import spire.algebra.{Order, Signed}
 
@@ -285,7 +283,7 @@ object FixedPoint extends FixedPointInstances {
   def apply(s: String)(implicit scale: FixedScale): FixedPoint =
     apply(Rational(s))
 
-  def apply[@spec(Float, Double) A](a: A)(implicit scale: FixedScale, fr: Fractional[A]): FixedPoint = {
+  def apply[@sp(Float, Double) A](a: A)(implicit scale: FixedScale, fr: Fractional[A]): FixedPoint = {
     val x = a * scale.denom
     if (x < fr.fromLong(Long.MinValue) || fr.fromLong(Long.MaxValue) < x)
       throw new FixedPointOverflow(x.toLong)

--- a/laws/src/main/scala/spire/laws/ActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/ActionLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/BaseLaws.scala
+++ b/laws/src/main/scala/spire/laws/BaseLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/GroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/GroupLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/LatticeLaws.scala
+++ b/laws/src/main/scala/spire/laws/LatticeLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.algebra.lattice._

--- a/laws/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
+++ b/laws/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.algebra.lattice._

--- a/laws/src/main/scala/spire/laws/LogicLaws.scala
+++ b/laws/src/main/scala/spire/laws/LogicLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra.{Eq, Bool}
 import spire.algebra.lattice.Heyting

--- a/laws/src/main/scala/spire/laws/OrderLaws.scala
+++ b/laws/src/main/scala/spire/laws/OrderLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/PartialActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialActionLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.algebra.partial._

--- a/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.algebra.partial._

--- a/laws/src/main/scala/spire/laws/Perm.scala
+++ b/laws/src/main/scala/spire/laws/Perm.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 /**
  * Represents a permutation encoded as a map from preimages to images, including

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 import spire.implicits._

--- a/laws/src/main/scala/spire/laws/arb.scala
+++ b/laws/src/main/scala/spire/laws/arb.scala
@@ -1,8 +1,8 @@
-package spire.laws
+package spire
+package laws
 
 import java.math.BigInteger
 
-import scala.reflect.ClassTag
 
 import spire.algebra._
 import spire.algebra.free._

--- a/laws/src/main/scala/spire/laws/gen.scala
+++ b/laws/src/main/scala/spire/laws/gen.scala
@@ -1,8 +1,8 @@
-package spire.laws
+package spire
+package laws
 
 import java.math.BigInteger
 
-import scala.reflect.ClassTag
 
 import spire.algebra._
 import spire.algebra.free._

--- a/macros/src/main/scala/spire/macros/Checked.scala
+++ b/macros/src/main/scala/spire/macros/Checked.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 import scala.language.existentials
 import language.experimental.macros

--- a/macros/src/main/scala/spire/macros/Syntax.scala
+++ b/macros/src/main/scala/spire/macros/Syntax.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 import spire.macros.compat.{termName, freshTermName, resetLocalAttrs, Context, setOrig}
 

--- a/macros/src/main/scala_2.10/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.10/spire/macros/compat.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 object compat {
 

--- a/macros/src/main/scala_2.11/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.11/spire/macros/compat.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 object compat {
 

--- a/macros/src/test/scala/spire/macros/CheckedTest.scala
+++ b/macros/src/test/scala/spire/macros/CheckedTest.scala
@@ -1,4 +1,5 @@
-package spire.macros
+package spire
+package macros
 
 import org.scalatest.FunSuite
 import org.scalatest.Matchers

--- a/tests/src/test/scala/spire/algebra/GCDTest.scala
+++ b/tests/src/test/scala/spire/algebra/GCDTest.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 import spire.math.{ Rational, NumberTag }
 import spire.std.int._

--- a/tests/src/test/scala/spire/algebra/GCDTest.scala
+++ b/tests/src/test/scala/spire/algebra/GCDTest.scala
@@ -8,7 +8,6 @@ import spire.std.double._
 import spire.syntax.euclideanRing._
 import spire.syntax.isReal.{ eqOps => _, _ }
 
-import scala.reflect.ClassTag
 
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers

--- a/tests/src/test/scala/spire/algebra/NRootTest.scala
+++ b/tests/src/test/scala/spire/algebra/NRootTest.scala
@@ -1,11 +1,11 @@
-package spire.algebra
+package spire
+package algebra
 
 import java.math.BigInteger
 
 import spire.implicits._
 import org.scalatest.FunSuite
 
-import scala.reflect.ClassTag
 
 class NRootTest extends FunSuite {
   def testIntegralNRoot[A: Ring: NRoot: ClassTag]: Unit = {

--- a/tests/src/test/scala/spire/algebra/PartialOrderTest.scala
+++ b/tests/src/test/scala/spire/algebra/PartialOrderTest.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/algebra/RingTest.scala
+++ b/tests/src/test/scala/spire/algebra/RingTest.scala
@@ -1,7 +1,6 @@
 package spire
 package algebra
 
-import scala.reflect.ClassTag
 
 // scalatest
 import org.scalatest.FunSuite

--- a/tests/src/test/scala/spire/algebra/RingTest.scala
+++ b/tests/src/test/scala/spire/algebra/RingTest.scala
@@ -22,7 +22,7 @@ class RingTest extends FunSuite {
    *
    *   a=-3  b=3  c=-9
    */
-  def runWith[@spec A:Ring:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
+  def runWith[@sp A:Ring:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
 
     val m = implicitly[ClassTag[A]]
 

--- a/tests/src/test/scala/spire/algebra/RingTest.scala
+++ b/tests/src/test/scala/spire/algebra/RingTest.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 import scala.reflect.ClassTag
 
@@ -10,7 +11,6 @@ import spire.math.{Rational, Complex, Jet, JetDim}
 import spire.implicits.{eqOps => _, _}
 
 // nice alias
-import scala.{specialized => spec}
 
 import java.math.MathContext
 

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -16,7 +16,7 @@ import java.math.MathContext
 
 
 class SignedTest extends FunSuite {
-  def runWith[@spec(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A): Unit = {
+  def runWith[@sp(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A): Unit = {
     val m = implicitly[ClassTag[A]]
 
     //// the name to use for this A

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -1,7 +1,6 @@
 package spire
 package algebra
 
-import scala.reflect.ClassTag
 
 // scalatest
 import org.scalatest.FunSuite

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 import scala.reflect.ClassTag
 
@@ -10,7 +11,6 @@ import spire.math.{Rational, Algebraic, Complex}
 import spire.implicits.{eqOps => _, _}
 
 // nice alias
-import scala.{specialized => spec}
 
 import java.math.MathContext
 

--- a/tests/src/test/scala/spire/laws/ArbTest.scala
+++ b/tests/src/test/scala/spire/laws/ArbTest.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import scala.util.Random
 

--- a/tests/src/test/scala/spire/laws/D3.scala
+++ b/tests/src/test/scala/spire/laws/D3.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import spire.algebra._
 

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -1,4 +1,5 @@
-package spire.laws
+package spire
+package laws
 
 import java.math.BigInteger
 import spire.algebra._
@@ -14,8 +15,6 @@ import spire.implicits.{
   ArrayOrder => _, ArrayEq => _,
   MapEq => _, MapGroup => _,
   _ }
-
-import scala.{specialized => sp}
 
 import org.typelevel.discipline.scalatest.Discipline
 

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra.Sign
 import spire.tests.SpireProperties

--- a/tests/src/test/scala/spire/math/ArbitrarySupport.scala
+++ b/tests/src/test/scala/spire/math/ArbitrarySupport.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra._
 

--- a/tests/src/test/scala/spire/math/BitStringTest.scala
+++ b/tests/src/test/scala/spire/math/BitStringTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/ComplexCheck.scala
+++ b/tests/src/test/scala/spire/math/ComplexCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/ComplexTest.scala
+++ b/tests/src/test/scala/spire/math/ComplexTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 import spire.implicits.{eqOps => _, _}
@@ -88,7 +89,7 @@ class ComplexTest extends FunSuite {
     assert(Complex.rootsOfUnity[Double](2) === Array(one, -one))
     assert(Complex.rootsOfUnity[Double](4) === Array(one, i, -one, -i))
 
-    val theta = 2.0 * math.Pi / 3.0
+    val theta = 2.0 * scala.math.Pi / 3.0
     val c1 = math.cos(theta) + math.sin(theta) * i
     val c2 = -one - c1
     assert(Complex.rootsOfUnity[Double](3) === Array(one, c1, c2))

--- a/tests/src/test/scala/spire/math/CooperativeEqualityTest.scala
+++ b/tests/src/test/scala/spire/math/CooperativeEqualityTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/FixedPointCheck.scala
+++ b/tests/src/test/scala/spire/math/FixedPointCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.implicits._
 import spire.laws.arb.rational

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.math.ArbitrarySupport.{Positive, NonNegative}
 

--- a/tests/src/test/scala/spire/math/JetTest.scala
+++ b/tests/src/test/scala/spire/math/JetTest.scala
@@ -1,6 +1,7 @@
-package spire.math
+package spire
+package math
+
 import org.scalatest._
-import scala.{specialized => sp}
 import spire.algebra._
 import spire.implicits._
 

--- a/tests/src/test/scala/spire/math/LiteralsTest.scala
+++ b/tests/src/test/scala/spire/math/LiteralsTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/MergingCheck.scala
+++ b/tests/src/test/scala/spire/math/MergingCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import java.util.Arrays
 
@@ -6,7 +7,6 @@ import org.scalacheck.{Arbitrary, Properties}
 import org.scalacheck.Prop._
 import spire.implicits._
 
-import scala.reflect.ClassTag
 
 object BinaryMergeCheck extends Properties("QuickArrayMerge") {
 

--- a/tests/src/test/scala/spire/math/MergingTest.scala
+++ b/tests/src/test/scala/spire/math/MergingTest.scala
@@ -1,10 +1,10 @@
-package spire.math
+package spire
+package math
 
 import spire.implicits._
 import org.scalatest.FunSuite
 import spire.algebra.Order
 
-import scala.reflect.ClassTag
 
 class CountingOrder[T:Order] extends Order[T] {
   val wrapped = implicitly[Order[T]]

--- a/tests/src/test/scala/spire/math/NaturalTest.scala
+++ b/tests/src/test/scala/spire/math/NaturalTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/NumberTest.scala
+++ b/tests/src/test/scala/spire/math/NumberTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/NumericTest.scala
+++ b/tests/src/test/scala/spire/math/NumericTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import scala.reflect.ClassTag
 
@@ -11,7 +12,6 @@ import spire.implicits.{eqOps => _, _}
 import java.math.MathContext
 
 // nice alias
-import scala.{specialized => spec}
 
 class NumericTest extends FunSuite {
 

--- a/tests/src/test/scala/spire/math/NumericTest.scala
+++ b/tests/src/test/scala/spire/math/NumericTest.scala
@@ -1,7 +1,6 @@
 package spire
 package math
 
-import scala.reflect.ClassTag
 
 // scalatest
 import org.scalatest.FunSuite

--- a/tests/src/test/scala/spire/math/NumericTest.scala
+++ b/tests/src/test/scala/spire/math/NumericTest.scala
@@ -21,7 +21,7 @@ class NumericTest extends FunSuite {
    *
    *   a=-3  b=3  c=9
    */
-  def runWith[@spec A:Numeric:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
+  def runWith[@sp A:Numeric:ClassTag](cls:String)(a:A, b:A, c:A): Unit = {
 
     // the name to use for this A
     //val cls = implicitly[ClassTag[A]].erasure.getSimpleName

--- a/tests/src/test/scala/spire/math/PackageCheck.scala
+++ b/tests/src/test/scala/spire/math/PackageCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/PackageTest.scala
+++ b/tests/src/test/scala/spire/math/PackageTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/PolynomialSamplingCheck.scala
+++ b/tests/src/test/scala/spire/math/PolynomialSamplingCheck.scala
@@ -1,11 +1,11 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra._
 import spire.math.poly._
 import spire.std.bigDecimal._
 import spire.syntax.euclideanRing._
 
-import scala.reflect.ClassTag
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra._
 import spire.math.poly._
@@ -6,7 +7,6 @@ import spire.std.bigDecimal._
 import spire.syntax.literals._
 import spire.optional.rationalTrig._
 
-import scala.reflect.ClassTag
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/QuaternionCheck.scala
+++ b/tests/src/test/scala/spire/math/QuaternionCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.implicits._
 import spire.laws.arb.{quaternion, real}

--- a/tests/src/test/scala/spire/math/RationalCheck.scala
+++ b/tests/src/test/scala/spire/math/RationalCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/RealCheck.scala
+++ b/tests/src/test/scala/spire/math/RealCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.implicits._
 import spire.laws.arb.{rational, real}

--- a/tests/src/test/scala/spire/math/SafeLongCheck.scala
+++ b/tests/src/test/scala/spire/math/SafeLongCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import java.math.BigInteger
 

--- a/tests/src/test/scala/spire/math/SafeLongTest.scala
+++ b/tests/src/test/scala/spire/math/SafeLongTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 import spire.algebra._

--- a/tests/src/test/scala/spire/math/SearchTest.scala
+++ b/tests/src/test/scala/spire/math/SearchTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import spire.implicits._
 

--- a/tests/src/test/scala/spire/math/SelectionTest.scala
+++ b/tests/src/test/scala/spire/math/SelectionTest.scala
@@ -4,7 +4,6 @@ package math
 import spire.algebra._
 import spire.std.int._
 
-import scala.reflect.ClassTag
 
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers

--- a/tests/src/test/scala/spire/math/SelectionTest.scala
+++ b/tests/src/test/scala/spire/math/SelectionTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.prop.Checkers
 trait SelectTest extends FunSuite /* with Checkers */ {
   def selector: Select
 
-  final def select[@spec A: Order: ClassTag](data: Array[A], k: Int) =
+  final def select[@sp A: Order: ClassTag](data: Array[A], k: Int) =
     selector.select(data, k)
 
   def shuffle[A: ClassTag](as: Array[A]): Array[A] =

--- a/tests/src/test/scala/spire/math/SelectionTest.scala
+++ b/tests/src/test/scala/spire/math/SelectionTest.scala
@@ -1,9 +1,9 @@
-package spire.math
+package spire
+package math
 
 import spire.algebra._
 import spire.std.int._
 
-import scala.{specialized => spec}
 import scala.reflect.ClassTag
 
 import org.scalatest.FunSuite

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.FunSuite
 

--- a/tests/src/test/scala/spire/math/TrigTest.scala
+++ b/tests/src/test/scala/spire/math/TrigTest.scala
@@ -1,4 +1,5 @@
-package spire.algebra
+package spire
+package algebra
 
 import org.scalatest.FunSuite
 import spire.math._

--- a/tests/src/test/scala/spire/math/TrileanCheck.scala
+++ b/tests/src/test/scala/spire/math/TrileanCheck.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -1,6 +1,5 @@
+package spire
 package test.scala.spire.math
-
-import scala.reflect.ClassTag
 
 import spire.algebra._
 import spire.math._

--- a/tests/src/test/scala/spire/math/UnsignedTest.scala
+++ b/tests/src/test/scala/spire/math/UnsignedTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._

--- a/tests/src/test/scala/spire/math/fpf/FPFilterTest.scala
+++ b/tests/src/test/scala/spire/math/fpf/FPFilterTest.scala
@@ -1,4 +1,5 @@
-package spire.math
+package spire
+package math
 
 import java.math.MathContext.UNLIMITED
 

--- a/tests/src/test/scala/spire/math/prime/FactorHeapCheck.scala
+++ b/tests/src/test/scala/spire/math/prime/FactorHeapCheck.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.math.SafeLong
 

--- a/tests/src/test/scala/spire/math/prime/FactorsCheck.scala
+++ b/tests/src/test/scala/spire/math/prime/FactorsCheck.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.implicits._
 import spire.laws.arb.safeLong

--- a/tests/src/test/scala/spire/math/prime/PrimeTest.scala
+++ b/tests/src/test/scala/spire/math/prime/PrimeTest.scala
@@ -1,4 +1,5 @@
-package spire.math.prime
+package spire
+package math.prime
 
 import spire.implicits._
 

--- a/tests/src/test/scala/spire/random/GaussianTest.scala
+++ b/tests/src/test/scala/spire/random/GaussianTest.scala
@@ -1,8 +1,6 @@
 package spire
 package random
 
-import scala.reflect.ClassTag
-
 import spire.algebra._
 import spire.std.float._
 import spire.std.double._

--- a/tests/src/test/scala/spire/random/GaussianTest.scala
+++ b/tests/src/test/scala/spire/random/GaussianTest.scala
@@ -1,6 +1,6 @@
-package spire.random
+package spire
+package random
 
-import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
 import spire.algebra._

--- a/tests/src/test/scala/spire/random/GeneratorTest.scala
+++ b/tests/src/test/scala/spire/random/GeneratorTest.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 
 import spire.random.rng._
 

--- a/tests/src/test/scala/spire/random/SamplingTest.scala
+++ b/tests/src/test/scala/spire/random/SamplingTest.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 
 import org.scalatest.Matchers
 import org.scalatest._

--- a/tests/src/test/scala/spire/random/ShufflingTest.scala
+++ b/tests/src/test/scala/spire/random/ShufflingTest.scala
@@ -1,4 +1,5 @@
-package spire.random
+package spire
+package random
 
 import org.scalatest.Matchers
 import org.scalatest._

--- a/tests/src/test/scala/spire/syntax/CforTest.scala
+++ b/tests/src/test/scala/spire/syntax/CforTest.scala
@@ -1,4 +1,5 @@
-package spire.syntax
+package spire
+package syntax
 
 import scala.collection.mutable
 

--- a/tests/src/test/scala/spire/syntax/StrictEqTest.scala
+++ b/tests/src/test/scala/spire/syntax/StrictEqTest.scala
@@ -1,4 +1,5 @@
-package spire.syntax
+package spire
+package syntax
 
 import shapeless.test.illTyped
 import spire.tests.SpireProperties

--- a/tests/src/test/scala/spire/util/OptCheck.scala
+++ b/tests/src/test/scala/spire/util/OptCheck.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 import org.scalatest.FunSuite
 import spire.algebra.Eq

--- a/tests/src/test/scala/spire/util/PackCheck.scala
+++ b/tests/src/test/scala/spire/util/PackCheck.scala
@@ -1,4 +1,5 @@
-package spire.util
+package spire
+package util
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._


### PR DESCRIPTION
Allowing `@tailrec`, `@sp[ecialized]`, and `ClassTag` without importing/renaming them into every file.

All approaches were intrusive, so I chose the one which I thought easiest to adapt to future requirements. There's a spire package object containing the new aliases, and all the files which take advantage of them have their package declarations modified. I left the other package declarations as they were, but they can be made consistent with the others if desired.
