### PR TITLE
Add toReal/toAlgebraic to Rational.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Rational.scala
+++ b/core/shared/src/main/scala/spire/math/Rational.scala
@@ -57,6 +57,10 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
 
   def gcd(rhs: Rational): Rational
 
+  def toReal: Real = Real(this)
+
+  def toAlgebraic: Algebraic = Algebraic(this)
+
   def toBigDecimal(scale: Int, mode: RoundingMode): BigDecimal = {
     val n = new JBigDecimal(numerator.toBigInteger)
     val d = new JBigDecimal(denominator.toBigInteger)

--- a/tests/src/test/scala/spire/math/RationalCheck.scala
+++ b/tests/src/test/scala/spire/math/RationalCheck.scala
@@ -58,6 +58,14 @@ class RationalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
 
   rat3("(x + y) * z == x * z + y * z") { (x: Q, y: Q, z: Q) => (x + y) * z shouldBe x * z + y * z }
 
+  rat1("Round-trip to Real") { (x: Q) =>
+    x.toReal.toRational shouldBe x
+  }
+
+  rat1("Round-trip to Algebraic") { (x: Q) =>
+    x.toAlgebraic.toRational shouldBe Some(x)
+  }
+
   property("Round-trip Double") {
     forAll("x") { (n: Double) =>
       Rational(n).toDouble == n


### PR DESCRIPTION
This just adds a couple of convenience methods to `Rational` to convert to `Real` & `Algebraic` types. Since these are lossless conversions provided by the types themselves, I wasn't really sure if it was worth testing them or anything.