### PR TITLE
use special Scala 2.11 sources for 2.12 too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,13 @@ lazy val crossVersionSharedSources: Seq[Setting[_]] =
   Seq(Compile, Test).map { sc =>
     (unmanagedSourceDirectories in sc) ++= {
       (unmanagedSourceDirectories in sc ).value.map {
-        dir:File => new File(dir.getPath + "_" + scalaBinaryVersion.value)
+        dir:File =>
+          CrossVersion.partialVersion(scalaBinaryVersion.value) match {
+            case Some((major, minor)) =>
+              new File(s"${dir.getPath}_$major.$minor")
+            case None =>
+              sys.error("couldn't parse scalaBinaryVersion ${scalaBinaryVersion.value}")
+          }
       }
     }
   }

--- a/core/shared/src/main/scala_2.12/spire/util/OptVersions.scala
+++ b/core/shared/src/main/scala_2.12/spire/util/OptVersions.scala
@@ -1,0 +1,11 @@
+package spire
+package util
+
+trait OptVersions {
+  // name-based extractor, cf. http://hseeberger.github.io/blog/2013/10/04/name-based-extractors-in-scala-2-dot-11/
+  def unapply[A](n: Opt[A]): Opt[A] = n
+}
+
+object OptVersions {
+  type Base = AnyVal
+}

--- a/macros/src/main/scala_2.12/spire/macros/compat.scala
+++ b/macros/src/main/scala_2.12/spire/macros/compat.scala
@@ -1,0 +1,22 @@
+package spire
+package macros
+
+object compat {
+
+  type Context = scala.reflect.macros.whitebox.Context
+
+  def freshTermName[C <: Context](c: C)(s: String) =
+    c.universe.TermName(c.freshName(s))
+
+  def termName[C <: Context](c: C)(s: String) =
+    c.universe.TermName(s)
+
+  def typeCheck[C <: Context](c: C)(t: c.Tree) =
+    c.typecheck(t)
+
+  def resetLocalAttrs[C <: Context](c: C)(t: c.Tree) =
+    c.untypecheck(t)
+
+  def setOrig[C <: Context](c: C)(tt: c.universe.TypeTree, t: c.Tree) =
+    c.universe.internal.setOriginal(tt, t)
+}


### PR DESCRIPTION
I don't know if copying these sources is the ideal way to resolve this
-- y'all can decide for yourselves. but I need some change along these
lines in order to resume tracking Spire's master branch in the Scala
2.12 community build.

note that CrossVersion.partialVersion will do the right thing even
for Scala milestones and RCs, weird dbuild-generated community
build Scala version numbers, etc.