### PR TITLE
Added scaladoc badges for all subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ cases, generic implementations using Spire's specialized type classes perform
 identically to corresponding direct implementations.
 
 ### Scaladoc
-[![Core](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11.svg?label=core)](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11)
+[![Core](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11.svg?label=core)](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11/index.html#spire.package)
 [![Extras](http://javadoc-badge.appspot.com/org.spire-math/spire-extras_2.11.svg?label=extras)](http://javadoc-badge.appspot.com/org.spire-math/spire-extras_2.11)
-[![Laws](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11.svg?label=laws)](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11)
-[![Macros](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11.svg?label=macros)](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11)
+[![Laws](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11.svg?label=laws)](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11/index.html#spire.laws.package)
+[![Macros](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11.svg?label=macros)](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11/index.html#spire.macros.package)
 
 Spire is provided to you as free software under the
 [MIT license](COPYING).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Build Status](https://api.travis-ci.org/non/spire.png)](https://travis-ci.org/non/spire/)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/non/spire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov.io](http://codecov.io/github/non/spire/coverage.svg?branch=master)](http://codecov.io/github/non/spire?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spire-math/spire_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spire-math/spire_2.11)
+
 ## Spire
 
 ### Overview
@@ -12,10 +17,11 @@ code without having to "bake in" particular numeric representations. In most
 cases, generic implementations using Spire's specialized type classes perform
 identically to corresponding direct implementations.
 
-[![Build Status](https://api.travis-ci.org/non/spire.png)](https://travis-ci.org/non/spire/)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/non/spire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![codecov.io](http://codecov.io/github/non/spire/coverage.svg?branch=master)](http://codecov.io/github/non/spire?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spire-math/spire_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spire-math/spire_2.11)
+### Scaladoc
+[![Core](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11.svg?label=core)](http://javadoc-badge.appspot.com/org.spire-math/spire_2.11)
+[![Extras](http://javadoc-badge.appspot.com/org.spire-math/spire-extras_2.11.svg?label=extras)](http://javadoc-badge.appspot.com/org.spire-math/spire-extras_2.11)
+[![Laws](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11.svg?label=laws)](http://javadoc-badge.appspot.com/org.spire-math/spire-laws_2.11)
+[![Macros](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11.svg?label=macros)](http://javadoc-badge.appspot.com/org.spire-math/spire-macros_2.11)
 
 Spire is provided to you as free software under the
 [MIT license](COPYING).


### PR DESCRIPTION
Added scaladoc badges for all subpackages. Also moved the normal badges to the top. This seems to be a common convention.

The pages you start up with when clicking on one of the doc badges are a bit blank. @xuwei-k is there a way to specify a start page? Do we *have* a good start page, at least for the core package?

In any case, I think having the docs linked from the README.md is an improvement. So @non @tixxit @denisrosset should I just merge this?