### PR TITLE
Bug/various root isolation and refinement bugs

### DIFF
--- a/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
+++ b/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
@@ -136,10 +136,10 @@ object BigDecimalRootRefinement {
         .round(mc)
 
     def floor(x: Rational): JBigDecimal =
-      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.CEILING)).bigDecimal
+      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.FLOOR)).bigDecimal
 
     def ceil(x: Rational): JBigDecimal =
-      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.FLOOR)).bigDecimal
+      x.toBigDecimal(new MathContext(mc.getPrecision, RoundingMode.CEILING)).bigDecimal
 
     def floor(x: JBigDecimal): JBigDecimal =
       x.round(new MathContext(mc.getPrecision, RoundingMode.FLOOR))
@@ -180,7 +180,7 @@ object BigDecimalRootRefinement {
     // Returns true if there is a root in the open sub-interval (l, r).
     def hasRoot(l: Rational, r: Rational): Boolean =
       if (l != r) {
-        // Ue Descartes' rule of signs to see if the root in the open interval
+        // Use Descartes' rule of signs to see if the root in the open interval
         // is actually in the sub interval (l, r).
         val poly0 = shift(shift(poly, l), (r - l).reciprocal)
         poly0.signVariations % 2 == 1
@@ -205,7 +205,7 @@ object BigDecimalRootRefinement {
             ExactRoot(lx)
           } else {
             // We try to push lx up a bit to get the sign to change.
-            adjust(lx.add(JBigDecimal.valueOf(1, getEps(lx))), Some(ly), rx, Some(ry))
+            adjust(lx.add(JBigDecimal.valueOf(1, getEps(lx))), None, rx, Some(ry))
           }
         } else if (ry.signum == 0) {
           if (qrx < upperBound) {
@@ -213,7 +213,7 @@ object BigDecimalRootRefinement {
             ExactRoot(rx)
           } else {
             // We try to push rx down a bit to get the sign to change.
-            adjust(lx, Some(ly), rx.subtract(JBigDecimal.valueOf(1, getEps(rx))), Some(ry))
+            adjust(lx, Some(ly), rx.subtract(JBigDecimal.valueOf(1, getEps(rx))), None)
           }
         } else if (ry.signum == ly.signum) {
           // We've managed to overshoot the actual root, but since we're still

--- a/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
+++ b/core/shared/src/main/scala/spire/math/poly/BigDecimalRootRefinement.scala
@@ -177,12 +177,43 @@ object BigDecimalRootRefinement {
         .removeZeroRoots
     }
 
+    // Returns a polynomial with the same roots as
+    // `poly.compose(Polynomial.linear(s))`, but without using any Rational
+    // arithmetic to compute it.
+    def mult(poly: Polynomial[BigDecimal], s: Rational): Polynomial[BigDecimal] = {
+      // Let s = a/b and n = poly.degree. The idea here is that we can scale
+      // poly by b^n, before composing this with the polynomial (1/b)x,
+      // followed by composing the result with the polynomial ax. The first 2
+      // steps, scaling + composition with (1/b)x, can be simulated by
+      // multiplying each term coefficient a_i by b^(n-i) (ie b^n/b^k=b^(n-k)).
+      // This rigamarole let's us avoid rational arithmetic. Most importantly,
+      // we avoid division, which we cannot do exactly with BigDecimal.
+      val n = poly.degree
+      poly
+        .mapTerms { case Term(coeff, k) =>
+          val a = BigDecimal(s.denominator.toBigInteger.pow(n - k), MathContext.UNLIMITED)
+          Term(coeff * a, k)
+        }
+        .compose(Polynomial.linear[BigDecimal](BigDecimal(s.numerator.toBigInteger, MathContext.UNLIMITED)))
+        .removeZeroRoots
+    }
+
     // Returns true if there is a root in the open sub-interval (l, r).
     def hasRoot(l: Rational, r: Rational): Boolean =
       if (l != r) {
         // Use Descartes' rule of signs to see if the root in the open interval
-        // is actually in the sub interval (l, r).
-        val poly0 = shift(shift(poly, l), (r - l).reciprocal)
+        // is actually in the sub interval (l, r). Since Descartes' rule of
+        // signs only reports positive roots, we need to first transform the
+        // polynomial by mapping the open interval (l, r) to (0, inf). This
+        // will ensure that the only positive roots are those in the open
+        // interval (l, r).  This is accomplished with following
+        // transformations:
+        //
+        // 1) shifting the polynomial by l by composing it with (x + l)
+        // 2) mapping (0, (r - l)) to (0, 1) by composing 1) with (r - l)
+        // 3) mapping (0, 1) to (1, inf) by taking the reciprocal of 2)
+        // 4) mapping (1, inf) to (0, inf) by composing 3) by x + 1.
+        val poly0 = mult(shift(poly, l), r - l).reciprocal.shift(1).removeZeroRoots
         poly0.signVariations % 2 == 1
       } else {
         false
@@ -220,9 +251,9 @@ object BigDecimalRootRefinement {
           // "in-bounds", we know it's in either the left cut off bit or the
           // right.
           if (hasRoot(lowerBound, qlx)) {
-            BoundedLeft(lowerBound, lb)
+            BoundedLeft(lowerBound, lx)
           } else {
-            BoundedRight(ub, upperBound)
+            BoundedRight(rx, upperBound)
           }
         } else {
           // Yay! We've successfully approximated the lower/upper bounds with

--- a/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
+++ b/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
@@ -2,7 +2,10 @@ package spire
 package math
 package poly
 
+import spire.algebra.Order
+import spire.optional.intervalGeometricPartialOrder
 import spire.std.bigInt._
+import spire.syntax.std.seq._
 
 /**
  * A type class for retreiving isolated roots.
@@ -48,16 +51,31 @@ object RootIsolator {
     val x = Polynomial.x[BigInt]
     val one = Polynomial.one[BigInt]
 
+    // As we go through the VAS algorithm, we transform the polynomial by
+    // shifting it along the x-axis, flipping it about the y-axis, or inverting
+    // it (polynomial reciprocal). When we isolate a root in a transformed
+    // polynomial, we need to be able to convert the interval that contains the
+    // transformed poly's root into an interval that contains the original
+    // polynomial's root. To do this, we also maintain a Mobius transformation
+    // (az + b) / (cz + d) that can map points from the transformed space back
+    // into the original space.
     case class TransformedPoly(p: Polynomial[BigInt], a: BigInt, b: BigInt, c: BigInt, d: BigInt)
 
     // Find all roots recursively that are between (0, 1) and (1, infinity).
     def split1(p: Polynomial[BigInt], a: BigInt, b: BigInt, c: BigInt, d: BigInt): List[TransformedPoly] = {
+      // We compose both the polynomial and the Mobius transform with x+1. This
+      // polynomial will be shifted 1 to the left, so all our roots between (0,
+      // 1) will become negative (and thus ignored in this algo).
       val r = p.compose(x + one)
       val rRoots = TransformedPoly(r, a, b + a, c, d + c)
       if (r.signVariations < p.signVariations) {
-        var l = p.reciprocal.compose(x + one)
-        while (l(0) == 0)
-          l = l.mapTerms { case Term(coeff, exp) => Term(coeff, exp - 1) }
+        // There may still be roots between (0, 1), so we need to create a
+        // polynomial whose positive roots correspond to the roots in (0, 1).
+        // We do this by first taking the reciprocal, which maps (0, 1) -> (1,
+        // inf), then compose the reciprocal with x+1 to shift (1, inf) to
+        // (0, inf). The positive real roots of this polynomial correspond to
+        // exactly those roots in (0, 1).
+        var l = p.reciprocal.compose(x + one).removeZeroRoots
         val lRoots = TransformedPoly(l, b, a + b, d, c + d)
         lRoots :: rRoots :: Nil
       } else {
@@ -73,31 +91,54 @@ object RootIsolator {
           rec(TransformedPoly(p0, a, b, c, d) :: rest, acc :+ Interval.point(Rational(b, d)))
         } else {
           p.signVariations match {
-            case 0 => // No roots.
+            case 0 => // No roots, the base case.
               rec(rest, acc)
 
-            case 1 => // Isolated exactly 1 root.
+            case 1 => // Isolated exactly 1 real, positive root.
+              // We found a single positive real root. We use the Mobius
+              // transform we've been maintaining to map the points 0 and
+              // infinity in the space of the transformed polynomial back to
+              // finite points in the space of the original polynomial. We use
+              // these points as the boundaries for the (open) interval
+              // containing the root.
+              //
+              // However, a problem is that one of the points may *actually* be
+              // infinity and we need finite points. In this case, we can just
+              // use an upper bound on the real roots of the polynomial
+              // instead. This let's us keep our interval bounded/finite.
               def ub: Rational = {
-                val exp = Roots.upperBound(p)
                 // This is an upper bound for p, but not for the initial poly.
+                val exp = Roots.upperBound(p)
                 val ub0 =
                   if (exp >= 0) Rational(BigInt(1) << exp)
                   else Rational(1, BigInt(1) << -exp)
                 // We map the upper bound for p back to a bound for the initial
-                // polynomial by using the inverse Mobius transformation.
-                (Rational(d) * ub0 - Rational(b)) / (Rational(-c) * ub0 + Rational(a))
+                // polynomial using the Mobius transformation.
+                (Rational(a) * ub0 + Rational(b)) / (Rational(c) * ub0 + Rational(d))
               }
-              val i0 = if (c == 0) ub else Rational(a, c)
-              val i1 = if (d == 0) ub else Rational(b, d)
+              val i0 = if (c == 0) ub else Rational(a, c) // The point at "inf"
+              val i1 = if (d == 0) ub else Rational(b, d) // The point at "0"
               if (i0 < i1) rec(rest, acc :+ Interval.open(i0, i1))
               else rec(rest, acc :+ Interval.open(i1, i0))
 
             case _ => // Exists 0 or 2 or more roots.
+              // In this case we want to split the polynomial into 2 and
+              // recursively try both. We do this by splitting the polynomial
+              // at (0, 1) and (1, infinity) and recursing (split1). However,
+              // if the first root is at , say, x = 1234, then we'd like to
+              // avoid checking O(1234) root-less polynomials before we finally
+              // find the first root. Luckily, we can easily compute a rough
+              // lower bound on the positive real roots of the polynomial. If
+              // this is > 1, then we shift the polynomial to the left so the
+              // lower bound is now 0.  Essentially, we take a shortcut and
+              // skip testing these fruitless polynomials.
               val lb = Roots.lowerBound(p)
               if (lb < 0) {
+                // Lower-bound is < 1, so no need to transform polynomial.
                 val more = split1(p, a, b, c, d)
                 rec(more reverse_::: rest, acc)
               } else {
+                // Lower-bound is >= 1, so make the lower-bound the new y-axis.
                 val flr = BigInt(1) << lb
                 val more = split1(p.compose(x + Polynomial.constant(flr)), a, b + a * flr, c, d + c * flr)
                 rec(more reverse_::: rest, acc)
@@ -113,10 +154,24 @@ object RootIsolator {
       // A degenerate case we cannot handle.
       Vector.empty
     } else {
+      // The algorithm only works on positive roots, so we isolate the positive
+      // roots and negative roots separately - the latter by flipping the
+      // polynomial about the y-axis.
       val zeroInterval = Interval.point(Rational.zero)
       val posRoots = rec(TransformedPoly(poly, 1, 0, 0, 1) :: Nil)
       val negRoots = rec(TransformedPoly(poly.flip, 1, 0, 0, 1) :: Nil).map(-_).filter(_ != zeroInterval)
-      negRoots ++ posRoots
+      val roots = negRoots ++ posRoots
+
+      // We expect all our isolated roots to be disjoint, so we can use the
+      // geometric partial order as a total order on our set of roots to order
+      // them correctly.
+      val partialOrder = intervalGeometricPartialOrder.intervalGeometricPartialOrder[Rational]
+      implicit val order: Order[Interval[Rational]] = Order.from { (x, y) =>
+        partialOrder.tryCompare(x, y).getOrElse {
+          throw new IllegalStateException("unexpected overlapping isolated roots")
+        }
+      }
+      roots.qsorted
     }
   }
 }

--- a/core/shared/src/main/scala/spire/math/poly/Roots.scala
+++ b/core/shared/src/main/scala/spire/math/poly/Roots.scala
@@ -72,13 +72,22 @@ object Roots {
    * Returns an upper bit bound on the roots of the polynomial `p`.
    */
   final def upperBound(p: Polynomial[BigInt]): Int = {
+    // We can construct an upper bound on the real roots of p, a polynomial of
+    // degree n, by computing a bound for each coefficient, except a_n, as
+    // `b_i = nroot(abs(a_i / a_n), n - i) + 1`. We then choose the maximum
+    // bound as the bound to return. However, since we're dealing with a pretty
+    // loose bound, we can actually skip the n-roots and division and work with
+    // bit-bounds instead, which let us replace division with subtraction and
+    // n-roots with division.
     val lgLastCoeff = p.maxOrderTermCoeff.abs.bitLength
     val n = p.degree
     var maxBound = Double.NegativeInfinity
     p.foreachNonZero { (k, coeff) =>
       if (k != n) {
         val i = n - k
-        val bound = ((coeff.abs.bitLength - lgLastCoeff - 1) / i) + 2
+        // Note: This corresponds to nroot(abs(a_i / a_n), n - 1) + 1, but we
+        // add 2 bits to account for the floor division and the +1 at the end.
+        val bound = ((coeff.abs.bitLength - lgLastCoeff + 1) / i) + 2
         maxBound = max(maxBound, bound.toDouble)
       }
     }

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -19,6 +19,13 @@ class AlgebraicTest extends SpireProperties {
     actual should be <= (approx + error)
   }
 
+  property("root isolation failure") {
+    val poly = Polynomial("4x^3 + 2x^2 - 3x - 1")
+    val roots = Algebraic.roots(poly) 
+    // should be -1}, (1 - sqrt(5))/4, (1 + sqrt(5))/4
+    (roots(0) - roots(1)).isZero shouldBe false 
+  }
+
   property("absolute approximation of addition is correct") {
     val sqrt2x100 = Iterator.fill(100)(Algebraic(2).sqrt).reduce(_ + _)
     val dblSqrt2x100 = math.sqrt(2) * 100

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -129,8 +129,6 @@ class AlgebraicTest extends SpireProperties {
     (trickyZero.toDouble shouldBe 0.0)
   }
 
-/*
-  // this causes frequent test failures. Todo: fix this
   // Generate a bunch of rational roots for a polynomial, then construct a
   // rational polynomial with these roots, and then verify that Algebraic.roots
   // finds all the roots exactly.
@@ -150,7 +148,6 @@ class AlgebraicTest extends SpireProperties {
       }
     }
   }
-  */
 
   // This was a failing test case found using the property tests above.
   property("root isolation uses inverse transform to map upper-bound") {

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -22,7 +22,7 @@ class AlgebraicTest extends SpireProperties {
   property("root isolation failure") {
     val poly = Polynomial("4x^3 + 2x^2 - 3x - 1")
     val roots = Algebraic.roots(poly) 
-    // should be -1}, (1 - sqrt(5))/4, (1 + sqrt(5))/4
+    // should be -1, (1 - sqrt(5))/4, (1 + sqrt(5))/4
     (roots(0) - roots(1)).isZero shouldBe false 
   }
 


### PR DESCRIPTION
This fixes a few bugs:

1) A bug in the detection of roots in between an exact rational bound
and a very close approximation. Usually the root would fall in between 2
approximations, and even then, in this specific case, the root detection
usually still reported the correct result.

2) Bug in the transformation of a root upper bound to an isolated root
bound. Originally, it was using the inverse Mobius transform, but
should've been using the Mobius transform as-is.

3) A bug in the computation the upper bound of real roots of a
polynomial. This was an off-by-1 bug that affected cases where
roots fell very near the actual upper bound - within 1 bit - and
the largest coefficient was on a term of degree <= 2.

Most importantly, this re-enables the rational roots property test for
Algebraic, which was the scalacheck test that found all 3 of these bugs.

@denisrosset This also includes your broken test + my fix for that.