### PR TITLE
Root isolation failure test case.

### DIFF
--- a/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
+++ b/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
@@ -136,10 +136,10 @@ object BigDecimalRootRefinement {
         .round(mc)
 
     def floor(x: Rational): JBigDecimal =
-      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.CEILING)).bigDecimal
+      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.FLOOR)).bigDecimal
 
     def ceil(x: Rational): JBigDecimal =
-      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.FLOOR)).bigDecimal
+      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.CEILING)).bigDecimal
 
     def floor(x: JBigDecimal): JBigDecimal =
       x.round(new MathContext(mc.getPrecision, RoundingMode.FLOOR))
@@ -180,7 +180,7 @@ object BigDecimalRootRefinement {
     // Returns true if there is a root in the open sub-interval (l, r).
     def hasRoot(l: Rational, r: Rational): Boolean =
       if (l != r) {
-        // Ue Descartes' rule of signs to see if the root in the open interval
+        // Use Descartes' rule of signs to see if the root in the open interval
         // is actually in the sub interval (l, r).
         val poly0 = shift(shift(poly, l), (r - l).reciprocal)
         poly0.signVariations % 2 == 1
@@ -205,7 +205,7 @@ object BigDecimalRootRefinement {
             ExactRoot(lx)
           } else {
             // We try to push lx up a bit to get the sign to change.
-            adjust(lx.add(JBigDecimal.valueOf(1, getEps(lx))), Some(ly), rx, Some(ry))
+            adjust(lx.add(JBigDecimal.valueOf(1, getEps(lx))), None, rx, Some(ry))
           }
         } else if (ry.signum == 0) {
           if (qrx < upperBound) {
@@ -213,7 +213,7 @@ object BigDecimalRootRefinement {
             ExactRoot(rx)
           } else {
             // We try to push rx down a bit to get the sign to change.
-            adjust(lx, Some(ly), rx.subtract(JBigDecimal.valueOf(1, getEps(rx))), Some(ry))
+            adjust(lx, Some(ly), rx.subtract(JBigDecimal.valueOf(1, getEps(rx))), None)
           }
         } else if (ry.signum == ly.signum) {
           // We've managed to overshoot the actual root, but since we're still

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -19,6 +19,13 @@ class AlgebraicTest extends SpireProperties {
     actual should be <= (approx + error)
   }
 
+  property("root isolation failure") {
+    val poly = Polynomial("4x^3 + 2x^2 - 3x - 1")
+    val roots = Algebraic.roots(poly) 
+    // should be -1}, (1 - sqrt(5))/4, (1 + sqrt(5))/4
+    (roots(0) - roots(1)).isZero shouldBe false 
+  }
+
   property("absolute approximation of addition is correct") {
     val sqrt2x100 = Iterator.fill(100)(Algebraic(2).sqrt).reduce(_ + _)
     val dblSqrt2x100 = math.sqrt(2) * 100

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -22,7 +22,7 @@ class AlgebraicTest extends SpireProperties {
   property("root isolation failure") {
     val poly = Polynomial("4x^3 + 2x^2 - 3x - 1")
     val roots = Algebraic.roots(poly) 
-    // should be -1}, (1 - sqrt(5))/4, (1 + sqrt(5))/4
+    // should be -1, (1 - sqrt(5))/4, (1 + sqrt(5))/4
     (roots(0) - roots(1)).isZero shouldBe false 
   }
 


### PR DESCRIPTION
Test case reporting the following bug:
```scala
scala> import spire.math._; import spire.implicits._
import spire.math._
import spire.implicits._

scala> Algebraic.roots(Polynomial("4x^3 + 2x^2 - 3x - 1"))
res0: Vector[spire.math.Algebraic] = Vector(Algebraic(-1), Algebraic(-1), Algebraic(~0.8090169943749474))
```

where actually the roots should be -1, (1 - sqrt(5))/4 and (1 + sqrt(5))/4

Note: I'm planning to investigate this later. The problem comes probably from the confusion between open and closed intervals, when isolating the root.