### PR TITLE
Find a tighter lower bound in root isolation.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Polynomial.scala
+++ b/core/shared/src/main/scala/spire/math/Polynomial.scala
@@ -284,10 +284,6 @@ trait Polynomial[@sp(Double) C] { lhs =>
    * this.shift(h).apply(x)`.  This is equivalent to calling
    * `this.compose(Polynomial.x + h)`, but is likely to compute the shifted
    * polynomial much faster.
-   *
-   * @note We *could* do this without a EuclideanRing, by keeping track of the
-   * the multipliers brought down by the derivative, and cancelling as
-   * required. This will require work though, so another time.
    */
   def shift(h: C)(implicit ring: Ring[C], eq: Eq[C]): Polynomial[C] = {
     // The trick here came from this answer:

--- a/tests/src/test/scala/spire/math/AlgebraicTest.scala
+++ b/tests/src/test/scala/spire/math/AlgebraicTest.scala
@@ -163,7 +163,7 @@ class AlgebraicTest extends SpireProperties {
     forAll(Gen.nonEmptyListOf(genRational), maxSize(8)) { roots =>
       val poly = roots.map(x => Polynomial.linear(Rational.one, -x)).qproduct
       val algebraicRoots = Algebraic.roots(poly)
-      (roots.sorted zip algebraicRoots.qsorted).foreach { case (qRoot, aRoot) =>
+      (roots.sorted zip algebraicRoots).foreach { case (qRoot, aRoot) =>
         aRoot shouldBe Algebraic(qRoot)
       }
     }


### PR DESCRIPTION
This is another perf improvement. This actually gets a pretty impressive improvement in the tests - well above 2x. Mainly, taking some time to find a tighter lower bound saves us quite a lot of calls to `Polynomial#shift`.