### PR TITLE
Polynomial[BigDecimal].gcd was blowing up the heap

### DIFF
--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -490,8 +490,13 @@ with EuclideanRing[Polynomial[C]] with VectorSpace[Polynomial[C], C] {
   override def quotmod(x: Polynomial[C], y: Polynomial[C]): (Polynomial[C], Polynomial[C]) = x /% y
 
   final def gcd(x: Polynomial[C], y: Polynomial[C]): Polynomial[C] = {
-    val k = spire.math.gcd(x.coeffsArray ++ y.coeffsArray)
-    k *: euclid(x :/ k, y :/ k)(Polynomial.eq).monic
+    val result = euclid(x, y)(Polynomial.eq)
+    if (result.degree > 0) {
+      result
+    } else {
+      // return the gcd of all coefficients when there is no higher degree divisor
+      Polynomial.constant(spire.math.gcd(x.coeffsArray ++ y.coeffsArray))
+    }
   }
 }
 

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -348,4 +348,12 @@ class PolynomialTest extends FunSuite {
     assert(spire.math.gcd(2 *: a, Polynomial("2")) == 2)
     assert(spire.math.gcd(2 *: a, 2 *: b) == 2)
   }
+
+  test("GCD doesn't run out of memory for BigDecimals") {
+    val a = Polynomial.linear(BigDecimal(2))
+    val b = Polynomial.constant(BigDecimal(3.4))
+    val c = (a + b) * (a + b) // (4x² + 13.6x + 11.56)
+    assert(spire.math.gcd(a, c) === 0.02)
+    assert(spire.math.gcd(a + b, c) === a + b)
+  }
 }


### PR DESCRIPTION
Includes a regression test and the fix.
Rescaling should only happen when there's no non-trivial divisor anyway.