### PR TITLE
Restrict accessibility of PositiveInt's constructor.

### DIFF
--- a/macros/src/main/scala/spire/macros/PositiveInt.scala
+++ b/macros/src/main/scala/spire/macros/PositiveInt.scala
@@ -11,7 +11,7 @@ import spire.macros.compat.Context
  * technology requires it to remain public. Instead, you should
  * construct instances via the PositiveInt(_) factory constructor.
  */
-class PositiveInt(val value: Int) extends AnyVal {
+class PositiveInt private [spire] (val value: Int) extends AnyVal {
   override def toString: String = value.toString
 }
 


### PR DESCRIPTION
I had been thinking that this PR was fully complete, and that it was simply waiting to be merged. But I was wrong - my mistake for not following through.

But, then I saw these comments https://github.com/non/spire/commit/65f0d4192ab947ae3600bcf3f82798afe65ded57#commitcomment-13447188 and https://github.com/non/spire/pull/520#issuecomment-143431888 to add the `private [spire]` modifier.

As a result of this change, my understanding is that clients/users  of `non/spire` won't be able to use `new PositiveInt` due to the `private [spire]` modifier - which is an improvement. But, any `com.spire` class will be able to bypass the safe constructor, `PositiveInt#apply`, as I understand. 

However, is it possible and worthwhile to add a warning when invoking `new PositiveInt` from **outside of** the `PostiveInt.scala` class? In other words, suppress warnings when calling it from the macro, but warn otherwise.
