### PR TITLE
Fix slow convergence behaviour in Rational#limitTo.

### DIFF
--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -2,15 +2,13 @@ package spire
 package math
 
 import java.lang.Long.numberOfLeadingZeros
-import java.lang.Double.{ isInfinite, isNaN }
 import java.math.{ MathContext, RoundingMode, BigInteger, BigDecimal => JBigDecimal }
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.math.{ ScalaNumber, ScalaNumericConversions }
 
 import spire.Platform
-import spire.algebra.{Eq, EuclideanRing, Field, IsAlgebraic, NRoot, Order, Ring, Sign, Signed}
-import spire.algebra.Sign.{ Positive, Negative, Zero }
+import spire.algebra.{Eq, Field, IsAlgebraic, NRoot, Order, Sign}
 import spire.macros.Checked.checked
 import spire.math.poly.{ Term, BigDecimalRootRefinement, RootFinder, Roots }
 import spire.std.bigInt._
@@ -41,7 +39,7 @@ import spire.syntax.std.seq._
 @SerialVersionUID(1L)
 final class Algebraic private (val expr: Algebraic.Expr)
 extends ScalaNumber with ScalaNumericConversions with Serializable {
-  import Algebraic.{ Zero, One, Expr, MinIntValue, MaxIntValue, MinLongValue, MaxLongValue, JBigDecimalOrder, roundExact, BFMSS, LiYap }
+  import Algebraic.{ One, Expr, MinIntValue, MaxIntValue, MinLongValue, MaxLongValue, JBigDecimalOrder, roundExact }
 
   /**
    * Returns an `Int` with the same sign as this algebraic number. Algebraic

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -308,6 +308,10 @@ class RationalTest extends FunSuite {
     }
   }
 
+  test("Rational(1).limitToInt returns 1") {
+    assert(Rational(1).limitToInt === Rational(1))
+  }
+
   test("gcd returns the correct rational GCD") {
     assert(Rational(1, 2).gcd(Rational(1, 3)) === Rational(1, 6))
     assert(Rational(11, 12).gcd(Rational(43, 22)) === Rational(1, 132))


### PR DESCRIPTION
Fixes #585

This fixes a class of bugs in limitTo which lead to horrible performance in `Rational#limitTo`. Before, `Rational(1).limitToInt` would spin for a loooooong time before finally returning. Now it completes almost instantly.