### PR TITLE
Improve performance of Polynomial#shift.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -3,9 +3,6 @@ package math
 
 import scala.collection.mutable.ArrayBuilder
 
-
-import java.math.{ BigDecimal => JBigDecimal, RoundingMode, MathContext }
-
 import spire.algebra._
 import spire.math.poly._
 import spire.std.array._
@@ -47,8 +44,6 @@ object Polynomial extends PolynomialInstances {
 
   def apply[@sp(Double) C: Semiring: Eq: ClassTag](c: C, e: Int): PolySparse[C] =
     PolySparse.safe(Array(e), Array(c))
-
-  import scala.util.{Try, Success, Failure}
 
   def apply(s: String): Polynomial[Rational] = parse(s)
 
@@ -285,6 +280,59 @@ trait Polynomial[@sp(Double) C] { lhs =>
   }
 
   /**
+   * Shift this polynomial along the x-axis by `h`, so that `this(x + h) ==
+   * this.shift(h).apply(x)`.  This is equivalent to calling
+   * `this.compose(Polynomial.x + h)`, but is likely to compute the shifted
+   * polynomial much faster.
+   *
+   * @note We *could* do this without a EuclideanRing, by keeping track of the
+   * the multipliers brought down by the derivative, and cancelling as
+   * required. This will require work though, so another time.
+   */
+  def shift(h: C)(implicit ring: Ring[C], eq: Eq[C]): Polynomial[C] = {
+    // The trick here came from this answer:
+    //   http://math.stackexchange.com/questions/694565/polynomial-shift
+    // This is a heavily optimized version of the same idea. This is fairly
+    // critical method to be fast, since it is the most expensive part of the
+    // VAS root isolation algorithm.
+
+    def fromSafeLong(x: SafeLong): C =
+      if (x.isValidInt) {
+        ring.fromInt(x.toInt)
+      } else {
+        val d = ring.fromInt(1 << 30)
+        val mask = (1L << 30) - 1
+
+        @tailrec def loop(k: C, y: SafeLong, acc: C): C =
+          if (y.isValidInt) {
+            k * ring.fromInt(y.toInt) + acc
+          } else {
+            val z = y >> 30
+            val r = ring.fromInt((y & mask).toInt)
+            loop(d * k, z, k * r + acc)
+          }
+
+        loop(ring.one, x, ring.zero)
+      }
+
+    val coeffs: Array[C] = this.coeffsArray.clone()
+    this.foreachNonZero { (deg, c) =>
+      var i = 1
+      var d = deg - 1
+      var m = SafeLong(1L)
+      var k = c
+      while (d >= 0) {
+        m = (m * (d + 1)) /~ i
+        k *= h
+        coeffs(d) = coeffs(d) + fromSafeLong(m) * k
+        d -= 1
+        i += 1
+      }
+    }
+    Polynomial.dense(coeffs)
+  }
+
+  /**
    * Returns this polynomial as a monic polynomial, where the leading
    * coefficient (ie. `maxOrderTermCoeff`) is 1.
    */
@@ -326,22 +374,8 @@ trait Polynomial[@sp(Double) C] { lhs =>
     Polynomial(terms map f)
 
   /**
-   * Returns this polynomial shifted by `h`. Equivalent to calling
-   * `poly.compose(x + h)`.
-   */
-  def shift(h: C)(implicit ring: Rig[C], eq: Eq[C]): Polynomial[C] =
-    compose(Polynomial.x[C] + Polynomial.constant(h))
-
-  /**
-   * Translates this polynomial by `h`. Equivalent to calling
-   * `poly.compose(x - h)`.
-   */
-  def translate(h: C)(implicit ring: Ring[C], eq: Eq[C]): Polynomial[C] =
-    compose(Polynomial.x[C] - Polynomial.constant(h))
-
-  /**
-   * Replace `x`, the variable, in this polynomial with `-x`. This will
-   * flip/mirror the polynomial about the y-axis.
+   * This will flip/mirror the polynomial about the y-axis. It is equivalent to
+   * `poly.compose(-Polynomial.x)`, but will likely be faster to calculate.
    */
   def flip(implicit ring: Rng[C], eq: Eq[C]): Polynomial[C] =
     mapTerms { case term @ Term(coeff, exp) =>

--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -39,8 +39,8 @@ object Polynomial extends PolynomialInstances {
   def apply[@sp(Double) C: Semiring: Eq: ClassTag](data: Map[Int, C]): PolySparse[C] =
     sparse(data)
 
-  def apply[@sp(Double) C: Semiring: Eq: ClassTag](terms: Iterable[Term[C]]): PolySparse[C] =
-    sparse(terms.map(_.toTuple)(collection.breakOut))
+  def apply[@sp(Double) C: Semiring: Eq: ClassTag](terms: TraversableOnce[Term[C]]): PolySparse[C] =
+    PolySparse(terms)
 
   def apply[@sp(Double) C: Semiring: Eq: ClassTag](c: C, e: Int): PolySparse[C] =
     PolySparse.safe(Array(e), Array(c))
@@ -371,7 +371,7 @@ trait Polynomial[@sp(Double) C] { lhs =>
     mapTerms { case Term(c, n) => Term(f(c), n) }
 
   def mapTerms[D: Semiring: Eq: ClassTag](f: Term[C] => Term[D])(implicit ring: Semiring[C], eq: Eq[C]): Polynomial[D] =
-    Polynomial(terms map f)
+    Polynomial(termsIterator.map(f))
 
   /**
    * This will flip/mirror the polynomial about the y-axis. It is equivalent to
@@ -389,10 +389,12 @@ trait Polynomial[@sp(Double) C] { lhs =>
    *
    * @see http://en.wikipedia.org/wiki/Reciprocal_polynomial
    */
-  def reciprocal(implicit ring: Semiring[C], eq: Eq[C]): Polynomial[C] =
+  def reciprocal(implicit ring: Semiring[C], eq: Eq[C]): Polynomial[C] = {
+    val d = degree
     mapTerms { case term @ Term(coeff, exp) =>
-      Term(coeff, degree - exp)
+      Term(coeff, d - exp)
     }
+  }
 
   // EuclideanRing ops.
 

--- a/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
@@ -236,16 +236,16 @@ object PolySparse {
     val zero = Semiring[C].zero
     var inReverseOrder = true
     var inOrder = true
-    var lastIndex = -1
+    var lastDeg = -1
 
     data.foreach { case Term(c, i) =>
       if (c =!= zero) {
         expBldr += i
         coeffBldr += c
+        inOrder &&= (lastDeg < i)
+        inReverseOrder &&= (lastDeg < 0 || lastDeg > i)
+        lastDeg = i
       }
-      inOrder &&= (lastIndex < i)
-      inReverseOrder &&= (lastIndex > i)
-      lastIndex = i
     }
 
     val exp = expBldr.result()

--- a/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
+++ b/core/shared/src/main/scala/spire/math/poly/RootIsolator.scala
@@ -66,7 +66,7 @@ object RootIsolator {
       // We compose both the polynomial and the Mobius transform with x+1. This
       // polynomial will be shifted 1 to the left, so all our roots between (0,
       // 1) will become negative (and thus ignored in this algo).
-      val r = p.compose(x + one)
+      val r = p.shift(BigInt(1))
       val rRoots = TransformedPoly(r, a, b + a, c, d + c)
       if (r.signVariations < p.signVariations) {
         // There may still be roots between (0, 1), so we need to create a
@@ -75,7 +75,7 @@ object RootIsolator {
         // inf), then compose the reciprocal with x+1 to shift (1, inf) to
         // (0, inf). The positive real roots of this polynomial correspond to
         // exactly those roots in (0, 1).
-        var l = p.reciprocal.compose(x + one).removeZeroRoots
+        var l = p.reciprocal.shift(BigInt(1)).removeZeroRoots
         val lRoots = TransformedPoly(l, b, a + b, d, c + d)
         lRoots :: rRoots :: Nil
       } else {
@@ -140,7 +140,7 @@ object RootIsolator {
               } else {
                 // Lower-bound is >= 1, so make the lower-bound the new y-axis.
                 val flr = BigInt(1) << lb
-                val more = split1(p.compose(x + Polynomial.constant(flr)), a, b + a * flr, c, d + c * flr)
+                val more = split1(p.shift(flr), a, b + a * flr, c, d + c * flr)
                 rec(more reverse_::: rest, acc)
               }
           }

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -207,7 +207,7 @@ class AlgebraicTest extends SpireProperties {
     // This test can be a bit slow, so we limit the tests here. If making major
     // changes to Algebraic, root isolation, refinement, etc, it is a good idea
     // to drop the limits and just give it a bit of time to run.
-    forAll(genRationalPoly, minSuccessful(20), maxSize(6)) { poly =>
+    forAll(genRationalPoly, maxSize(8)) { poly =>
       val apoly = poly.map(Algebraic(_))
       Algebraic.roots(poly).forall { root =>
         apoly(root).isZero

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -273,6 +273,11 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
 
 class PolynomialTest extends FunSuite {
 
+  test("Polynomial(List(Term(0, 0), Term(0, 0))) should not throw") {
+    val ts = Term(r"0", 0) :: Term(r"0", 0) :: Nil
+    assert(Polynomial(ts) == Polynomial.zero[Rational])
+  }
+
   test("polynomial term implicit operations") {
     val t = Term(r"5/6", 2)
     assert(t.eval(r"2") === r"10/3")

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -4,9 +4,9 @@ package math
 import spire.algebra._
 import spire.math.poly._
 import spire.std.bigDecimal._
+import spire.std.bigInt._
 import spire.syntax.literals._
 import spire.optional.rationalTrig._
-
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
@@ -150,6 +150,14 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
     }
   }
 
+  implicit val arbPolynomial: Arbitrary[Polynomial[BigInt]] = Arbitrary(for {
+    ts <- arbitrary[List[Term[BigInt]]]
+    isDense <- arbitrary[Boolean]
+  } yield {
+    val p = Polynomial(ts)
+    if (isDense) p.toDense else p.toSparse
+  })
+
   implicit val arbDense: Arbitrary[PolyDense[Rational]] = Arbitrary(for {
     ts <- arbitrary[List[Term[Rational]]]
   } yield {
@@ -222,6 +230,12 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
       val p = Polynomial(r, 0)
       p shouldBe r
       p.## shouldBe r.##
+    }
+  }
+
+  property(s"p.shift(h) = p.compose(x + h)") {
+    forAll { (p: Polynomial[BigInt], h: BigInt) =>
+      p.shift(h) shouldBe p.compose(Polynomial.x[BigInt] + Polynomial.constant(h))
     }
   }
 

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -370,4 +370,30 @@ class PolynomialTest extends FunSuite {
     assert(spire.math.gcd(a, c) === BigDecimal("0.02"))
     assert(spire.math.gcd(a + b, c) === a + b)
   }
+
+  test("Polynomial(terms...) sums terms") {
+    val terms = List(
+      Term(Rational("-2/17"), 10),
+      Term(Rational("97/8"), 0),
+      Term(Rational("-8/7"), 0),
+      Term(Rational("-8/47"), 47),
+      Term(Rational("-1/71"), 26),
+      Term(Rational("1"), 0),
+      Term(Rational("0"), 1),
+      Term(Rational("-29/8"), 19),
+      Term(Rational("55/7"), 57),
+      Term(Rational("-8/97"), 93),
+      Term(Rational("-99/62"), 1),
+      Term(Rational("0"), 58),
+      Term(Rational("-7/22"), 1),
+      Term(Rational("-93/70"), 38),
+      Term(Rational("-2/21"), 54),
+      Term(Rational("34/79"), 47),
+      Term(Rational("-56/55"), 49),
+      Term(Rational("19/44"), 0))
+    val expected = terms
+      .map { case Term(c, k) => Polynomial(Map(k -> c)) }
+      .foldLeft(Polynomial.zero[Rational])(_ + _)
+    assert(Polynomial(terms) === expected)
+  }
 }


### PR DESCRIPTION
This improves the performance of Polynomial's `shift` method, which is the major bottleneck in the VAS root isolation algorithm. It uses the trick described here: http://math.stackexchange.com/questions/694565/polynomial-shift

The tl;dr is that when I ran the "find all rational roots of rational polynomial" test w/ minSuccessful(1000), it took over a minute to run before. After this update it takes ~15s, which is a pretty substantial improvement.