### PR TITLE
fix infinite recursion on Integral[Int] methods

### DIFF
--- a/core/shared/src/main/scala/spire/math/Integral.scala
+++ b/core/shared/src/main/scala/spire/math/Integral.scala
@@ -39,7 +39,7 @@ with ConvertableFromInt with ConvertableToInt with IntIsReal with Serializable {
   override def toRational(n: Int): Rational = super[IntIsReal].toRational(n)
   override def toAlgebraic(n: Int): Algebraic = super[IntIsReal].toAlgebraic(n)
   override def toReal(n: Int): Real = super[IntIsReal].toReal(n)
-  override def toBigInt(n: Int): BigInt = super[IntIsReal].toBigInt(n)
+  override def toBigInt(n: Int): BigInt = BigInt(n)
 }
 
 @SerialVersionUID(0L)


### PR DESCRIPTION
solves infinite recursion for methods .factor, .isPrime, and .toSafeLong over Ints
(solves #574)