### PR TITLE
Overlap operation for Intervals

### DIFF
--- a/core/shared/src/main/scala/spire/math/Interval.scala
+++ b/core/shared/src/main/scala/spire/math/Interval.scala
@@ -7,7 +7,6 @@ import spire.algebra._
 import spire.math.poly.Term
 import spire.math.interval._
 import spire.math.interval.Bound._
-import spire.math.interval.Overlap._
 import spire.syntax.field._
 import spire.syntax.nroot._
 import spire.syntax.order._
@@ -789,29 +788,7 @@ sealed abstract class Interval[A](implicit order: Order[A]) extends Serializable
     * a.overlap(b)
     * }
     */
-  def overlap(rhs: Interval[A]): Overlap[A] = {
-
-    def lessAndOverlaps(intersectionLowerBound: Bound[A]): Overlap[A] =
-      if (lhs.lowerBound === intersectionLowerBound) PartialOverlap(lhs, rhs) else PartialOverlap(rhs, lhs)
-
-    if (lhs === rhs) {
-      Equal()
-    } else {
-      (lhs, rhs) match {
-        case (sub, sup) if sup.isSupersetOf(sub) => Subset(sub, sup)
-        case (sup, sub) if sup.isSupersetOf(sub) => Subset(sub, sup)
-        // only possible cases left are disjoint (empty intersection) or partial overlap
-        case _ => lhs.intersect(rhs) match {
-          case i: Bounded[A] => lessAndOverlaps(i.lowerBound)
-          case i: Point[A] => lessAndOverlaps(i.lowerBound)
-          case Empty() =>
-            if (Interval.fromBounds(lhs.lowerBound, rhs.upperBound).isEmpty) Disjoint(rhs, lhs)
-            else Disjoint(lhs, rhs)
-          case _ => throw new Exception("impossible")
-        }
-      }
-    }
-  }
+  def overlap(rhs: Interval[A]): Overlap[A] = Overlap(lhs, rhs)
 }
 
 case class All[A: Order] private[spire] () extends Interval[A] {

--- a/core/shared/src/main/scala/spire/math/Interval.scala
+++ b/core/shared/src/main/scala/spire/math/Interval.scala
@@ -788,8 +788,8 @@ sealed abstract class Interval[A](implicit order: Order[A]) extends Serializable
     */
   def overlap(rhs: Interval[A]): Overlap[A] = {
 
-    def lessAndOverlaps(intersectionLowerBound: A): Overlap[A] =
-      if (lhs.hasBelow(intersectionLowerBound)) LessAndOverlaps(lhs, rhs) else LessAndOverlaps(rhs, lhs)
+    def lessAndOverlaps(intersectionLowerBound: Bound[A]): Overlap[A] =
+      if (lhs.lowerBound === intersectionLowerBound) LessAndOverlaps(lhs, rhs) else LessAndOverlaps(rhs, lhs)
 
     if (lhs === rhs) {
       Equals(lhs, rhs)
@@ -799,8 +799,8 @@ sealed abstract class Interval[A](implicit order: Order[A]) extends Serializable
         case (sup, sub) if sup.isSupersetOf(sub) => Subset(sub, sup)
         // only possible cases left are disjoint (empty intersection) or partial overlap
         case _ => lhs.intersect(rhs) match {
-          case Bounded(lower, upper, _) => lessAndOverlaps(lower)
-          case Point(value) => lessAndOverlaps(value)
+          case i: Bounded[A] => lessAndOverlaps(i.lowerBound)
+          case i: Point[A] => lessAndOverlaps(i.lowerBound)
           case Empty() =>
             if (Interval.fromBounds(lhs.lowerBound, rhs.upperBound).isEmpty) StrictlyLess(rhs, lhs)
             else StrictlyLess(lhs, rhs)

--- a/core/shared/src/main/scala/spire/math/interval/Bound.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Bound.scala
@@ -106,6 +106,17 @@ object Bound {
       case (Open(lv), Closed(rv)) if rv >= lv => rhs
       case (Open(_), Closed(_)) => lhs
     }
+
+  implicit def eq[A](implicit ev: Eq[A]): Eq[Bound[A]] =
+    new Eq[Bound[A]] {
+      def eqv(x: Bound[A], y: Bound[A]): Boolean = (x, y) match {
+        case (EmptyBound(), EmptyBound()) => true
+        case (Unbound(), Unbound()) => true
+        case (Closed(a), Closed(b)) => ev.eqv(a, b)
+        case (Open(a), Open(b)) => ev.eqv(a, b)
+        case _ => false
+      }
+    }
 }
 
 case class EmptyBound[A]() extends Bound[A]

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -1,13 +1,13 @@
 package spire.math.interval
 
-import spire.algebra.{Eq, Order}
+import spire.algebra.Eq
 import spire.math.Interval
 import spire.math.interval.Overlap.{Disjoint, Equal, Subset}
 
 /**
   * An ADT that represents overlapping result for any two intervals.
   */
-sealed abstract class Overlap[A: Order] extends Serializable {
+sealed abstract class Overlap[A] extends Product with Serializable {
   def isDisjoint: Boolean = this.isInstanceOf[Disjoint[_]]
   def isSubset: Boolean = this match {
     case Subset(_, _) | Equal() => true
@@ -21,7 +21,7 @@ object Overlap {
     * Intervals are nonEmpty and don't intersect
     * [[lower.upperBound]] is strictly less than [[upper.lowerBound]].
     */
-  case class Disjoint[A: Order] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A] {
+  case class Disjoint[A] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A] {
 
     /**
       * An interval that joins [[lower]] and [[upper]] in a continuous interval without intersecting any of them.
@@ -35,7 +35,7 @@ object Overlap {
     * [[upper]] ∋ [[lower.upperBound]] && [[upper]] ∌ [[lower.lowerBound]]
     * For example: (-2, 10] and [5, 13)
     */
-  case class PartialOverlap[A: Order] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A]
+  case class PartialOverlap[A] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A]
 
   /**
     * [[inner]] is a subset of [[outer]].
@@ -44,12 +44,12 @@ object Overlap {
     *
     * For example [1,4) and [1, 5]
     */
-  case class Subset[A: Order] private[spire](inner: Interval[A], outer: Interval[A]) extends Overlap[A]
+  case class Subset[A] private[spire](inner: Interval[A], outer: Interval[A]) extends Overlap[A]
 
   /**
     * Intervals are equal
     */
-  case class Equal[A: Order] private[spire]() extends Overlap[A]
+  case class Equal[A] private[spire]() extends Overlap[A]
 
 
   implicit def eqInstance[A: Eq]: Eq[Overlap[A]] = new Eq[Overlap[A]] {

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -62,8 +62,6 @@ case class LessAndOverlaps[A: Order] private[spire](lhs: Interval[A], rhs: Inter
   */
 case class Subset[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
   def isLessAndOverlaps: Boolean = false
-  def isGreater: Boolean = false
-  def isSuperset: Boolean = false
   def isSubset: Boolean = true
   def isEqual: Boolean = false
   def difference: List[Interval[A]] = rhs -- lhs

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -1,0 +1,93 @@
+package spire.math.interval
+
+import spire.algebra.{Eq, Order}
+import spire.math.Interval
+
+/**
+  * An ADT that represents overlapping result for any two intervals.
+  * All subclasses and method names are "left-biased":
+  * for example, [[StrictlyLess]] result means, that [[lhs]] is strictly less than [[rhs]].
+  */
+sealed abstract class Overlap[A: Order] extends Serializable {
+  def lhs: Interval[A]
+  def rhs: Interval[A]
+  def isStrictlyLess: Boolean
+  def isDisjoint: Boolean = isStrictlyLess
+  def isLess: Boolean
+  def isSubset: Boolean
+  def isEqual: Boolean
+}
+
+/**
+  * Intervals are nonEmpty and don't intersect
+  * [[lhs.upperBound]] is strictly less than [[rhs.lowerBound]].
+  */
+case class StrictlyLess[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Overlap[A] {
+  def isSubset: Boolean = false
+  def isEqual: Boolean = false
+  def isStrictlyLess: Boolean = true
+  def isLess: Boolean = true
+
+  /**
+    * An interval that joins [[lhs]] and [[rhs]] in a continuous interval without intersecting any of them.
+    * For example for (-5, 1] and (4, 6), a join is (1,4]
+    */
+  def join: Interval[A] = (~lhs).last.intersect((~rhs).head)
+}
+
+/**
+  * Intermediate abstract class for non-empty overlaps
+  */
+sealed abstract class Intersects[A: Order] private[spire]() extends Overlap[A] {
+  def isStrictlyLess: Boolean = false
+}
+
+/**
+  * Non empty intervals, for which holds:
+  * [[rhs]] ∋ [[lhs.upperBound]] && [[rhs]] ∌ [[lhs.lowerBound]]
+  * For example: (-2, 10] and [5, 13)
+  */
+case class LessAndOverlaps[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
+  def isLess: Boolean = true
+  def isSubset: Boolean = false
+  def isEqual: Boolean = false
+  def intersection: Interval[A] = lhs.intersect(rhs)
+}
+
+/**
+  * [[lhs]] is a subset of [[rhs]].
+  * Empty interval is always a subset of any other, so all overlaps on empty intervals go here,
+  * except `(Ø).overlap(Ø)`, that results in equality.
+  *
+  * For example [1,4) and [1, 5]
+  */
+case class Subset[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
+  def isLess: Boolean = false
+  def isGreater: Boolean = false
+  def isSuperset: Boolean = false
+  def isSubset: Boolean = true
+  def isEqual: Boolean = false
+  def difference: List[Interval[A]] = rhs -- lhs
+}
+
+/**
+  * Intervals are equal
+  */
+case class Equals[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
+  def isLess: Boolean = false
+  def isSubset: Boolean = true
+  def isEqual: Boolean = true
+}
+
+object Overlap {
+  implicit def eqInstance[A: Eq]: Eq[Overlap[A]] = new Eq[Overlap[A]] {
+    val eq = Eq[Interval[A]]
+    def eqv(x: Overlap[A], y: Overlap[A]): Boolean = (x, y) match {
+      case (Equals(x1, y1), Equals(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case (StrictlyLess(x1, y1), StrictlyLess(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case (LessAndOverlaps(x1, y1), LessAndOverlaps(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case (Subset(x1, y1), Subset(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case _ => false
+    }
+  }
+}

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -4,6 +4,7 @@ import spire.algebra.{Eq, Order}
 import spire.math.{Bounded, Empty, Interval, Point}
 import spire.math.interval.Overlap.{Disjoint, Equal, Subset}
 import spire.syntax.eq._
+
 /**
   * An ADT that represents overlapping result for any two intervals.
   */
@@ -57,22 +58,17 @@ object Overlap {
     def lessAndOverlaps(intersectionLowerBound: Bound[A]): Overlap[A] =
       if (lhs.lowerBound === intersectionLowerBound) PartialOverlap(lhs, rhs) else PartialOverlap(rhs, lhs)
 
-    if (lhs === rhs) {
-      Equal()
-    } else {
-      (lhs, rhs) match {
-        case (sub, sup) if sup.isSupersetOf(sub) => Subset(sub, sup)
-        case (sup, sub) if sup.isSupersetOf(sub) => Subset(sub, sup)
-        // only possible cases left are disjoint (empty intersection) or partial overlap
-        case _ => lhs.intersect(rhs) match {
-          case i: Bounded[A] => lessAndOverlaps(i.lowerBound)
-          case i: Point[A] => lessAndOverlaps(i.lowerBound)
-          case Empty() =>
-            if (Interval.fromBounds(lhs.lowerBound, rhs.upperBound).isEmpty) Disjoint(rhs, lhs)
-            else Disjoint(lhs, rhs)
-          case _ => throw new Exception("impossible")
-        }
-      }
+    if (lhs === rhs) Equal()
+    else if (rhs.isSupersetOf(lhs)) Subset(lhs, rhs)
+    else if (lhs.isSupersetOf(rhs)) Subset(rhs, lhs)
+    else lhs.intersect(rhs) match {
+      // only possible cases left are disjoint or partial overlap
+      case i: Bounded[A] => lessAndOverlaps(i.lowerBound)
+      case i: Point[A] => lessAndOverlaps(i.lowerBound)
+      case Empty() =>
+        if (Interval.fromBounds(lhs.lowerBound, rhs.upperBound).isEmpty) Disjoint(rhs, lhs)
+        else Disjoint(lhs, rhs)
+      case _ => throw new Exception("impossible")
     }
   }
 

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -2,87 +2,62 @@ package spire.math.interval
 
 import spire.algebra.{Eq, Order}
 import spire.math.Interval
+import spire.math.interval.Overlap.{Disjoint, Equal, Subset}
 
 /**
   * An ADT that represents overlapping result for any two intervals.
-  * All subclasses and method names are "left-biased":
-  * for example, [[StrictlyLess]] result means, that [[lhs]] is strictly less than [[rhs]].
   */
 sealed abstract class Overlap[A: Order] extends Serializable {
-  def lhs: Interval[A]
-  def rhs: Interval[A]
-  def isStrictlyLess: Boolean
-  def isLessAndOverlaps: Boolean
-  def isSubset: Boolean
-  def isEqual: Boolean
-}
-
-/**
-  * Intervals are nonEmpty and don't intersect
-  * [[lhs.upperBound]] is strictly less than [[rhs.lowerBound]].
-  */
-case class StrictlyLess[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Overlap[A] {
-  def isSubset: Boolean = false
-  def isEqual: Boolean = false
-  def isStrictlyLess: Boolean = true
-  def isLessAndOverlaps: Boolean = false
-
-  /**
-    * An interval that joins [[lhs]] and [[rhs]] in a continuous interval without intersecting any of them.
-    * For example for (-5, 1] and (4, 6), a join is (1,4]
-    */
-  def join: Interval[A] = (~lhs).last.intersect((~rhs).head)
-}
-
-/**
-  * Intermediate abstract class for non-empty overlaps
-  */
-sealed abstract class Intersects[A: Order] private[spire]() extends Overlap[A] {
-  def isStrictlyLess: Boolean = false
-}
-
-/**
-  * Non empty intervals, for which holds:
-  * [[rhs]] ∋ [[lhs.upperBound]] && [[rhs]] ∌ [[lhs.lowerBound]]
-  * For example: (-2, 10] and [5, 13)
-  */
-case class LessAndOverlaps[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLessAndOverlaps: Boolean = true
-  def isSubset: Boolean = false
-  def isEqual: Boolean = false
-  def intersection: Interval[A] = lhs.intersect(rhs)
-}
-
-/**
-  * [[lhs]] is a subset of [[rhs]].
-  * Empty interval is always a subset of any other, so all overlaps on empty intervals go here,
-  * except `(Ø).overlap(Ø)`, that results in equality.
-  *
-  * For example [1,4) and [1, 5]
-  */
-case class Subset[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLessAndOverlaps: Boolean = false
-  def isSubset: Boolean = true
-  def isEqual: Boolean = false
-  def difference: List[Interval[A]] = rhs -- lhs
-}
-
-/**
-  * Intervals are equal
-  */
-case class Equals[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLessAndOverlaps: Boolean = false
-  def isSubset: Boolean = true
-  def isEqual: Boolean = true
+  def isDisjoint: Boolean = this.isInstanceOf[Disjoint[_]]
+  def isSubset: Boolean = this match {
+    case Subset(_, _) | Equal() => true
+    case _ => false
+  }
+  def isEqual: Boolean = this.isInstanceOf[Equal[_]]
 }
 
 object Overlap {
+  /**
+    * Intervals are nonEmpty and don't intersect
+    * [[lower.upperBound]] is strictly less than [[upper.lowerBound]].
+    */
+  case class Disjoint[A: Order] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A] {
+
+    /**
+      * An interval that joins [[lower]] and [[upper]] in a continuous interval without intersecting any of them.
+      * For example for (-5, 1] and (4, 6), a join is (1,4]
+      */
+    def join: Interval[A] = (~lower).last.intersect((~upper).head)
+  }
+
+  /**
+    * Non empty intervals, for which holds:
+    * [[upper]] ∋ [[lower.upperBound]] && [[upper]] ∌ [[lower.lowerBound]]
+    * For example: (-2, 10] and [5, 13)
+    */
+  case class PartialOverlap[A: Order] private[spire](lower: Interval[A], upper: Interval[A]) extends Overlap[A]
+
+  /**
+    * [[inner]] is a subset of [[outer]].
+    * Empty interval is always a subset of any other, so all overlaps on empty intervals go here,
+    * except `(Ø).overlap(Ø)`, that results in equality.
+    *
+    * For example [1,4) and [1, 5]
+    */
+  case class Subset[A: Order] private[spire](inner: Interval[A], outer: Interval[A]) extends Overlap[A]
+
+  /**
+    * Intervals are equal
+    */
+  case class Equal[A: Order] private[spire]() extends Overlap[A]
+
+
   implicit def eqInstance[A: Eq]: Eq[Overlap[A]] = new Eq[Overlap[A]] {
     val eq = Eq[Interval[A]]
     def eqv(x: Overlap[A], y: Overlap[A]): Boolean = (x, y) match {
-      case (Equals(x1, y1), Equals(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
-      case (StrictlyLess(x1, y1), StrictlyLess(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
-      case (LessAndOverlaps(x1, y1), LessAndOverlaps(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case (Equal(), Equal()) => true
+      case (Disjoint(x1, y1), Disjoint(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
+      case (PartialOverlap(x1, y1), PartialOverlap(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
       case (Subset(x1, y1), Subset(x2, y2)) => eq.eqv(x1, x2) && eq.eqv(y1, y2)
       case _ => false
     }

--- a/core/shared/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/shared/src/main/scala/spire/math/interval/Overlap.scala
@@ -12,8 +12,7 @@ sealed abstract class Overlap[A: Order] extends Serializable {
   def lhs: Interval[A]
   def rhs: Interval[A]
   def isStrictlyLess: Boolean
-  def isDisjoint: Boolean = isStrictlyLess
-  def isLess: Boolean
+  def isLessAndOverlaps: Boolean
   def isSubset: Boolean
   def isEqual: Boolean
 }
@@ -26,7 +25,7 @@ case class StrictlyLess[A: Order] private[spire](lhs: Interval[A], rhs: Interval
   def isSubset: Boolean = false
   def isEqual: Boolean = false
   def isStrictlyLess: Boolean = true
-  def isLess: Boolean = true
+  def isLessAndOverlaps: Boolean = false
 
   /**
     * An interval that joins [[lhs]] and [[rhs]] in a continuous interval without intersecting any of them.
@@ -48,7 +47,7 @@ sealed abstract class Intersects[A: Order] private[spire]() extends Overlap[A] {
   * For example: (-2, 10] and [5, 13)
   */
 case class LessAndOverlaps[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLess: Boolean = true
+  def isLessAndOverlaps: Boolean = true
   def isSubset: Boolean = false
   def isEqual: Boolean = false
   def intersection: Interval[A] = lhs.intersect(rhs)
@@ -62,7 +61,7 @@ case class LessAndOverlaps[A: Order] private[spire](lhs: Interval[A], rhs: Inter
   * For example [1,4) and [1, 5]
   */
 case class Subset[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLess: Boolean = false
+  def isLessAndOverlaps: Boolean = false
   def isGreater: Boolean = false
   def isSuperset: Boolean = false
   def isSubset: Boolean = true
@@ -74,7 +73,7 @@ case class Subset[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) e
   * Intervals are equal
   */
 case class Equals[A: Order] private[spire](lhs: Interval[A], rhs: Interval[A]) extends Intersects[A] {
-  def isLess: Boolean = false
+  def isLessAndOverlaps: Boolean = false
   def isSubset: Boolean = true
   def isEqual: Boolean = true
 }

--- a/laws/src/main/scala/spire/laws/arb.scala
+++ b/laws/src/main/scala/spire/laws/arb.scala
@@ -76,7 +76,7 @@ object arb {
   implicit def bound[A: Arbitrary]: Arbitrary[Bound[A]] =
     Arbitrary(gen.bound[A])
 
-  implicit def interval[A: Arbitrary: Order: AdditiveMonoid]: Arbitrary[Interval[A]] =
+  implicit def interval[A: Arbitrary: Order]: Arbitrary[Interval[A]] =
     Arbitrary(gen.interval[A])
 
   implicit def freeMonoid[A: Arbitrary]: Arbitrary[FreeMonoid[A]] =

--- a/laws/src/main/scala/spire/laws/gen.scala
+++ b/laws/src/main/scala/spire/laws/gen.scala
@@ -164,7 +164,7 @@ object gen {
       openUpperInterval[A],
       closedInterval[A])
 
-  def interval[A: Arbitrary: Order: AdditiveMonoid]: Gen[Interval[A]] =
+  def interval[A: Arbitrary: Order]: Gen[Interval[A]] =
     Gen.frequency[Interval[A]](
       (1, Gen.const(Interval.all[A])),
       (1, arbitrary[A].map(Interval.above(_))),

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -588,7 +588,7 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
-      whenever(sorted.distinct.size >= 3 && sorted(0) != sorted(1)) {
+      whenever(sorted.distinct.size >= 3 && sorted(0) != sorted(1) && sorted(2) != sorted(3)) {
         Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))) shouldBe a[PartialOverlap[_]]
       }
     }

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -14,6 +14,7 @@ import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
 import org.scalatest._
 import prop._
+import interval._
 
 import org.scalacheck._
 import Gen._
@@ -530,6 +531,118 @@ class IntervalIteratorCheck extends PropSpec with Matchers with GeneratorDrivenP
   property("unbound intervals are not supported") {
     forAll { (step: Rational) =>
       Try(Interval.all[Rational].iterator(step)).isFailure shouldBe true
+    }
+  }
+}
+
+class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  property("(x overlap y) = (y overlap x)") {
+    forAll() { (x: Interval[Rational], y: Interval[Rational]) =>
+      x.overlap(y) shouldBe y.overlap(x)
+    }
+  }
+
+  property("x overlap x = Equals(x, x)") {
+    forAll() { x: Interval[Rational] =>
+      x.overlap(x) shouldBe Equals(x, x)
+    }
+  }
+
+  property("(x overlap Ø) = Subset(Ø, x) id x != Ø") {
+    forAll() { x: Interval[Rational] =>
+      whenever(x.nonEmpty) {
+        val empty = Interval.empty[Rational]
+        x.overlap(empty) shouldBe Subset(empty, x)
+      }
+    }
+  }
+
+  property("consistency with Interval#isSubset") {
+    forAll() { (x: Interval[Rational], y: Interval[Rational]) =>
+      x.overlap(y).isSubset shouldBe (x.isSubsetOf(y) || y.isSubsetOf(x))
+    }
+  }
+
+  property("(-inf, a] overlap [a, +inf) = LessAndOverlaps") {
+    forAll() { (x: Rational) =>
+      Interval.atOrBelow(x).overlap(Interval.atOrAbove(x)) shouldBe a[LessAndOverlaps[_]]
+    }
+  }
+
+  property("[a, b) overlap (c, d] = LessAndOverlaps if a <= c < b <= d") {
+    forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
+
+      import spire.algebra.Order.ordering
+
+      val sorted = List(x, y, m, n).sorted
+      whenever(sorted(1) < sorted(2)) {
+        Interval.openUpper(sorted(0), sorted(2)).overlap(Interval.openLower(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+      }
+    }
+  }
+
+  property("[a, b] overlap [c, d] = LessAndOverlaps if a <= c <= b <= d") {
+    forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
+
+      import spire.algebra.Order.ordering
+
+      val sorted = List(x, y, m, n).sorted
+      Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+    }
+  }
+
+  property("(-inf, a) overlap (b, +inf) = LessAndOverlaps if a > b") {
+    forAll() { (x: Rational, y: Rational) =>
+      whenever(x != y) {
+        Interval.below(max(x, y)).overlap(Interval.above(min(x, y))).isLessAndOverlaps shouldBe true
+      }
+    }
+  }
+
+  property("(-inf, a) overlap (b, +inf) = StrictlyLess if a <= b") {
+    forAll() { (x: Rational, y: Rational) =>
+      Interval.below(min(x, y)).overlap(Interval.above(max(x, y))).isStrictlyLess shouldBe true
+    }
+  }
+
+  property("StrictlyLess((-inf, a), (b, +inf)).join = [a, b]") {
+    forAll() { (x: Rational, y: Rational) =>
+      val l = min(x, y)
+      val u = max(x, y)
+      StrictlyLess(Interval.below(l), Interval.above(u)).join shouldBe Interval.closed(l, u)
+    }
+  }
+
+  property("[a, b) overlap (c, d] = StrictlyLess if a <= b <= c <= d") {
+    forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
+
+      import spire.algebra.Order.ordering
+
+      val sorted = List(x, y, m, n).sorted
+      val overlap = Interval.openUpper(sorted(0), sorted(1)).overlap(Interval.openLower(sorted(2), sorted(3)))
+      overlap.isStrictlyLess shouldBe true
+      overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.closed(sorted(1), sorted(2))
+    }
+  }
+
+  property("[a, b] overlap [c, d] = StrictlyLess if a <= b < c <= d") {
+    forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
+
+      import spire.algebra.Order.ordering
+
+      val sorted = List(x, y, m, n).sorted
+      whenever(sorted(1) < sorted(2)) {
+        val overlap = Interval.closed(sorted(0), sorted(1)).overlap(Interval.closed(sorted(2), sorted(3)))
+        overlap.isStrictlyLess shouldBe true
+        overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.open(sorted(1), sorted(2))
+      }
+    }
+  }
+
+  property("x overlap [a] is never a LessAndOverlaps") {
+    forAll() { (x: Interval[Rational], b: Rational) =>
+      x.overlap(Interval.point(b)).isLessAndOverlaps shouldNot be(true)
     }
   }
 }

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
 import org.scalatest._
 import prop._
-import interval._
+import interval.Overlap._
 
 import org.scalacheck._
 import Gen._
@@ -543,9 +543,9 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
     }
   }
 
-  property("x overlap x = Equals(x, x)") {
+  property("x overlap x = Equal(x, x)") {
     forAll() { x: Interval[Rational] =>
-      x.overlap(x) shouldBe Equals(x, x)
+      x.overlap(x) shouldBe Equal[Rational]()
     }
   }
 
@@ -564,59 +564,59 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
     }
   }
 
-  property("(-inf, a] overlap [a, +inf) = LessAndOverlaps") {
+  property("(-inf, a] overlap [a, +inf) = PartialOverlap") {
     forAll() { (x: Rational) =>
-      Interval.atOrBelow(x).overlap(Interval.atOrAbove(x)) shouldBe a[LessAndOverlaps[_]]
+      Interval.atOrBelow(x).overlap(Interval.atOrAbove(x)) shouldBe a[PartialOverlap[_]]
     }
   }
 
-  property("[a, c) overlap (b, d] = LessAndOverlaps if a < b < c < d") {
+  property("[a, c) overlap (b, d] = PartialOverlap if a < b < c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
       whenever(sorted.distinct == sorted) {
-        Interval.openUpper(sorted(0), sorted(2)).overlap(Interval.openLower(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+        Interval.openUpper(sorted(0), sorted(2)).overlap(Interval.openLower(sorted(1), sorted(3))) shouldBe a[PartialOverlap[_]]
       }
     }
   }
 
-  property("[a, c] overlap [b, d] = LessAndOverlaps if a < b <= c < d") {
+  property("[a, c] overlap [b, d] = PartialOverlap if a < b <= c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
       whenever(sorted.distinct.size >= 3 && sorted(0) != sorted(1)) {
-        Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+        Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))) shouldBe a[PartialOverlap[_]]
       }
     }
   }
 
-  property("(-inf, a) overlap (b, +inf) = LessAndOverlaps if a > b") {
+  property("(-inf, a) overlap (b, +inf) = PartialOverlap if a > b") {
     forAll() { (x: Rational, y: Rational) =>
       whenever(x != y) {
-        Interval.below(max(x, y)).overlap(Interval.above(min(x, y))).isLessAndOverlaps shouldBe true
+        Interval.below(max(x, y)).overlap(Interval.above(min(x, y))) shouldBe a[PartialOverlap[_]]
       }
     }
   }
 
-  property("(-inf, a) overlap (b, +inf) = StrictlyLess if a <= b") {
+  property("(-inf, a) overlap (b, +inf) = Disjoint if a <= b") {
     forAll() { (x: Rational, y: Rational) =>
-      Interval.below(min(x, y)).overlap(Interval.above(max(x, y))).isStrictlyLess shouldBe true
+      Interval.below(min(x, y)).overlap(Interval.above(max(x, y))).isDisjoint shouldBe true
     }
   }
 
-  property("StrictlyLess((-inf, a), (b, +inf)).join = [a, b]") {
+  property("Disjoint((-inf, a), (b, +inf)).join = [a, b]") {
     forAll() { (x: Rational, y: Rational) =>
       val l = min(x, y)
       val u = max(x, y)
-      StrictlyLess(Interval.below(l), Interval.above(u)).join shouldBe Interval.closed(l, u)
+      Disjoint(Interval.below(l), Interval.above(u)).join shouldBe Interval.closed(l, u)
     }
   }
 
-  property("[a, b) overlap (c, d] = StrictlyLess if a < b <= c < d") {
+  property("[a, b) overlap (c, d] = Disjoint if a < b <= c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
@@ -624,13 +624,13 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
       val sorted = List(x, y, m, n).sorted
       whenever(sorted(0) < sorted(1) && sorted(2) < sorted(3)) {
         val overlap = Interval.openUpper(sorted(0), sorted(1)).overlap(Interval.openLower(sorted(2), sorted(3)))
-        overlap.isStrictlyLess shouldBe true
-        overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.closed(sorted(1), sorted(2))
+        overlap.isDisjoint shouldBe true
+        overlap.asInstanceOf[Disjoint[Rational]].join shouldBe Interval.closed(sorted(1), sorted(2))
       }
     }
   }
 
-  property("[a, b] overlap [c, d] = StrictlyLess if a <= b < c <= d") {
+  property("[a, b] overlap [c, d] = Disjoint if a <= b < c <= d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
@@ -638,15 +638,15 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
       val sorted = List(x, y, m, n).sorted
       whenever(sorted(1) < sorted(2)) {
         val overlap = Interval.closed(sorted(0), sorted(1)).overlap(Interval.closed(sorted(2), sorted(3)))
-        overlap.isStrictlyLess shouldBe true
-        overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.open(sorted(1), sorted(2))
+        overlap.isDisjoint shouldBe true
+        overlap.asInstanceOf[Disjoint[Rational]].join shouldBe Interval.open(sorted(1), sorted(2))
       }
     }
   }
 
-  property("x overlap [a] is never a LessAndOverlaps") {
+  property("x overlap [a] is never a PartialOverlap") {
     forAll() { (x: Interval[Rational], b: Rational) =>
-      x.overlap(Interval.point(b)).isLessAndOverlaps shouldNot be(true)
+      x.overlap(Interval.point(b)) should not be a[PartialOverlap[_]]
     }
   }
 }

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -570,25 +570,27 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
     }
   }
 
-  property("[a, b) overlap (c, d] = LessAndOverlaps if a <= c < b <= d") {
+  property("[a, c) overlap (b, d] = LessAndOverlaps if a < b < c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
-      whenever(sorted(1) < sorted(2)) {
+      whenever(sorted.distinct == sorted) {
         Interval.openUpper(sorted(0), sorted(2)).overlap(Interval.openLower(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
       }
     }
   }
 
-  property("[a, b] overlap [c, d] = LessAndOverlaps if a <= c <= b <= d") {
+  property("[a, c] overlap [b, d] = LessAndOverlaps if a < b <= c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
-      Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+      whenever(sorted.distinct.size >= 3 && sorted(0) != sorted(1)) {
+        Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))).isLessAndOverlaps shouldBe true
+      }
     }
   }
 
@@ -614,15 +616,17 @@ class IntervalOverlapCheck extends PropSpec with Matchers with GeneratorDrivenPr
     }
   }
 
-  property("[a, b) overlap (c, d] = StrictlyLess if a <= b <= c <= d") {
+  property("[a, b) overlap (c, d] = StrictlyLess if a < b <= c < d") {
     forAll() { (x: Rational, y: Rational, m: Rational, n: Rational) =>
 
       import spire.algebra.Order.ordering
 
       val sorted = List(x, y, m, n).sorted
-      val overlap = Interval.openUpper(sorted(0), sorted(1)).overlap(Interval.openLower(sorted(2), sorted(3)))
-      overlap.isStrictlyLess shouldBe true
-      overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.closed(sorted(1), sorted(2))
+      whenever(sorted(0) < sorted(1) && sorted(2) < sorted(3)) {
+        val overlap = Interval.openUpper(sorted(0), sorted(1)).overlap(Interval.openLower(sorted(2), sorted(3)))
+        overlap.isStrictlyLess shouldBe true
+        overlap.asInstanceOf[StrictlyLess[Rational]].join shouldBe Interval.closed(sorted(1), sorted(2))
+      }
     }
   }
 

--- a/tests/src/test/scala/spire/math/interval/BoundTest.scala
+++ b/tests/src/test/scala/spire/math/interval/BoundTest.scala
@@ -1,0 +1,29 @@
+package spire.math.interval
+
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import spire.laws.arb._
+import spire.syntax.eq._
+import spire.math.Rational
+
+class BoundTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  property("Bound equality") {
+    forAll { (x: Rational, y: Rational) =>
+      whenever(x =!= y) {
+        import spire.algebra.Eq
+
+        val eq = Eq[Bound[Rational]]
+
+        eq.eqv(EmptyBound(), EmptyBound()) shouldBe true
+        eq.eqv(Unbound(), Unbound()) shouldBe true
+
+        eq.eqv(Open(x), Open(x)) shouldBe true
+        eq.eqv(Open(x), Open(y)) shouldBe false
+
+        eq.eqv(Closed(x), Closed(x)) shouldBe true
+        eq.eqv(Closed(x), Closed(y)) shouldBe false
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/spire/math/interval/OverlapTest.scala
+++ b/tests/src/test/scala/spire/math/interval/OverlapTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import spire.laws.arb._
 import spire.math.{Interval, Rational}
+import spire.math.interval.Overlap._
 import spire.syntax.eq._
 
 class OverlapTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
@@ -15,14 +16,13 @@ class OverlapTest extends PropSpec with Matchers with GeneratorDrivenPropertyChe
 
         val eq = Eq[Overlap[Rational]]
 
-        eq.eqv(Equals(x, y), Equals(x, y)) shouldBe true
-        eq.eqv(Equals(x, y), Equals(y, x)) shouldBe false
+        eq.eqv(Equal(), Equal()) shouldBe true
 
-        eq.eqv(StrictlyLess(x, y), StrictlyLess(x, y)) shouldBe true
-        eq.eqv(StrictlyLess(x, y), StrictlyLess(y, x)) shouldBe false
+        eq.eqv(Disjoint(x, y), Disjoint(x, y)) shouldBe true
+        eq.eqv(Disjoint(x, y), Disjoint(y, x)) shouldBe false
 
-        eq.eqv(LessAndOverlaps(x, y), LessAndOverlaps(x, y)) shouldBe true
-        eq.eqv(LessAndOverlaps(x, y), LessAndOverlaps(y, x)) shouldBe false
+        eq.eqv(PartialOverlap(x, y), PartialOverlap(x, y)) shouldBe true
+        eq.eqv(PartialOverlap(x, y), PartialOverlap(y, x)) shouldBe false
 
         eq.eqv(Subset(x, y), Subset(x, y)) shouldBe true
         eq.eqv(Subset(x, y), Subset(y, x)) shouldBe false

--- a/tests/src/test/scala/spire/math/interval/OverlapTest.scala
+++ b/tests/src/test/scala/spire/math/interval/OverlapTest.scala
@@ -1,0 +1,32 @@
+package spire.math.interval
+
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import spire.laws.arb._
+import spire.math.{Interval, Rational}
+import spire.syntax.eq._
+
+class OverlapTest extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  property("Overlap equality") {
+    forAll { (x: Interval[Rational], y: Interval[Rational]) =>
+      whenever(x =!= y) {
+        import spire.algebra.Eq
+
+        val eq = Eq[Overlap[Rational]]
+
+        eq.eqv(Equals(x, y), Equals(x, y)) shouldBe true
+        eq.eqv(Equals(x, y), Equals(y, x)) shouldBe false
+
+        eq.eqv(StrictlyLess(x, y), StrictlyLess(x, y)) shouldBe true
+        eq.eqv(StrictlyLess(x, y), StrictlyLess(y, x)) shouldBe false
+
+        eq.eqv(LessAndOverlaps(x, y), LessAndOverlaps(x, y)) shouldBe true
+        eq.eqv(LessAndOverlaps(x, y), LessAndOverlaps(y, x)) shouldBe false
+
+        eq.eqv(Subset(x, y), Subset(x, y)) shouldBe true
+        eq.eqv(Subset(x, y), Subset(y, x)) shouldBe false
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following [gitter discussion](https://gitter.im/non/spire?at=57d6ff2fa0e8dbb04f308eab), I'm proposing a rich overlap operation for Intervals.

For any two Intervals `x` and `y`, overlap operation can return one of the following:

- `StrictlyLess(x , y)`, meaning that both are nonEmpty, `x ∩ y = Ø` and `x.upperBound < y.lowerBound`. Example: `(0, 1)` and `[3, 4]`.
- `LessAndOverlap(x , y)`. Partial overlap: both are nonEmpty, `y ∋ x.upperBound` && `y ∌ x.lowerBound`. Example: `[0, 4)` and `[3, 5)`
- `Subset(x, y)`, meaning `x` is a subset of `y` (including `x = Ø`).
- Any of the previous with `x` and `y` switched.
- `Equals(x, y)`, meaning `x` is equal to `y`

Also added `Eq` instances for `Bound` and `Overlap`.

P.S. Not sure, if actual overlap implementation is the best one performance-wise, advice is welcome :)