### PR TITLE
DivisionRing and Quaternion made lawful.

### DIFF
--- a/core/shared/src/main/scala/spire/algebra/DivisionRing.scala
+++ b/core/shared/src/main/scala/spire/algebra/DivisionRing.scala
@@ -1,0 +1,50 @@
+package spire
+package algebra
+
+import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
+import java.lang.Long.{ numberOfTrailingZeros }
+
+trait DivisionRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with MultiplicativeGroup[A] { self =>
+
+  def fromDouble(a: Double): A = DivisionRing.fromDouble[A](a)(self, self)
+}
+
+
+object DivisionRing {
+
+  @inline final def apply[A](implicit f: DivisionRing[A]): DivisionRing[A] = f
+
+  // TODO: use instead algebra Ring.fromDouble, if PR algebra/#190 is accepted
+  /**
+    * This is implemented in terms of basic ops. However, this is
+    * probably significantly less efficient than can be done with a specific
+    * type. So, it is recommended to specialize this general method.
+    *
+    * This is possible because a Double is a rational number.
+    */
+  def fromDouble[A](a: Double)(implicit ringA: Ring[A], mgA: MultiplicativeGroup[A]): A =
+    if (a == 0.0) ringA.zero else {
+      import ringA._
+      require(!isInfinite(a) && !isNaN(a),
+        "Double must be representable as a fraction.")
+      val bits = doubleToLongBits(a)
+      val m = bits & 0x000FFFFFFFFFFFFFL | 0x0010000000000000L
+      val zeros = numberOfTrailingZeros(m)
+      val value = m >>> zeros
+      val exp = ((bits >> 52) & 0x7FF).toInt - 1075 + zeros // 1023 + 52
+
+      val high = times(fromInt((value >>> 30).toInt), fromInt(1 << 30))
+      val low = fromInt((value & 0x3FFFFFFF).toInt)
+      val num = plus(high, low)
+      val unsigned = if (exp > 0) {
+        times(num, pow(fromInt(2), exp))
+      } else if (exp < 0) {
+        mgA.div(num, pow(fromInt(2), -exp))
+      } else {
+        num
+      }
+
+      if (a < 0) negate(unsigned) else unsigned
+    }
+
+}

--- a/core/shared/src/main/scala/spire/math/Complex.scala
+++ b/core/shared/src/main/scala/spire/math/Complex.scala
@@ -107,10 +107,10 @@ final case class Complex[@sp(Float, Double) T](real: T, imag: T)
   def complexSignum(implicit f: Field[T], o: IsReal[T], n: NRoot[T]): Complex[T] =
     if (isZero) this else this / abs
 
-  def abs(implicit f: Field[T], o: IsReal[T], n: NRoot[T]): T =
+  def abs(implicit f: Field[T], n: NRoot[T], s: Signed[T]): T =
     (real * real + imag * imag).sqrt
 
-  def arg(implicit f: Field[T], t: Trig[T], o: IsReal[T]): T =
+  def arg(implicit f: Field[T], s: Signed[T], t: Trig[T]): T =
     if (isZero) f.zero else t.atan2(imag, real)
 
   def norm(implicit f: Field[T], n: NRoot[T], o: Order[T]): T = hypot(real, imag)
@@ -120,9 +120,9 @@ final case class Complex[@sp(Float, Double) T](real: T, imag: T)
   def asTuple: (T, T) = (real, imag)
   def asPolarTuple(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): (T, T) = (abs, arg)
 
-  def isZero(implicit o: IsReal[T]): Boolean = real.isSignZero && imag.isSignZero
-  def isImaginary(implicit o: IsReal[T]): Boolean = real.isSignZero
-  def isReal(implicit o: IsReal[T]): Boolean = imag.isSignZero
+  def isZero(implicit s: Signed[T]): Boolean = real.isSignZero && imag.isSignZero
+  def isImaginary(implicit s: Signed[T]): Boolean = real.isSignZero
+  def isReal(implicit s: Signed[T]): Boolean = imag.isSignZero
 
   def eqv(b: Complex[T])(implicit o: Eq[T]): Boolean = real === b.real && imag === b.imag
   def neqv(b: Complex[T])(implicit o: Eq[T]): Boolean = real =!= b.real || imag =!= b.imag
@@ -200,15 +200,15 @@ final case class Complex[@sp(Float, Double) T](real: T, imag: T)
 
   def **(b: Int)(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): Complex[T] = pow(b)
 
-  def nroot(k: Int)(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): Complex[T] =
+  def nroot(k: Int)(implicit f: Field[T], n: NRoot[T], o: Order[T], s: Signed[T], t: Trig[T]): Complex[T] =
     if (isZero) Complex.zero else pow(Complex(f.fromInt(k).reciprocal, f.zero))
 
-  def pow(b: Int)(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): Complex[T] =
+  def pow(b: Int)(implicit f: Field[T], n: NRoot[T], s: Signed[T], t: Trig[T]): Complex[T] =
     if (isZero) Complex.zero else Complex.polar(abs.pow(b), arg * b)
 
-  def **(b: Complex[T])(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): Complex[T] = pow(b)
+  def **(b: Complex[T])(implicit f: Field[T], n: NRoot[T], o: Order[T], s: Signed[T], t: Trig[T]): Complex[T] = pow(b)
 
-  def pow(b: Complex[T])(implicit f: Field[T], n: NRoot[T], t: Trig[T], o: IsReal[T]): Complex[T] =
+  def pow(b: Complex[T])(implicit f: Field[T], n: NRoot[T], o: Order[T], s: Signed[T], t: Trig[T]): Complex[T] =
     if (b.isZero) {
       Complex.one[T]
     } else if (this.isZero) {

--- a/core/shared/src/main/scala/spire/math/Quaternion.scala
+++ b/core/shared/src/main/scala/spire/math/Quaternion.scala
@@ -26,17 +26,11 @@ object Quaternion extends QuaternionInstances {
     Quaternion(c.real, c.imag, f.zero, f.zero)
 }
 
-// really a skew field
-private[math] trait QuaternionAlgebra[A]
-    extends Field[Quaternion[A]]
-    with Eq[Quaternion[A]]
-    with NRoot[Quaternion[A]]
-    with InnerProductSpace[Quaternion[A], A]
-    with FieldAlgebra[Quaternion[A], A] {
+/** Quaternion algebra over an ordered field. */
+private[math] trait QuaternionOverField[A] extends Eq[Quaternion[A]] with DivisionRing[Quaternion[A]] with FieldAlgebra[Quaternion[A], A] {
 
-  implicit def f: Fractional[A]
-  implicit def t: Trig[A]
-  implicit def r: IsReal[A]
+  implicit def o: Order[A]
+  implicit def s: Signed[A]
 
   def eqv(x: Quaternion[A], y: Quaternion[A]): Boolean = x == y
   override def neqv(x: Quaternion[A], y: Quaternion[A]): Boolean = x != y
@@ -50,33 +44,47 @@ private[math] trait QuaternionAlgebra[A]
   def zero: Quaternion[A] = Quaternion.zero[A]
 
   def div(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] = a / b
-  /* TODO: is it sound?
-  def quot(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] = a /~ b
-  def mod(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] = a % b
-  def gcd(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] = {
-    @tailrec def _gcd(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] =
-      if (b.isZero) a else _gcd(b, a - (a / b).round * b)
-    _gcd(a, b)
-  }
-   */
+
+  def timesl(a: A, q: Quaternion[A]): Quaternion[A] = q * a
+  def dot(x: Quaternion[A], y: Quaternion[A]): A = x.dot(y)
+
+}
+
+private[math] trait QuaternionOverRichField[A] extends QuaternionOverField[A]
+  with NRoot[Quaternion[A]]
+  with InnerProductSpace[Quaternion[A], A] {
+
+  implicit def n: NRoot[A]
+  implicit def t: Trig[A]
 
   def nroot(a: Quaternion[A], k: Int): Quaternion[A] = a.nroot(k)
   override def sqrt(a: Quaternion[A]): Quaternion[A] = a.sqrt
   def fpow(a: Quaternion[A], b: Quaternion[A]): Quaternion[A] = a.fpow(b.r) //FIXME
 
-  def timesl(a: A, q: Quaternion[A]): Quaternion[A] = q * a
-  def dot(x: Quaternion[A], y: Quaternion[A]): A = x.dot(y)
 }
 
-trait QuaternionInstances {
-  implicit def QuaternionAlgebra[A](implicit fr: Fractional[A], tr: Trig[A], isr: IsReal[A]): QuaternionAlgebra[A] =
-    new QuaternionAlgebra[A] {
-      val f = fr
-      val t = tr
-      val r = isr
-      def scalar = f
-      def nroot = f
+trait QuaternionInstances1 {
+
+  implicit def QuaternionOverField[A](implicit f0: Field[A], o0: Order[A], s0: Signed[A]): QuaternionOverField[A] =
+    new QuaternionOverField[A] {
+      val scalar = f0
+      val o = o0
+      val s = s0
     }
+
+}
+
+trait QuaternionInstances extends QuaternionInstances1 {
+
+  implicit def QuaternionOverRichField[A](implicit f0: Field[A], n0: NRoot[A], o0: Order[A], s0: Signed[A], t0: Trig[A]): QuaternionOverRichField[A] =
+    new QuaternionOverRichField[A] {
+      val scalar = f0
+      val n = n0
+      val o = o0
+      val s = s0
+      val t = t0
+    }
+
 }
 
 final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
@@ -121,17 +129,17 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
   def =!=(that: Quaternion[_]): Boolean =
     !(this === that)
 
-  def isZero(implicit o: IsReal[A]): Boolean = r.isSignZero && i.isSignZero && j.isSignZero && k.isSignZero
-  def isReal(implicit o: IsReal[A]): Boolean = i.isSignZero && j.isSignZero && k.isSignZero
-  def isPure(implicit o: IsReal[A]): Boolean = r.isSignZero
+  def isZero(implicit s: Signed[A]): Boolean = r.isSignZero && i.isSignZero && j.isSignZero && k.isSignZero
+  def isReal(implicit s: Signed[A]): Boolean = i.isSignZero && j.isSignZero && k.isSignZero
+  def isPure(implicit s: Signed[A]): Boolean = r.isSignZero
 
   def real(implicit s: Semiring[A]): Quaternion[A] = Quaternion(r)
   def pure(implicit s: Semiring[A]): Quaternion[A] = Quaternion(s.zero, i, j, k)
 
-  def abs(implicit f: Field[A], o: IsReal[A], n: NRoot[A]): A =
+  def abs(implicit f: Field[A], n: NRoot[A], s: Signed[A]): A =
     (r.pow(2) + i.pow(2) + j.pow(2) + k.pow(2)).sqrt
 
-  def pureAbs(implicit f: Field[A], o: IsReal[A], n: NRoot[A]): A =
+  def pureAbs(implicit f: Field[A], n: NRoot[A], s: Signed[A]): A =
     (i.pow(2) + j.pow(2) + k.pow(2)).sqrt
 
   def eqv(rhs: Quaternion[A])(implicit o: Eq[A]): Boolean =
@@ -144,7 +152,7 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
 
   def toComplex: Complex[A] = Complex(r, i)
 
-  def signum(implicit o: IsReal[A]): Int = r.signum match {
+  def signum(implicit s: Signed[A]): Int = r.signum match {
     case 0 => i.signum match {
       case 0 => j.signum match {
         case 0 => k.signum
@@ -155,10 +163,10 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
     case n => n
   }
 
-  def quaternionSignum(implicit f: Field[A], o: IsReal[A], n: NRoot[A]): Quaternion[A] =
+  def quaternionSignum(implicit f: Field[A], o: Order[A], n: NRoot[A]): Quaternion[A] =
     if (isZero) this else this / abs
 
-  def pureSignum(implicit f: Field[A], o: IsReal[A], n: NRoot[A]): Quaternion[A] =
+  def pureSignum(implicit f: Field[A], o: Order[A], n: NRoot[A]): Quaternion[A] =
     if (isReal) Quaternion.zero[A] else (pure / pureAbs)
 
   def unary_-(implicit s: Rng[A]): Quaternion[A] =
@@ -170,7 +178,7 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
   def reciprocal(implicit f: Field[A]): Quaternion[A] =
     conjugate / (r.pow(2) + i.pow(2) + j.pow(2) + k.pow(2))
 
-  def sqrt(implicit f: Field[A], o: IsReal[A], n0: NRoot[A]): Quaternion[A] =
+  def sqrt(implicit f: Field[A], nr: NRoot[A], s: Signed[A]): Quaternion[A] =
     if (!isReal) {
       val n = (r + abs).sqrt
       Quaternion(n, i / n, j / n, k / n) / f.fromInt(2).sqrt
@@ -180,7 +188,7 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
       Quaternion(f.zero, r.abs.sqrt, f.zero, f.zero)
     }
 
-  def nroot(m: Int)(implicit f: Field[A], o: IsReal[A], n0: NRoot[A], tr: Trig[A]): Quaternion[A] =
+  def nroot(m: Int)(implicit f: Field[A], nr: NRoot[A], o: Order[A], si: Signed[A], tr: Trig[A]): Quaternion[A] =
     if (m <= 0) {
       throw new IllegalArgumentException(s"illegal root: $m")
     } else if (m == 1) {
@@ -199,7 +207,7 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
       Quaternion(Complex(r).nroot(m))
     }
 
-  def unit(implicit f: Field[A], o: IsReal[A], n: NRoot[A]): Quaternion[A] =
+  def unit(implicit f: Field[A], n: NRoot[A], s: Signed[A]): Quaternion[A] =
     Quaternion(r.pow(2), i.pow(2), j.pow(2), k.pow(2)) / abs
 
   def +(rhs: A)(implicit s: Semiring[A]): Quaternion[A] =
@@ -251,7 +259,7 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
 
   def **(k: Int)(implicit s: Ring[A]): Quaternion[A] = pow(k)
 
-  def fpow(k0: A)(implicit f: Field[A], o: IsReal[A], n0: NRoot[A], tr: Trig[A]): Quaternion[A] =
+  def fpow(k0: A)(implicit f: Field[A], nr: NRoot[A], o: Order[A], si: Signed[A], tr: Trig[A]): Quaternion[A] =
     if (k0.signum < 0) {
       Quaternion.zero
     } else if (k0 == f.zero) {
@@ -270,44 +278,8 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
       Quaternion(Complex(r).pow(Complex(k0)))
     }
 
-  def floor(implicit o: IsReal[A]): Quaternion[A] =
-    Quaternion(r.floor, i.floor, j.floor, k.floor)
-
-  def ceil(implicit o: IsReal[A]): Quaternion[A] =
-    Quaternion(r.ceil, i.ceil, j.ceil, k.ceil)
-
-  def round(implicit o: IsReal[A]): Quaternion[A] =
-    Quaternion(r.round, i.round, j.round, k.round)
-
-  // TODO: instead of floor for /~, should be round-toward-zero
-
-  def /~(rhs: A)(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    (lhs / rhs).floor
-  def /~(rhs: Complex[A])(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    (lhs / rhs).floor
-  def /~(rhs: Quaternion[A])(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    (lhs / rhs).floor
-
-  def %(rhs: A)(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    lhs - (lhs /~ rhs)
-  def %(rhs: Complex[A])(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    lhs - (lhs /~ rhs)
-  def %(rhs: Quaternion[A])(implicit f: Field[A], o: IsReal[A]): Quaternion[A] =
-    lhs - (lhs /~ rhs)
-
-  def /%(rhs: A)(implicit f: Field[A], o: IsReal[A]): (Quaternion[A], Quaternion[A]) = {
-    val q = lhs /~ rhs
-    (q, lhs - q)
-  }
-  def /%(rhs: Complex[A])(implicit f: Field[A], o: IsReal[A]): (Quaternion[A], Quaternion[A]) = {
-    val q = lhs /~ rhs
-    (q, lhs - q)
-  }
-  def /%(rhs: Quaternion[A])(implicit f: Field[A], o: IsReal[A]): (Quaternion[A], Quaternion[A]) = {
-    val q = lhs /~ rhs
-    (q, lhs - q)
-  }
 
   def dot(rhs: Quaternion[A])(implicit f: Field[A]): A =
     (lhs.conjugate * rhs + rhs.conjugate * lhs).r / f.fromInt(2)
+
 }

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -112,6 +112,15 @@ trait RingLaws[A] extends GroupLaws[A] {
     parents = Seq(rig, rng)
   )
 
+  def divisionRing(implicit A: DivisionRing[A]) = new RingProperties(
+    name = "divisionRing",
+    al = additiveAbGroup,
+    ml = multiplicativeGroup,
+    parents = Seq(ring)
+  ) {
+    override def nonZero = true
+  }
+
   def euclideanRing(implicit A: EuclideanRing[A]) = RingProperties.fromParent(
     // TODO tests?!
     name = "euclidean ring",

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -40,6 +40,10 @@ class LawTests extends FunSuite with Discipline {
   checkAll("Rational",   RingLaws[Rational].field)
   checkAll("Real",       RingLaws[Real].field)
 
+  checkAll("Complex[Rational]", RingLaws[Complex[Rational]].field)
+
+  checkAll("Quaternion[Rational]", RingLaws[Quaternion[Rational]].divisionRing)
+
   checkAll("Levenshtein distance", BaseLaws[String].metricSpace)
   checkAll("BigInt",               BaseLaws[BigInt].metricSpace)
 

--- a/tests/src/test/scala/spire/math/QuaternionTest.scala
+++ b/tests/src/test/scala/spire/math/QuaternionTest.scala
@@ -1,0 +1,15 @@
+package spire.math
+
+import spire.algebra.DivisionRing
+import spire.syntax.ring._
+import org.scalatest.FunSuite
+
+class QuaternionTest extends FunSuite {
+
+  test("Quaternion[Double].fromDouble") {
+    assert(DivisionRing[Quaternion[Rational]].fromDouble(0).isZero)
+    assert((-DivisionRing[Quaternion[Rational]].fromDouble(-1)).isValidInt)
+    assert(DivisionRing[Quaternion[Rational]].fromDouble(1) === DivisionRing[Quaternion[Rational]].one)
+  }
+
+}


### PR DESCRIPTION
Added a DivisionRing typeclass.

Converted Quaternion to DivisionRing; split the Quaternion instances into one requiring only a signed Field scalar, and another richer that include roots but requires a NRoot/Trig scalar.

Added tests using the Quaternion[Rational] type.

Note: I changed some `IsReal` implicits into `Order` / `Signed` to be more relaxed in the requirements. This change will be complete in a future PR.