### PR TITLE
bump version in README to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ scala-js for both versions).
 To get started with SBT, simply add the following to your `build.sbt` file:
 
 ```
-libraryDependencies += "org.spire-math" %% "spire" % "0.11.0"
+libraryDependencies += "org.spire-math" %% "spire" % "0.13.0"
 ```
 
 For Maven instructions, and to download the jars directly, visit the


### PR DESCRIPTION
Small update to bump the version in the README

Is spire working with Scala 2.12? If so, I'm happy to update that too