### PR TITLE
Fix issue 624: '@sp' causing stack overflow on Numeric[N].toRational(n)

### DIFF
--- a/core/shared/src/main/scala/spire/algebra/IsReal.scala
+++ b/core/shared/src/main/scala/spire/algebra/IsReal.scala
@@ -49,16 +49,16 @@ object IsAlgebraic {
   def apply[@sp A](implicit A: IsAlgebraic[A]): IsAlgebraic[A] = A
 }
 
-trait IsRational[@sp A] extends Any with IsAlgebraic[A] {
+trait IsRational[A] extends Any with IsAlgebraic[A] {
   def toRational(a: A): Rational
   def toAlgebraic(a: A): Algebraic = Algebraic(toRational(a))
 }
 
 object IsRational {
-  def apply[@sp A](implicit A: IsRational[A]): IsRational[A] = A
+  def apply[A](implicit A: IsRational[A]): IsRational[A] = A
 }
 
-trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsRational[A] {
+trait IsIntegral[A] extends Any with IsRational[A] {
   def ceil(a: A): A = a
   def floor(a: A): A = a
   def round(a: A): A = a
@@ -68,5 +68,5 @@ trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsRational[A] {
 }
 
 object IsIntegral {
-  def apply[@sp A](implicit A: IsIntegral[A]): IsIntegral[A] = A
+  def apply[A](implicit A: IsIntegral[A]): IsIntegral[A] = A
 }

--- a/tests/src/test/scala/spire/math/NumericTest.scala
+++ b/tests/src/test/scala/spire/math/NumericTest.scala
@@ -73,4 +73,23 @@ class NumericTest extends FunSuite {
     Complex(BigDecimal(3), BigDecimal(0)),
     Complex(BigDecimal(-9), BigDecimal(0))
   )*/
+
+  def testImplicitNumeric[N](cls: String)(implicit numN: Numeric[N]): Unit = {
+
+    def runTest(name:String)(f: => Unit) = test("%s:%s" format(cls, name))(f)
+
+    val n1 = numN.one
+
+    runTest("toDouble(1)")(assert(numN.toDouble(n1) === 1D))
+    runTest("toRational(1)")(assert(numN.toRational(n1) === Rational(1)))
+    runTest("toReal(1)")(assert(numN.toReal(n1) === Real(1)))
+  }
+
+  testImplicitNumeric[Int]("Int")
+  testImplicitNumeric[Long]("Long")
+  testImplicitNumeric[Float]("Float")
+  testImplicitNumeric[Double]("Double")
+  testImplicitNumeric[BigInt]("BigInt")
+  testImplicitNumeric[BigDecimal]("BigDecimal")
+  testImplicitNumeric[Rational]("Rational")
 }


### PR DESCRIPTION
Fixes #624 by removing `@sp` from trait `IsRational` and `IsIntegral`