### PR TITLE
Unsigned integer types form a commutative Rig.

### DIFF
--- a/core/shared/src/main/scala/spire/math/UByte.scala
+++ b/core/shared/src/main/scala/spire/math/UByte.scala
@@ -1,7 +1,7 @@
 package spire
 package math
 
-import spire.algebra.{IsIntegral, Order, Rig, Signed}
+import spire.algebra.{CRig, IsIntegral, Order, Signed}
 
 object UByte extends UByteInstances {
   @inline final def apply(n: Byte): UByte = new UByte(n)
@@ -77,7 +77,7 @@ trait UByteInstances {
   implicit final val UByteTag = new UnsignedIntTag[UByte](UByte.MinValue, UByte.MaxValue)
 }
 
-private[math] trait UByteIsRig extends Rig[UByte] {
+private[math] trait UByteIsCRig extends CRig[UByte] {
   def one: UByte = UByte(1)
   def plus(a:UByte, b:UByte): UByte = a + b
   override def pow(a:UByte, b:Int): UByte = {
@@ -142,4 +142,4 @@ private[math] class UByteBitString extends BitString[UByte] with Serializable {
 }
 
 @SerialVersionUID(0L)
-private[math] class UByteAlgebra extends UByteIsRig with UByteIsReal with Serializable
+private[math] class UByteAlgebra extends UByteIsCRig with UByteIsReal with Serializable

--- a/core/shared/src/main/scala/spire/math/UInt.scala
+++ b/core/shared/src/main/scala/spire/math/UInt.scala
@@ -1,7 +1,7 @@
 package spire
 package math
 
-import spire.algebra.{IsIntegral, Order, Rig, Signed}
+import spire.algebra.{CRig, IsIntegral, Order, Signed}
 
 object UInt extends UIntInstances {
   @inline final def apply(n: Int): UInt = new UInt(n)
@@ -67,7 +67,7 @@ trait UIntInstances {
   implicit final val UIntTag = new UnsignedIntTag[UInt](UInt.MinValue, UInt.MaxValue)
 }
 
-private[math] trait UIntIsRig extends Rig[UInt] {
+private[math] trait UIntIsCRig extends CRig[UInt] {
   def one: UInt = UInt(1)
   def plus(a:UInt, b:UInt): UInt = a + b
   override def pow(a:UInt, b:Int): UInt = {
@@ -126,4 +126,4 @@ private[math] trait UIntIsReal extends IsIntegral[UInt] with UIntOrder with UInt
 }
 
 @SerialVersionUID(0L)
-private[math] class UIntAlgebra extends UIntIsRig with UIntIsReal with Serializable
+private[math] class UIntAlgebra extends UIntIsCRig with UIntIsReal with Serializable

--- a/core/shared/src/main/scala/spire/math/ULong.scala
+++ b/core/shared/src/main/scala/spire/math/ULong.scala
@@ -1,8 +1,7 @@
 package spire
 package math
 
-
-import spire.algebra.{IsIntegral, Order, Rig, Signed}
+import spire.algebra.{CRig, IsIntegral, Order, Signed}
 
 object ULong extends ULongInstances {
   @inline final def apply(n: Long): ULong = new ULong(n)
@@ -138,7 +137,7 @@ trait ULongInstances {
   implicit final val ULongTag = new UnsignedIntTag[ULong](ULong.MinValue, ULong.MaxValue)
 }
 
-private[math] trait ULongIsRig extends Rig[ULong] {
+private[math] trait ULongIsCRig extends CRig[ULong] {
   def one: ULong = ULong(1)
   def plus(a:ULong, b:ULong): ULong = a + b
   override def pow(a:ULong, b:Int): ULong = {
@@ -197,4 +196,4 @@ private[math] trait ULongIsReal extends IsIntegral[ULong] with ULongOrder with U
 }
 
 @SerialVersionUID(0L)
-private[math] class ULongAlgebra extends ULongIsRig with ULongIsReal with Serializable
+private[math] class ULongAlgebra extends ULongIsCRig with ULongIsReal with Serializable

--- a/core/shared/src/main/scala/spire/math/UShort.scala
+++ b/core/shared/src/main/scala/spire/math/UShort.scala
@@ -1,7 +1,7 @@
 package spire
 package math
 
-import spire.algebra.{IsIntegral, Order, Rig, Signed}
+import spire.algebra.{CRig, IsIntegral, Order, Signed}
 
 object UShort extends UShortInstances {
   @inline final def apply(n: Char): UShort = new UShort(n)
@@ -68,7 +68,7 @@ trait UShortInstances {
   implicit final val UShortTag = new UnsignedIntTag[UShort](UShort.MinValue, UShort.MaxValue)
 }
 
-private[math] trait UShortIsRig extends Rig[UShort] {
+private[math] trait UShortIsCRig extends CRig[UShort] {
   def one: UShort = UShort(1)
   def plus(a:UShort, b:UShort): UShort = a + b
   override def pow(a:UShort, b:Int): UShort = {
@@ -133,4 +133,4 @@ private[math] trait UShortIsReal extends IsIntegral[UShort] with UShortOrder wit
 }
 
 @SerialVersionUID(0L)
-private[math] class UShortAlgebra extends UShortIsRig with UShortIsReal with Serializable
+private[math] class UShortAlgebra extends UShortIsCRig with UShortIsReal with Serializable

--- a/laws/src/main/scala/spire/laws/GroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/GroupLaws.scala
@@ -57,6 +57,14 @@ trait GroupLaws[A] extends Laws {
     )
   )
 
+  def cMonoid(implicit A: CMonoid[A]) = new GroupProperties(
+    name = "commutative monoid",
+    parent = Some(monoid),
+    "commutative" → forAll((x: A, y: A) =>
+      (x |+| y) === (y |+| x)
+    )
+  )
+
   def group(implicit A: Group[A]) = new GroupProperties(
     name = "group",
     parent = Some(monoid),
@@ -102,6 +110,12 @@ trait GroupLaws[A] extends Laws {
     "isZero" → forAll((a: A) =>
       a.isZero === (a === A.zero)
     )
+  )
+
+
+  def additiveCMonoid(implicit A: AdditiveCMonoid[A]) = new AdditiveProperties(
+    base = cMonoid(A.additive),
+    parent = Some(additiveMonoid)
   )
 
   def additiveGroup(implicit A: AdditiveGroup[A]) = new AdditiveProperties(

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -61,6 +61,11 @@ trait RingLaws[A] extends GroupLaws[A] {
     )
   )
 
+  def multiplicativeCMonoid(implicit A: MultiplicativeCMonoid[A]) = new MultiplicativeProperties(
+    base = _.cMonoid(A.multiplicative),
+    parent = Some(multiplicativeMonoid)
+  )
+
   def multiplicativeGroup(implicit A: MultiplicativeGroup[A]) = new MultiplicativeProperties(
     base = _.group(A.multiplicative),
     parent = Some(multiplicativeMonoid),
@@ -99,8 +104,16 @@ trait RingLaws[A] extends GroupLaws[A] {
 
   def rig(implicit A: Rig[A]) = new RingProperties(
     name = "rig",
-    al = additiveMonoid,
+    al = additiveCMonoid,
     ml = multiplicativeMonoid,
+    parents = Seq(semiring)
+  )
+
+
+  def cRig(implicit A: CRig[A]) = new RingProperties(
+    name = "commutative rig",
+    al = additiveCMonoid,
+    ml = multiplicativeCMonoid,
     parents = Seq(semiring)
   )
 
@@ -112,10 +125,17 @@ trait RingLaws[A] extends GroupLaws[A] {
     parents = Seq(rig, rng)
   )
 
+  def cRing(implicit A: CRing[A]) = new RingProperties(
+    name = "commutative ring",
+    al = additiveAbGroup,
+    ml = multiplicativeCMonoid,
+    parents = Seq(ring)
+  )
+
   def euclideanRing(implicit A: EuclideanRing[A]) = RingProperties.fromParent(
     // TODO tests?!
     name = "euclidean ring",
-    parent = ring
+    parent = cRing
   )
 
   // Everything below fields (e.g. rings) does not require their multiplication

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -39,6 +39,10 @@ class LawTests extends FunSuite with Discipline {
   checkAll("BigInteger", RingLaws[BigInteger].euclideanRing)
   checkAll("Rational",   RingLaws[Rational].field)
   checkAll("Real",       RingLaws[Real].field)
+  checkAll("UByte",      RingLaws[UInt].cRig)
+  checkAll("UShort",     RingLaws[UInt].cRig)
+  checkAll("UInt",       RingLaws[UInt].cRig)
+  checkAll("ULong",      RingLaws[ULong].cRig)
 
   checkAll("Levenshtein distance", BaseLaws[String].metricSpace)
   checkAll("BigInt",               BaseLaws[BigInt].metricSpace)

--- a/tests/src/test/scala/spire/math/UnsignedTest.scala
+++ b/tests/src/test/scala/spire/math/UnsignedTest.scala
@@ -118,7 +118,6 @@ class ULongTest extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
   property("toDouble") {
     forAll { (n: ULong) =>
       val d = new java.math.BigDecimal(n.toDouble).toPlainString
-      println(s"$n versus $d")
       n.toDouble shouldBe n.toBigInt.toDouble
     }
   }


### PR DESCRIPTION
For some reason, this was missing.

The test coverage should be more complete for those types (modulo the redundancy in UnsignedTest)