### PR TITLE
Cleaned up imports.

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -1,19 +1,9 @@
 package spire
 package benchmark
 
-
-import scala.util.Random
-
 import spire.algebra._
 import spire.math._
 import spire.implicits._
-
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
-import java.lang.Math
-import java.math.BigInteger
 
 object AddBenchmarks extends MyRunner(classOf[AddBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
@@ -7,8 +7,6 @@ import Random._
 import spire.algebra._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object AnyValAddBenchmarks extends MyRunner(classOf[AnyValAddBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
@@ -7,8 +7,6 @@ import Random._
 import spire.algebra._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object AnyValSubtractBenchmarks extends MyRunner(cls = classOf[AnyValSubtractBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -8,8 +8,6 @@ import Random._
 import spire.algebra._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object ArrayOrderBenchmarks extends MyRunner(classOf[ArrayOrderBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
@@ -9,10 +9,6 @@ import spire.math._
 
 import com.google.caliper.Runner
 import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
-import java.lang.Math
-import java.math.BigInteger
 
 /**
  * Extend this to create an actual benchmarking class.

--- a/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
@@ -4,8 +4,6 @@ package benchmark
 import scala.util.Random
 import Random._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 import spire.syntax.cfor._

--- a/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
@@ -1,10 +1,7 @@
 package spire
 package benchmark
 
-import scala.util.Random
 import spire.macros.Checked
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object CheckedBenchmarks extends MyRunner(classOf[CheckedBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
@@ -8,8 +8,6 @@ import spire.algebra._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object ComplexAddBenchmarks extends MyRunner(classOf[ComplexAddBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
@@ -1,20 +1,11 @@
 package spire
 package benchmark
 
-
-import scala.util.Random
-
 import spire.algebra._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
-import java.lang.Math
 import java.math.BigInteger
-import java.lang.Long.numberOfTrailingZeros
 
 object BigIntegerIsRig extends Rig[BigInteger] {
   def zero: BigInteger = new BigInteger("0")

--- a/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
@@ -7,10 +7,6 @@ import Random._
 
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
 import java.lang.Math
 import java.math.BigInteger
 import java.lang.Long.numberOfTrailingZeros

--- a/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
@@ -1,14 +1,8 @@
 package spire
 package benchmark
 
-import scala.util.Random
-
 import spire.implicits._
 import spire.math._
-
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
 
 object JuliaBenchmarks extends MyRunner(classOf[JuliaBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -4,7 +4,7 @@ package benchmark
 import spire.algebra._
 import spire.implicits._
 
-import com.google.caliper.{ Runner, SimpleBenchmark, Param }
+import com.google.caliper.Param
 
 import scala.util.Random._
 

--- a/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
@@ -8,10 +8,6 @@ import Random._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
 object Mo5Benchmarks extends MyRunner(classOf[Mo5Benchmarks])
 
 class Mo5Benchmarks extends MyBenchmark {

--- a/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
@@ -7,8 +7,6 @@ import scala.util.Random
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 import java.lang.Math

--- a/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
@@ -7,9 +7,8 @@ import Random._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.{ Runner, SimpleBenchmark, Param }
+import com.google.caliper.Param
 import org.apache.commons.math3.analysis.polynomials._
-import org.apache.commons.math3.analysis.UnivariateFunction
 
 object PolynomialBenchmarks extends MyRunner(classOf[PolynomialBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
@@ -7,14 +7,6 @@ import Random._
 
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
-
-import java.lang.Math
-import java.math.BigInteger
-import java.lang.Long.numberOfTrailingZeros
-
 object PowBenchmarks extends MyRunner(classOf[PowBenchmarks])
 
 class PowBenchmarks extends MyBenchmark {

--- a/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
@@ -1,12 +1,7 @@
 package spire
 package benchmark
 
-
 import spire.implicits._
-
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
-import com.google.caliper.Param
 
 object RandomBenchmarks extends MyRunner(classOf[RandomBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
@@ -7,8 +7,6 @@ import Random._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 import org.apfloat._

--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -7,12 +7,7 @@ import scala.util.Random
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
-
-import java.lang.Math
-import java.math.BigInteger
 
 object RationalBenchmarks extends MyRunner(classOf[RationalBenchmarks])
 

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -6,8 +6,6 @@ import spire.implicits._
 import spire.math._
 
 import scala.util.Random._
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object RexBenchmarks extends MyRunner(classOf[RexBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -7,11 +7,8 @@ import Random._
 import spire.algebra._
 import spire.std.any._
 
-import spire.math.{Numeric => SpireN}
 import scala.math.{Numeric => ScalaN}
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object ScalaVsSpireBenchmarks extends MyRunner(classOf[ScalaVsSpireBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
@@ -9,8 +9,6 @@ import spire.algebra._
 import spire.math._
 import spire.implicits._
 
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object SelectionBenchmarks extends MyRunner(classOf[SelectionBenchmarks])

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -9,11 +9,6 @@ import spire.algebra._
 import spire.math._
 import spire.implicits._
 
-import spire.math.{Numeric => SpireN}
-import scala.math.{Numeric => ScalaN}
-
-import com.google.caliper.Runner
-import com.google.caliper.SimpleBenchmark
 import com.google.caliper.Param
 
 object SortingBenchmarks extends MyRunner(classOf[SortingBenchmarks])

--- a/core/shared/src/main/scala/spire/algebra/NRoot.scala
+++ b/core/shared/src/main/scala/spire/algebra/NRoot.scala
@@ -23,8 +23,6 @@ trait NRoot[@sp(Double,Float,Int,Long) A] extends Any {
   def fpow(a:A, b:A): A
 }
 
-import spire.math.{ConvertableTo, ConvertableFrom, Number}
-
 object NRoot {
   @inline final def apply[@sp(Int,Long,Float,Double) A](implicit ev:NRoot[A]): NRoot[A] = ev
 

--- a/core/shared/src/main/scala/spire/compat.scala
+++ b/core/shared/src/main/scala/spire/compat.scala
@@ -1,8 +1,8 @@
 package spire
 
 import spire.algebra.{Eq, EuclideanRing, Field, PartialOrder, Order, Ring, Signed}
-import spire.math.{ConvertableFrom, ConvertableTo}
-import spire.math.{ScalaEquivWrapper, ScalaFractionalWrapper, ScalaIntegralWrapper, ScalaNumericWrapper, ScalaPartialOrderingWrapper, ScalaOrderingWrapper}
+import spire.math.{ConvertableFrom, ScalaEquivWrapper, ScalaFractionalWrapper}
+import spire.math.{ScalaIntegralWrapper, ScalaNumericWrapper, ScalaPartialOrderingWrapper, ScalaOrderingWrapper}
 
 private[spire] trait CompatPriority1 {
   implicit def numeric[A: Ring: ConvertableFrom: Signed: Order]: scala.math.Numeric[A] =

--- a/core/shared/src/main/scala/spire/macros/Auto.scala
+++ b/core/shared/src/main/scala/spire/macros/Auto.scala
@@ -200,15 +200,18 @@ abstract class AutoAlgebra extends AutoOps { ops =>
 }
 
 case class ScalaAlgebra[C <: Context](c: C) extends AutoAlgebra {
-  def plusplus[A]: c.Expr[A] = binop[A]("$plus$plus")
-  def plus[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$plus")
-  def minus[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$minus")
-  def times[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$times")
-  def negate[A: c.WeakTypeTag]: c.Expr[A] = unop[A]("unary_$minus")
-  def quot[A: c.WeakTypeTag]: c.Expr[A] = binopSearch[A]("quot" :: "$div" :: Nil) getOrElse failedSearch("quot", "/~")
-  def div[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$div")
-  def mod[A: c.WeakTypeTag](stub: => c.Expr[A]): c.Expr[A] = binop[A]("$percent")
-  def equals: c.Expr[Boolean] = binop[Boolean]("$eq$eq")
+  // we munge these names with dollar signs in them to avoid getting
+  // warnings about possible interpolations. these are not intended to
+  // be interpolations.
+  def plusplus[A]: c.Expr[A] = binop[A]("$" + "plus" + "$" + "plus")
+  def plus[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$" + "plus")
+  def minus[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$" + "minus")
+  def times[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$" + "times")
+  def negate[A: c.WeakTypeTag]: c.Expr[A] = unop[A]("unary_" + "$" + "minus")
+  def quot[A: c.WeakTypeTag]: c.Expr[A] = binopSearch[A]("quot" :: ("$" + "div") :: Nil) getOrElse failedSearch("quot", "/~")
+  def div[A: c.WeakTypeTag]: c.Expr[A] = binop[A]("$" + "div")
+  def mod[A: c.WeakTypeTag](stub: => c.Expr[A]): c.Expr[A] = binop[A]("$" + "percent")
+  def equals: c.Expr[Boolean] = binop[Boolean]("$" + "eq" + "$" + "eq")
   def compare: c.Expr[Int] = binop[Int]("compare")
 }
 

--- a/core/shared/src/main/scala/spire/macros/fpf/Fuser.scala
+++ b/core/shared/src/main/scala/spire/macros/fpf/Fuser.scala
@@ -1,8 +1,6 @@
 package spire
 package macros.fpf
 
-import scala.language.experimental.macros
-
 import spire.macros.compat.{freshTermName, resetLocalAttrs, typeCheck, Context}
 import spire.math.{FpFilter, FpFilterApprox, FpFilterExact}
 

--- a/core/shared/src/main/scala/spire/math/Algebraic.scala
+++ b/core/shared/src/main/scala/spire/math/Algebraic.scala
@@ -39,7 +39,7 @@ import spire.syntax.std.seq._
 @SerialVersionUID(1L)
 final class Algebraic private (val expr: Algebraic.Expr)
 extends ScalaNumber with ScalaNumericConversions with Serializable {
-  import Algebraic.{ One, Expr, MinIntValue, MaxIntValue, MinLongValue, MaxLongValue, JBigDecimalOrder, roundExact }
+  import Algebraic.{ One, Expr, MinIntValue, MaxIntValue, MinLongValue, MaxLongValue, roundExact }
 
   /**
    * Returns an `Int` with the same sign as this algebraic number. Algebraic

--- a/core/shared/src/main/scala/spire/math/BitString.scala
+++ b/core/shared/src/main/scala/spire/math/BitString.scala
@@ -3,8 +3,6 @@ package math
 
 import spire.algebra.Bool
 
-import java.lang.Math
-
 trait BitString[@sp(Byte, Short, Int, Long) A] extends Any with Bool[A] {
   def signed: Boolean
   def width: Int

--- a/core/shared/src/main/scala/spire/math/Complex.scala
+++ b/core/shared/src/main/scala/spire/math/Complex.scala
@@ -8,9 +8,7 @@ import spire.syntax.isReal._
 import spire.syntax.nroot._
 import spire.syntax.order._
 
-import scala.math.{ScalaNumber, ScalaNumericConversions, ScalaNumericAnyConversions}
-import java.lang.Math
-
+import scala.math.{ScalaNumber, ScalaNumericConversions}
 
 object Complex extends ComplexInstances {
   def i[@sp(Float, Double) T](implicit T: Rig[T]): Complex[T] =
@@ -435,7 +433,7 @@ class FloatComplex(val u: Long) extends AnyVal {
  * Not bad, eh?
  */
 object FastComplex {
-  import java.lang.Math.{atan2, cos, sin, sqrt}
+  import java.lang.Math.{atan2, cos, sin}
 
   // note the superstitious use of @inline and final everywhere
 

--- a/core/shared/src/main/scala/spire/math/Convertable.scala
+++ b/core/shared/src/main/scala/spire/math/Convertable.scala
@@ -3,9 +3,6 @@ package math
 
 import java.math.MathContext
 
-
-import spire.algebra.{ Trig, IsReal }
-
 trait ConvertableTo[@sp A] extends Any {
   def fromByte(n: Byte): A
   def fromShort(n: Short): A

--- a/core/shared/src/main/scala/spire/math/Fractional.scala
+++ b/core/shared/src/main/scala/spire/math/Fractional.scala
@@ -4,8 +4,6 @@ package math
 import spire.algebra.{Field, NRoot}
 import spire.std._
 
-import java.lang.Math
-
 trait Fractional[@sp(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]
 
 object Fractional {

--- a/core/shared/src/main/scala/spire/math/Natural.scala
+++ b/core/shared/src/main/scala/spire/math/Natural.scala
@@ -168,8 +168,6 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
   def isEven: Boolean = (digit & UInt(1)) == UInt(0)
 
   def powerOfTwo: Int = {
-    import java.lang.Integer.highestOneBit
-
     def test(n: UInt): Int = {
       if ((n.signed & -n.signed) != n.signed) return -1
       // TODO: this could be better/faster

--- a/core/shared/src/main/scala/spire/math/Number.scala
+++ b/core/shared/src/main/scala/spire/math/Number.scala
@@ -1,7 +1,7 @@
 package spire
 package math
 
-import scala.math.{ScalaNumber, ScalaNumericConversions}
+import scala.math.ScalaNumericConversions
 import java.lang.Math
 
 import spire.algebra.{Eq, EuclideanRing, Field, IsReal, IsRational, NRoot, Order, Ring, Signed, Trig}
@@ -590,8 +590,6 @@ private[math] case class RationalNumber(n: Rational) extends Number { lhs =>
     // FIXME: we should actually try to return values with a meaningful approximation context
     Number(spire.math.pow(n.toDouble, rhs.toDouble))
   }
-
-  import spire.algebra.Field
 
   def floor: Number = RationalNumber(IsReal[Rational].floor(n))
   def ceil: Number = RationalNumber(IsReal[Rational].ceil(n))

--- a/core/shared/src/main/scala/spire/math/Quaternion.scala
+++ b/core/shared/src/main/scala/spire/math/Quaternion.scala
@@ -1,8 +1,6 @@
 package spire
 package math
 
-import java.lang.Math
-
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 import spire.algebra._
 import spire.syntax.field._

--- a/core/shared/src/main/scala/spire/math/Real.scala
+++ b/core/shared/src/main/scala/spire/math/Real.scala
@@ -8,7 +8,7 @@ import spire.syntax.nroot._
 
 sealed trait Real extends ScalaNumber with ScalaNumericConversions { x =>
 
-  import Real.{roundUp, Exact, Inexact}
+  import Real.{roundUp, Exact}
 
   def apply(p: Int): SafeLong
 

--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -2,7 +2,6 @@ package spire
 
 import java.lang.Long.numberOfTrailingZeros
 import java.lang.Math
-import java.math.BigInteger
 import java.math.MathContext
 import java.math.RoundingMode
 

--- a/core/shared/src/main/scala/spire/math/prime/Factors.scala
+++ b/core/shared/src/main/scala/spire/math/prime/Factors.scala
@@ -8,8 +8,6 @@ import spire.std.int._
 import spire.std.map._
 import spire.syntax.rng._
 
-import scala.collection.mutable
-
 object Factors {
   val zero = Factors(Map.empty, Zero)
   val one = Factors(Map.empty, Positive)

--- a/core/shared/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/shared/src/main/scala/spire/math/prime/Siever.scala
@@ -1,7 +1,7 @@
 package spire
 package math.prime
 
-import spire.math.{SafeLong, log, max}
+import spire.math.SafeLong
 
 import SieveUtil._
 

--- a/core/shared/src/main/scala/spire/math/prime/package.scala
+++ b/core/shared/src/main/scala/spire/math/prime/package.scala
@@ -2,7 +2,7 @@ package spire
 package math
 
 import spire.algebra.Sign
-import spire.algebra.Sign.{Negative, Zero, Positive}
+import spire.algebra.Sign.Positive
 import spire.syntax.cfor._
 import spire.syntax.nroot._
 
@@ -171,12 +171,12 @@ package object prime {
       if (n == 1) {
         Factors.one
       } else if (isPrime(n)) {
-        Factors(Map(n -> 1), Positive)
+        Factors(Map((n, 1)), Positive)
       } else if (n % 2 == 0) {
         var x = n / 2
         var e = 1
         while (x % 2 == 0) { x /= 2; e += 1 }
-        Factors(Map(SafeLong(2) -> e), Positive) * factor(x)
+        Factors(Map((SafeLong(2), e)), Positive) * factor(x)
       } else {
         var divisor = rho(n, rand(n))
         while (divisor == n) divisor = rho(n, rand(n))

--- a/core/shared/src/main/scala/spire/random/Dist.scala
+++ b/core/shared/src/main/scala/spire/random/Dist.scala
@@ -6,7 +6,6 @@ import spire.syntax.all._
 import spire.math.{Complex, Interval, Natural, Rational, SafeLong, UByte, UShort, UInt, ULong}
 
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 
 trait Dist[@sp A] extends Any { self =>

--- a/core/shared/src/main/scala/spire/random/Random.scala
+++ b/core/shared/src/main/scala/spire/random/Random.scala
@@ -1,8 +1,6 @@
 package spire
 package random
 
-import scala.collection.mutable.{ArrayBuffer, Builder}
-import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 
 sealed trait Op[+A] {

--- a/core/shared/src/main/scala/spire/random/rng/Lcg64.scala
+++ b/core/shared/src/main/scala/spire/random/rng/Lcg64.scala
@@ -3,7 +3,6 @@ package random
 package rng
 
 import spire.util.Pack
-import java.nio.ByteBuffer
 
 final class Lcg64(_seed: Long) extends LongBasedGenerator {
   private var seed: Long = _seed

--- a/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
+++ b/core/shared/src/main/scala/spire/random/rng/SecureJava.scala
@@ -2,8 +2,6 @@ package spire
 package random
 package rng
 
-import java.nio.ByteBuffer
-import java.util.Arrays
 import java.security.SecureRandom
 
 class SecureJava(rand: SecureRandom) extends IntBasedGenerator {

--- a/core/shared/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/shared/src/main/scala/spire/syntax/std/Ops.scala
@@ -2,7 +2,6 @@ package spire
 package syntax
 package std
 
-import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import spire.algebra.{AdditiveMonoid, Field, Monoid, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -5,7 +5,6 @@ import spire.algebra._
 import spire.math.Rational
 import spire.implicits._
 
-import scala.collection.IterableLike
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.{ Builder, ListBuffer }
 

--- a/examples/src/main/scala/spire/example/operators.scala
+++ b/examples/src/main/scala/spire/example/operators.scala
@@ -1,8 +1,6 @@
 package spire
 package example
 
-import language.implicitConversions
-
 import spire.algebra._
 import spire.math._
 import spire.implicits._

--- a/examples/src/main/scala/spire/example/simplification.scala
+++ b/examples/src/main/scala/spire/example/simplification.scala
@@ -5,7 +5,7 @@ import spire.implicits._
 import spire.math._
 
 import scala.collection.IterableLike
-import scala.collection.mutable.{Builder, GrowingBuilder, MapBuilder}
+import scala.collection.mutable.Builder
 import scala.collection.generic.CanBuildFrom
 
 /**

--- a/laws/src/main/scala/spire/laws/ActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/ActionLaws.scala
@@ -21,7 +21,7 @@ trait ActionLaws[G, A] extends Laws {
 
   val scalarLaws: GroupLaws[G]
 
-  import scalarLaws.{ Equ => EqG, Arb => ArG }
+  import scalarLaws.{ Arb => ArG }
 
   implicit def EquA: Eq[A]
   implicit def ArbA: Arbitrary[A]

--- a/laws/src/main/scala/spire/laws/BaseLaws.scala
+++ b/laws/src/main/scala/spire/laws/BaseLaws.scala
@@ -6,7 +6,7 @@ import spire.implicits._
 
 import org.typelevel.discipline.Laws
 
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
 object BaseLaws {

--- a/laws/src/main/scala/spire/laws/LogicLaws.scala
+++ b/laws/src/main/scala/spire/laws/LogicLaws.scala
@@ -8,7 +8,7 @@ import spire.syntax.bool._
 
 import org.typelevel.discipline.Laws
 
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
 object LogicLaws {

--- a/laws/src/main/scala/spire/laws/PartialActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialActionLaws.scala
@@ -22,7 +22,7 @@ trait PartialActionLaws[G, A] extends Laws {
 
   val scalarLaws: PartialGroupLaws[G]
 
-  import scalarLaws.{ Equ => EqG, Arb => ArG }
+  import scalarLaws.{ Arb => ArG }
 
   implicit def EquA: Eq[A]
   implicit def ArbA: Arbitrary[A]

--- a/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
@@ -5,9 +5,7 @@ import spire.algebra._
 import spire.algebra.partial._
 import spire.implicits._
 
-import org.typelevel.discipline.Laws
-
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
 object PartialGroupLaws {

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -4,7 +4,7 @@ package laws
 import spire.algebra._
 import spire.implicits._
 
-import org.typelevel.discipline.{Laws, Predicate}
+import org.typelevel.discipline.Predicate
 
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Arbitrary._

--- a/laws/src/main/scala/spire/laws/arb.scala
+++ b/laws/src/main/scala/spire/laws/arb.scala
@@ -7,7 +7,7 @@ import spire.math.extras.{FixedPoint, FixedScale}
 import spire.algebra._
 import spire.algebra.free._
 import spire.math._
-import spire.math.interval.{Bound, Closed, Open, Unbound}
+import spire.math.interval.Bound
 
 import org.scalacheck.Arbitrary
 

--- a/macros/src/main/scala/spire/macros/Syntax.scala
+++ b/macros/src/main/scala/spire/macros/Syntax.scala
@@ -3,8 +3,6 @@ package macros
 
 import spire.macros.compat.{termName, freshTermName, resetLocalAttrs, Context, setOrig}
 
-import scala.language.higherKinds
-
 object Ops extends machinist.Ops {
 
   def uesc(c: Char): String = "$u%04X".format(c.toInt)
@@ -75,11 +73,13 @@ case class SyntaxUtil[C <: Context with Singleton](val c: C) {
 }
 
 // This is Scala reflection source compatibility hack between Scala 2.10 and 2.11
+// Will raise a Unused import warning on Scala 2.11
 private object HasCompat { val compat = ??? }; import HasCompat._
 
 class InlineUtil[C <: Context with Singleton](val c: C) {
   import c.universe._
   // This is Scala reflection source compatibility hack between Scala 2.10 and 2.11
+  // Will raise a Unused import warning on Scala 2.11
   import compat._
 
   def inlineAndReset[T](tree: Tree): c.Expr[T] = {

--- a/macros/src/test/scala/spire/macros/CheckedTest.scala
+++ b/macros/src/test/scala/spire/macros/CheckedTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 
 class CheckedTest extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
   import Checked.checked

--- a/tests/src/test/scala/spire/PartialSyntaxTest.scala
+++ b/tests/src/test/scala/spire/PartialSyntaxTest.scala
@@ -10,10 +10,9 @@ import spire.std.boolean._
 import spire.std.int._
 import spire.syntax.eq._
 
-import org.scalatest.{FunSuite, Matchers, NonImplicitAssertions}
+import org.scalatest.{FunSuite, NonImplicitAssertions}
 import org.scalatest.prop.Checkers
 
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 

--- a/tests/src/test/scala/spire/SyntaxTest.scala
+++ b/tests/src/test/scala/spire/SyntaxTest.scala
@@ -9,8 +9,6 @@ import spire.std.string._
 import spire.syntax.all._
 import spire.tests.{SpireTests, SpireProperties}
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
 import org.scalatest.prop.Checkers
 
 import org.scalacheck.{Arbitrary, Gen}

--- a/tests/src/test/scala/spire/algebra/GCDTest.scala
+++ b/tests/src/test/scala/spire/algebra/GCDTest.scala
@@ -13,7 +13,7 @@ import spire.syntax.isReal.{ eqOps => _, _ }
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 

--- a/tests/src/test/scala/spire/algebra/SignedTest.scala
+++ b/tests/src/test/scala/spire/algebra/SignedTest.scala
@@ -9,11 +9,6 @@ import org.scalatest.FunSuite
 import spire.math.{Rational, Algebraic, Complex}
 import spire.implicits.{eqOps => _, _}
 
-// nice alias
-
-import java.math.MathContext
-
-
 class SignedTest extends FunSuite {
   def runWith[@sp(Int, Long, Float, Double) A: Signed: ClassTag](neg: A, pos: A, zero: A): Unit = {
     val m = implicitly[ClassTag[A]]

--- a/tests/src/test/scala/spire/laws/ExtraLawTests.scala
+++ b/tests/src/test/scala/spire/laws/ExtraLawTests.scala
@@ -2,12 +2,12 @@ package spire.laws
 
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
-import spire.math.extras.interval.{IntervalTrieArbitrary, IntervalTrie, IntervalSeq, IntervalSeqArbitrary}
+import spire.math.extras.interval.{IntervalSeq, IntervalSeqArbitrary} // IntervalTrie, IntervalTrieArbitrary
 import spire.implicits._
 
 class ExtraLawTests extends FunSuite with Discipline {
   import IntervalSeqArbitrary._
-  import IntervalTrieArbitrary._
+  // import IntervalTrieArbitrary._
   checkAll("Bool[IntervalSeq[Int]]", LogicLaws[IntervalSeq[Int]].bool)
 //  checkAll("Bool[IntervalTrie[Long]]", LogicLaws[IntervalTrie[Long]].bool)
 }

--- a/tests/src/test/scala/spire/math/ArbitrarySupport.scala
+++ b/tests/src/test/scala/spire/math/ArbitrarySupport.scala
@@ -3,7 +3,6 @@ package math
 
 import spire.algebra._
 
-import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import Arbitrary.arbitrary

--- a/tests/src/test/scala/spire/math/BitStringTest.scala
+++ b/tests/src/test/scala/spire/math/BitStringTest.scala
@@ -1,7 +1,6 @@
 package spire
 package math
 
-import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
 
 import spire.implicits._

--- a/tests/src/test/scala/spire/math/IntervalTest.scala
+++ b/tests/src/test/scala/spire/math/IntervalTest.scala
@@ -8,7 +8,6 @@ import scala.util.Try
 import org.scalatest.FunSuite
 import spire.implicits.{eqOps => _, _}
 import spire.laws.arb.{interval => interval_, rational}
-import spire.random.{Uniform, Dist}
 
 import org.scalatest.Matchers
 import org.scalacheck.Arbitrary._
@@ -18,7 +17,6 @@ import interval.Overlap._
 
 import org.scalacheck._
 import Gen._
-import Arbitrary.arbitrary
 
 class IntervalTest extends FunSuite {
   def cc(n1: Double, n2: Double) = Interval.closed(n1, n2)
@@ -161,7 +159,7 @@ class IntervalGeometricPartialOrderTest extends FunSuite {
 class IntervalSubsetPartialOrderTest extends FunSuite {
   import spire.optional.intervalSubsetPartialOrder._
 
-  import Interval.{openUpper, openLower, closed, open, point}
+  import Interval.{closed, point}
 
   test("Minimal and maximal elements of {[1, 3], [3], [2], [1]} by subset partial order") {
     val intervals = Seq(closed(1, 3), point(3), point(2), point(1))
@@ -402,7 +400,6 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
   property("(-inf, a] < [b, inf) if a < b") {
     import spire.optional.intervalGeometricPartialOrder._
 
-    import spire.algebra.{Order, PartialOrder}
     forAll { (a: Rational, w: Positive[Rational]) =>
       val b = a + w.num
       // a < b
@@ -417,7 +414,6 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
 
   property("(-inf, a] does not compare to [b, inf) if a >= b") {
     import spire.optional.intervalGeometricPartialOrder._
-    import spire.algebra.{Order, PartialOrder}
     forAll { (a: Rational, w: NonNegative[Rational]) =>
       val b = a - w.num
       // a >= b
@@ -430,7 +426,6 @@ class IntervalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
 
   property("(-inf, inf) does not compare with [a, b]") {
     import spire.optional.intervalGeometricPartialOrder._
-    import spire.algebra.{Order, PartialOrder}
     forAll { (a: Rational, b: Rational) =>
       val i = Interval.all[Rational]
       val j = Interval.closed(a, b)

--- a/tests/src/test/scala/spire/math/QuaternionCheck.scala
+++ b/tests/src/test/scala/spire/math/QuaternionCheck.scala
@@ -11,7 +11,6 @@ import prop._
 
 import org.scalacheck._
 import Gen._
-import Arbitrary.arbitrary
 
 class QuaternionCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
 

--- a/tests/src/test/scala/spire/math/RealCheck.scala
+++ b/tests/src/test/scala/spire/math/RealCheck.scala
@@ -11,7 +11,6 @@ import prop._
 
 import org.scalacheck._
 import Gen._
-import Arbitrary.arbitrary
 
 import ArbitrarySupport._
 import Ordinal._

--- a/tests/src/test/scala/spire/math/SearchTest.scala
+++ b/tests/src/test/scala/spire/math/SearchTest.scala
@@ -4,7 +4,6 @@ package math
 import spire.implicits._
 
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
 
 class SearchTest extends FunSuite {
   test("search when type provides a traditional comparison method") {

--- a/tests/src/test/scala/spire/math/SelectionTest.scala
+++ b/tests/src/test/scala/spire/math/SelectionTest.scala
@@ -4,10 +4,7 @@ package math
 import spire.algebra._
 import spire.std.int._
 
-
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
-
 
 trait SelectTest extends FunSuite /* with Checkers */ {
   def selector: Select

--- a/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
+++ b/tests/src/test/scala/spire/math/TypeclassExistenceTest.scala
@@ -5,10 +5,7 @@ import spire.algebra._
 import spire.math._
 import spire.implicits._
 
-import java.math.MathContext
-
 import org.scalatest.FunSuite
-
 
 /**
  * Just some sanity tests to make sure that the type classes we expect to exist

--- a/tests/src/test/scala/spire/math/extras/interval/IntervalTrieSampleCheck.scala
+++ b/tests/src/test/scala/spire/math/extras/interval/IntervalTrieSampleCheck.scala
@@ -1,9 +1,9 @@
 package spire.math.extras.interval
 
-import org.scalacheck.Prop._
-import org.scalacheck.Properties
-import spire.std.any._
-import spire.syntax.all._
+//import org.scalacheck.Prop._
+//import org.scalacheck.Properties
+//import spire.std.any._
+//import spire.syntax.all._
 
 /*
 object IntervalTrieSampleCheck extends Properties("IntervalSet.Sample") {

--- a/tests/src/test/scala/spire/math/prime/FactorHeapCheck.scala
+++ b/tests/src/test/scala/spire/math/prime/FactorHeapCheck.scala
@@ -10,7 +10,6 @@ import prop._
 
 import org.scalacheck._
 import Gen._
-import Arbitrary.arbitrary
 
 import spire.implicits._
 

--- a/tests/src/test/scala/spire/math/prime/FactorsCheck.scala
+++ b/tests/src/test/scala/spire/math/prime/FactorsCheck.scala
@@ -19,8 +19,6 @@ import Ordinal._
 
 class FactorsCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks {
 
-  import Factors.{zero, one}
-
   implicit val arbitraryFactors: Arbitrary[Factors] =
     Arbitrary(arbitrary[SafeLong].map(n => Factors(n)))
 


### PR DESCRIPTION
I split manually the patch of the #576 PR. This is the part that remove most of the warnings (import, interpolation, etc...). I however did not modify the flags in `build.sbt`.

The rest of the patch is here: https://gist.github.com/denisrosset/45774ba1cb9221a75f9c6be85f80fd4a

I'm working on importing the group terminology rename now.