### PR TITLE
Add basic release notes for 0.14.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,58 @@
+## Version 0.14.0
+
+This release is a major milestone for Spire.
+
+First of all, it introduces a dependency on typelevel/algebra (and
+thus on typelevel/cats-kernel). This provides immediate compatibility
+with Cats and Algebird.
+
+Second of all, Spire is now published to the org.typelevel
+organization (which was previously org.spire-math).
+
+Additions:
+ * Add GCDRing, generalized from EuclideanRing
+ * Add DivisionRing, a field without commutative multiplication
+
+Changes:
+ * Many type classes are now aliases to algebra's type classes
+ * The relationship between EuclideanRing and Gcd has changed
+ * IsReal is no longer required to be ordered, only signed
+ * Many different efficiency improvements
+
+Fixes:
+ * Instances for Complex and Quaternion are more precise
+ * Numeric[Complex[A]] is no longer provided
+ * Many bug fixes
+
+## Version 0.13.0
+
+Additions:
+ * Added Eq[Bound[A]] instance
+ * Added Interval#overlap and supporting machinery
+
+Changes:
+ * Improve Polynomial performance
+ * Support negative roots for Real
+ * Migrate to newer ScalaCheck
+
+Fixes:
+ * Fix bugs in root isolation/refinement for Algebraic
+ * Speed up convergence for Rational#limitTo
+
+## Version 0.12.0
+
+Additions:
+ * IntervalSeq and IntervalTrie added to spire-extras
+ * .toReal and .toAlgebraic methods on Rational
+
+Changes:
+ * Package restructuring and improvements
+ * Make Interval serializable
+ * Deprecate use of SecureJava.fromBytes
+
+Fixes:
+ * Numerous bug fixes
+
 ## Version 0.11.0
 
 Spire has two new core maintainers: Rüdiger Klaehn and Denis Rosset.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,14 +9,26 @@ with Cats and Algebird.
 Second of all, Spire is now published to the org.typelevel
 organization (which was previously org.spire-math).
 
-Additions:
- * Add GCDRing, generalized from EuclideanRing
- * Add DivisionRing, a field without commutative multiplication
+Additions: 
+ * Added GCDRing, part of the commutative ring hierarchy
+ * Clarified the laws of EuclideanRing
+ * Added DivisionRing, a ring in which division is possible
+   (generalization of fields to the noncommutative case;
+   used now by Spire's quaternions).
 
 Changes:
  * Many type classes are now aliases to algebra's type classes
- * The relationship between EuclideanRing and Gcd has changed
- * IsReal is no longer required to be ordered, only signed
+ * Algebra provides commutative rings and fields, but the
+   intemediate structures (GCDRing/EuclideanRing) are added
+   by Spire; thus Spire Field differs from algebra Field by
+   extending GCDRing and EuclideanRing.
+ * The EuclidenRing operations for Field have been corrected;
+   in particular, Float, Double no longer perform truncated division
+   but a /~ b = 0 for nonzero b, as a can always be divided by b in a
+   field.
+ * Signed now extends Order, thus IsReal only extends Signed.
+ * IsReal has been replaced by Signed for some operations in
+   e.g. Complex, making them more precise/general.
  * Many different efficiency improvements
 
 Fixes:

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -171,7 +171,7 @@ Here's a brief description of some of the most common properties:
 In some cases the operator names are different (e.g. `+`, `*`) but the
 properties themselves remain the same.
 
-### Eq
+#### Eq
 
 Spire provides an `Eq[A]` type class to represent type-safe
 equality. This allows us to talk about types for which there isn't a
@@ -194,7 +194,7 @@ The anti-symmetry property may seem confusing. The idea is that if `a === b`
 then `a` and `b` must be substitutable for each other, such that for any
 expression `f(x)`, `f(a) === f(b)`.
 
-### Order
+#### Order
 
 Total orderings in Spire are supported by the `Order[A]` type
 class. Unlike other ordering type classes
@@ -234,7 +234,25 @@ numbers, which breaks *O2*.  In these cases, users will need to be
 aware of the risks and limit their use to situations where the
 particular law is not needed.
 
-### PartialOrder
+#### Signed
+
+Translation-invariant total orders are captured by the `Signed[A]` type class. In
+general, the type `A` is equipped with a commutative additive operation `+` and a
+zero element `0` (see the definition of commutative rings below). The following
+laws hold:
+
+ * if `a <= b` then `a + c <= b + c` (linear order),
+ * `signum(x) = -1` if `x < 0`, `signum(x) = 1` if `x > 0`, `signum(x) = 0` otherwise.
+
+If the type `A` is equipped with negative elements `-x`, then we have:
+
+ * `abs(x) = -x` if `x < 0`, or `x` otherwise,
+
+The above laws imply:
+
+ * `abs(a + b) <= abs(a) + abs(b)`
+
+#### PartialOrder
 
 Partial orderings in Spire are supported by the `PartialOrder[A]` type class.
 Its implementation differs from `scala.math.PartialOrdering` in two features: `PartialOrder`
@@ -330,13 +348,38 @@ inheritance:
 
 Rings also provide a `pow` method (`**`) for doing repeated multiplication.
 
+#### Commutative ring hierarchy
+
+Commutative rings (also called domains in the literature) have a rich
+structure.
+
+Spire focuses on the structures relevant for computational algebra
+(GCD rings, Euclidean rings and fields).
+
+ * `GCDRing[A]` extends `CRing[A]`
+ * `EuclideanRing[A]` extends `GCDRing[A]`
+ * `spire.Field[A]` extends` algebra.Field[A]` with `EuclideanRing[A]`
+
+#### GCDRings
+
+GCD rings define two operations:
+
+ * `gcd` (`a gcd b`) find the greatest common divisor of `a` and `b`.
+ * `lcm` (`a lcm b`) find the lowest common multiple of `a` and `b`.
+ 
+ obeying the following law:
+ 
+ * `d * m === a * b` for `d = gcd(a, b)` and `m = lcm(a, b)`.
+ 
+Note that the gcd is defined up to a divisible element (unit);
+in particular, its sign 
+
 #### EuclideanRings
 
 Spire supports euclidean domains (called `EuclideanRing[A]`). A
 euclidean domain is a commutative ring (`CRing[A]`) that also supports
-euclidean division (e.g. floor division or integer division). This
-structure generalizes many useful properties of the integers (for
-instance, quotients and remainders, and greatest common divisors).
+euclidean division. This structure generalizes many useful properties 
+of the integers (for instance, quotients and remainders).
 
 Formally, euclidean domains have a *euclidean function* f such that
 for any `x` and `y` in `A`, if `y` is nonzero, then there are `q` and
@@ -346,13 +389,16 @@ function.
 
 Spire's `EuclideanRing[A]` supports the following operations:
 
- * `quot` (`a /~ b`) finding the quotient (often integer division).
+ * `quot` (`a /~ b`) finding the quotient.
  * `mod` (`a % b`) the remainder from the quotient operation.
  * `quotmod` (`a /% b`) combines `quot` and `mod` into one operation.
- * `gcd` (`a gcd b`) find the greatest common divisor of `a` and `b`.
- * `lcm` (`a lcm b`) find the lowest common multiple of `a` and `b`.
 
 Spire requires that `b * (a /~ b) + (a % b)` is equivalent to `a`.
+
+On integers, Euclidean quotient and remainder corresponds to
+truncated division; however, the sign of the result is a matter
+of convention. On rational (or floating-point) numbers, `a /~ b = a / b`
+and `a % b = 0` by definition.
 
 #### Fields
 

--- a/README.md
+++ b/README.md
@@ -52,17 +52,20 @@ Concerns or issues can be sent to any of Spire's maintainers, or to the
 
 ### Set up
 
-Spire is currently available for Scala 2.10 and 2.11 (and supports
-scala-js for both versions).
+Spire is currently available for Scala 2.10, 2.11, and 2.12, for the
+JVM and JS platforms.
 
 To get started with SBT, simply add the following to your `build.sbt` file:
 
 ```
-libraryDependencies += "org.spire-math" %% "spire" % "0.13.0"
+libraryDependencies += "org.spire-math" %% "spire" % "0.14.0"
 ```
 
+(Previous to 0.14.0, Spire was published under *org.spire-math*
+instead of *org.typelevel*.)
+
 For Maven instructions, and to download the jars directly, visit the
-[Central Maven repository](http://search.maven.org/#artifactdetails%7Corg.spire-math%7Cspire_2.11%7C0.11.0%7Cjar).
+[Central Maven repository](http://search.maven.org/#artifactdetails%7Corg.spire-math%7Cspire_2.11%7C0.14.0%7Cjar).
 
 Here is a list of all of Spire's modules:
 
@@ -70,6 +73,10 @@ Here is a list of all of Spire's modules:
  * `spire`: the core Spire library, the types and type classes
  * `spire-laws`: optional support for law-checking and testing
  * `spire-extras`: extra types which are more specific or esoteric
+
+Spire depends on [typelevel/algebra](https://github.com/typelevel/algebra)
+and uses this project to interoperate with [Cats](https://github.com/typelevel/cats) and
+[Algebird](https://github.com/twitter/algebird).
 
 ### Playing Around
 
@@ -541,7 +548,7 @@ measure relative as well as absolute performance.
 Code is offered as-is, with no implied warranty of any kind. Comments,
 criticisms, and/or praise are welcome, especially from numerical analysts! ;)
 
-Copyright 2011-2015 Erik Osheim, Tom Switzer
+Copyright 2011-2017 Erik Osheim, Tom Switzer
 
 A full list of contributors can be found in [AUTHORS.md](AUTHORS.md).
 


### PR DESCRIPTION
This primarily updates the version number used in the README, and adds (very
terse) release notes for 0.12, 0.13, and 0.14.

We still need to update the GUIDE and README with new types and changes, but
this is a start.