### PR TITLE
Deprecate SecureJava.fromBytes

### DIFF
--- a/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
+++ b/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
@@ -19,6 +19,8 @@ class SecureJava(rand: SecureRandom) extends IntBasedGenerator {
 }
 
 object SecureJava {
+
+  @deprecated("seed is ignored except on windows. will be removed before 1.0", "0.12.0")
   def fromBytes(bytes: Array[Byte]): SecureJava =
     new SecureJava(new SecureRandom(bytes))
 


### PR DESCRIPTION
This would have to be removed completely in one of the next releases. Related to #547 , but not a fix yet.

Review by @non or @tixxit