### PR TITLE
Use sensible MathContexts in Algebraic BigDecimal approximations.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -273,10 +273,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
 
   /**
    * Absolute approximation to `scale` decimal places with the given rounding
-   * mode. Rounding is always exact.
+   * mode. Rounding is always exact. The returned `BigDecimal` will have use
+   * `java.math.MathContext.UNLIMITED` as it's context.
    */
   def toBigDecimal(scale: Int, roundingMode: RoundingMode): BigDecimal =
-    BigDecimal(roundExact(this, expr.toBigDecimal(scale + 2), scale, roundingMode))
+    new BigDecimal(roundExact(this, expr.toBigDecimal(scale + 2), scale, roundingMode), MathContext.UNLIMITED)
 
   /**
    * Relative approximation to the precision specified in `mc` with the given
@@ -345,8 +346,9 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     val adjustedApprox =
       if (newScale <= approx.scale) approx.setScale(newScale + 1, RoundingMode.DOWN)
       else approx
-    roundExact(this, adjustedApprox, newScale, roundingMode)
+    val finalApprox = roundExact(this, adjustedApprox, newScale, roundingMode)
       .round(mc) // We perform a final round, since roundExact uses scales.
+    new BigDecimal(finalApprox, mc)
   }
 
   /**


### PR DESCRIPTION
Since we weren't explicitly setting the `MathContext`, it was using the default. However, by default, `BigDecimal` won't round the input, so it looked OK. However, any operations performed with this number as the receiver of the method would've truncated the result. Probably unexpectedly. Ugh... Scala's BigDecimal is such a mess.
