### PR TITLE
[READY] Tests of primitive types with limited range

### DIFF
--- a/core/shared/src/main/scala/spire/math/Integral.scala
+++ b/core/shared/src/main/scala/spire/math/Integral.scala
@@ -4,6 +4,7 @@ package math
 import spire.algebra.{EuclideanRing, IsReal}
 import spire.std._
 
+/** Integral number types, where `/` is truncated division. */
 trait Integral[@sp(Int,Long) A] extends Any
     with EuclideanRing[A]
     with ConvertableFrom[A]
@@ -11,6 +12,8 @@ trait Integral[@sp(Int,Long) A] extends Any
     with IsReal[A]
 
 object Integral {
+  implicit final val ByteIsIntegral = new ByteIsIntegral
+  implicit final val ShortIsIntegral = new ShortIsIntegral
   implicit final val IntIsIntegral = new IntIsIntegral
   implicit final val LongIsIntegral = new LongIsIntegral
   implicit final val BigIntIsIntegral = new BigIntIsIntegral
@@ -33,6 +36,30 @@ class IntegralOps[A](lhs: A)(implicit ev: Integral[A]) {
   def ! : BigInt = spire.math.fact(coerce(lhs))
 
   def choose(rhs: A): BigInt = spire.math.choose(coerce(lhs), coerce(rhs))
+}
+
+@SerialVersionUID(0L)
+private[math] class ByteIsIntegral extends Integral[Byte] with ByteIsEuclideanRing
+    with ConvertableFromByte with ConvertableToByte with ByteIsReal with Serializable {
+  override def fromInt(n: Int): Byte = n.toByte
+  override def fromBigInt(n: BigInt): Byte = n.toByte
+  override def toDouble(n: Byte): Double = n.toDouble
+  override def toRational(n: Byte): Rational = super[ByteIsReal].toRational(n)
+  override def toAlgebraic(n: Byte): Algebraic = super[ByteIsReal].toAlgebraic(n)
+  override def toReal(n: Byte): Real = super[ByteIsReal].toReal(n)
+  override def toBigInt(n: Byte): BigInt = BigInt(n)
+}
+
+@SerialVersionUID(0L)
+private[math] class ShortIsIntegral extends Integral[Short] with ShortIsEuclideanRing
+    with ConvertableFromShort with ConvertableToShort with ShortIsReal with Serializable {
+  override def fromInt(n: Int): Short = n.toShort
+  override def fromBigInt(n: BigInt): Short = n.toShort
+  override def toDouble(n: Short): Double = n.toDouble
+  override def toRational(n: Short): Rational = super[ShortIsReal].toRational(n)
+  override def toAlgebraic(n: Short): Algebraic = super[ShortIsReal].toAlgebraic(n)
+  override def toReal(n: Short): Real = super[ShortIsReal].toReal(n)
+  override def toBigInt(n: Short): BigInt = BigInt(n)
 }
 
 @SerialVersionUID(0L)

--- a/core/shared/src/main/scala/spire/math/Natural.scala
+++ b/core/shared/src/main/scala/spire/math/Natural.scala
@@ -3,7 +3,7 @@ package math
 
 import scala.math.{ScalaNumber, ScalaNumericConversions}
 
-import spire.algebra.{IsIntegral, Order, Rig}
+import spire.algebra.{CRig, IsIntegral, Order, SignedAdditiveCMonoid}
 
 import Natural._
 
@@ -703,7 +703,7 @@ trait NaturalInstances {
     Integral, Some(Natural.zero), Some(Natural.zero), None, false, false)
 }
 
-private[math] trait NaturalIsRig extends Rig[Natural] {
+private[math] trait NaturalIsCRig extends CRig[Natural] {
   def one: Natural = Natural(1L)
   def plus(a:Natural, b:Natural): Natural = a + b
   override def pow(a:Natural, b:Int): Natural = {
@@ -725,6 +725,10 @@ private[math] trait NaturalOrder extends Order[Natural] {
   def compare(x: Natural, y: Natural): Int = x.compare(y)
 }
 
+private[math] trait NaturalSigned extends NaturalOrder with SignedAdditiveCMonoid[Natural] {
+  def abs(x: Natural): Natural = x
+}
+
 private[math] trait NaturalIsReal extends IsIntegral[Natural]
 with NaturalOrder {
   def toDouble(n: Natural): Double = n.toDouble
@@ -732,4 +736,4 @@ with NaturalOrder {
 }
 
 @SerialVersionUID(0L)
-class NaturalAlgebra extends NaturalIsRig with NaturalOrder with Serializable
+class NaturalAlgebra extends NaturalIsCRig with NaturalSigned with Serializable

--- a/core/shared/src/main/scala/spire/std/byte.scala
+++ b/core/shared/src/main/scala/spire/std/byte.scala
@@ -46,7 +46,7 @@ trait ByteIsNRoot extends NRoot[Byte] {
 }
 
 trait ByteIsSigned extends Signed[Byte] {
-  override def signum(a: Byte): Int = a
+  override def signum(a: Byte): Int = java.lang.Integer.signum(a)
   override def abs(a: Byte): Byte = (if (a < 0) -a else a).toByte
 }
 

--- a/core/shared/src/main/scala/spire/std/short.scala
+++ b/core/shared/src/main/scala/spire/std/short.scala
@@ -56,7 +56,7 @@ trait ShortOrder extends Order[Short] {
 }
 
 trait ShortIsSigned extends Signed[Short] {
-  override def signum(a: Short): Int = a
+  override def signum(a: Short): Int = java.lang.Integer.signum(a)
   override def abs(a: Short): Short = (if (a < 0) -a else a).toShort
 }
 

--- a/laws/src/main/scala/spire/laws/BaseLaws.scala
+++ b/laws/src/main/scala/spire/laws/BaseLaws.scala
@@ -21,6 +21,7 @@ trait BaseLaws[A] extends Laws {
   implicit def Equ: Eq[A]
   implicit def Arb: Arbitrary[A]
 
+  // copy of these laws in LimitedRangeLaws.scala
 
   def signed(implicit A: Signed[A]) = new SimpleRuleSet(
     name = "signed",

--- a/laws/src/main/scala/spire/laws/CombinationLaws.scala
+++ b/laws/src/main/scala/spire/laws/CombinationLaws.scala
@@ -22,6 +22,8 @@ trait CombinationLaws[A] extends BaseLaws[A] {
   implicit def Equ: Eq[A]
   implicit def Arb: Arbitrary[A]
 
+  // copy of those in LimitedRangeLaws
+
   def signedAdditiveCMonoid(implicit signedA: Signed[A], additiveCMonoidA: AdditiveCMonoid[A]) = new DefaultRuleSet(
     name = "signedAdditiveCMonoid",
     parent = Some(signed),

--- a/laws/src/main/scala/spire/laws/GroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/GroupLaws.scala
@@ -85,7 +85,7 @@ trait GroupLaws[A] extends Laws {
   )
 
 
-  // additive groups
+  // additive groups, copy in LimitedRangeLaws
 
   def additiveSemigroup(implicit A: AdditiveSemigroup[A]) = new AdditiveProperties(
     base = semigroup(A.additive),

--- a/laws/src/main/scala/spire/laws/LimitedRangeLaws.scala
+++ b/laws/src/main/scala/spire/laws/LimitedRangeLaws.scala
@@ -1,0 +1,324 @@
+package spire
+package laws
+
+import spire.algebra._
+import spire.math.{Integral, NumberTag}
+import spire.implicits._
+
+import org.typelevel.discipline.{Laws, Predicate}
+
+import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Prop._
+
+object LimitedRangeLaws {
+  // Integral is 
+  def apply[A:Eq:Arbitrary:Integral:NumberTag](implicit _pred: Predicate[A]) = new LimitedRangeLaws[A] {
+    def Equ = Eq[A]
+    def Arb = implicitly[Arbitrary[A]]
+    def Tag = NumberTag[A]
+    def Itg = Integral[A]
+    def pred = _pred
+  }
+}
+
+
+
+trait LimitedRangeSyntax[A] {
+
+  implicit def Itg: Integral[A]
+  implicit def Tag: NumberTag[A]
+
+  trait SeqAdapter[S] extends Function1[S, Seq[BigInt]]
+
+  object SeqAdapter {
+
+    def apply[S](implicit ev: SeqAdapter[S]): SeqAdapter[S] = ev
+
+    implicit object seq extends SeqAdapter[Seq[BigInt]] {
+      def apply(s: Seq[BigInt]) = s
+    }
+
+    implicit object bigInt extends SeqAdapter[BigInt] {
+      def apply(b: BigInt) = Seq(b)
+    }
+
+    implicit object tuple2 extends SeqAdapter[(BigInt, BigInt)] {
+      def apply(b: (BigInt, BigInt)) = Seq(b._1, b._2)
+    }
+
+    implicit object tuple3 extends SeqAdapter[(BigInt, BigInt, BigInt)] {
+      def apply(b: (BigInt, BigInt, BigInt)) = Seq(b._1, b._2, b._3)
+    }
+
+    implicit object tuple4 extends SeqAdapter[(BigInt, BigInt, BigInt, BigInt)] {
+      def apply(b: (BigInt, BigInt, BigInt, BigInt)) = Seq(b._1, b._2, b._3, b._4)
+    }
+
+  }
+
+  def isInRange[S:SeqAdapter](s: S) = SeqAdapter[S].apply(s).forall(isBigIntInRange)
+
+  def isBigIntInRange(y: BigInt): Boolean = {
+    Tag.hasMinValue.fold(true)(minVal => Itg.toBigInt(minVal) <= y) &&
+    Tag.hasMaxValue.fold(true)(maxVal => y <= Itg.toBigInt(maxVal))
+  }
+
+  def inRange[S:SeqAdapter](x1: A)(f: BigInt => S): Boolean =
+    isInRange(f(Itg.toBigInt(x1)))
+
+  def inRange[S:SeqAdapter](x1: A, x2: A)(f: (BigInt, BigInt) => S): Boolean =
+    isInRange(f(Itg.toBigInt(x1), Itg.toBigInt(x2)))
+
+  def inRange[S:SeqAdapter](x1: A, x2: A, x3: A)(f: (BigInt, BigInt, BigInt) => S): Boolean =
+    isInRange(f(Itg.toBigInt(x1), Itg.toBigInt(x2), Itg.toBigInt(x3)))
+
+}
+
+/** Shadows tests from other Laws traits by allowing the property test only when the
+  * intermediate results are in the range of the tested type. 
+  */
+trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
+
+  implicit override def Itg: Integral[A]
+  implicit def Equ: Eq[A]
+  implicit def Arb: Arbitrary[A]
+
+  def pred: Predicate[A]
+
+  // BaseLaws
+
+  def signed(implicit A: Signed[A]) = new SimpleRuleSet(
+    name = "signed",
+    "abs non-negative" → forAll((x: A) =>
+      inRange(x)(x1 => Seq(x1.abs)) ==>
+        (x.abs.sign != Sign.Negative)
+    ),
+    "signum returns -1/0/1" → forAll((x: A) =>
+      x.signum.abs <= 1
+    ),
+    "signum is sign.toInt" → forAll((x: A) =>
+      x.signum == x.sign.toInt
+    )
+  )
+
+  def signedAdditiveCMonoid(implicit signedA: Signed[A], additiveCMonoidA: AdditiveCMonoid[A]) = new DefaultRuleSet(
+    name = "signedAdditiveCMonoid",
+    parent = Some(signed),
+    "ordered group" → forAll { (x: A, y: A, z: A) =>
+      inRange(x, y, z) { (x1, y1, z1) => (x1 + z1, y1 + z1) } ==>
+      ((x <= y) ==> (x + z <= y + z))
+    },
+    "triangle inequality" → forAll { (x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => (x1.abs + y1.abs) } ==>
+      ((x + y).abs <= x.abs + y.abs)
+    }
+  )
+
+  def signedAdditiveAbGroup(implicit signedA: Signed[A], additiveAbGroupA: AdditiveAbGroup[A]) = new DefaultRuleSet(
+    name = "signedAdditiveAbGroup",
+    parent = Some(signedAdditiveCMonoid),
+    "abs(x) equals abs(-x)" → forAll { (x: A) =>
+      inRange(x) { y => y.abs } ==>
+      (x.abs === (-x).abs)
+    }
+  )
+
+  def signedGCDRing(implicit signedA: Signed[A], gcdRingA: GCDRing[A]) = new DefaultRuleSet(
+    name = "signedGCDRing",
+    parent = Some(signedAdditiveAbGroup),
+    "gcd(x, y) >= 0" → forAll { (x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => x1.gcd(y1) } ==>
+      ((x gcd y).signum >= 0)
+    },
+    "gcd(x, 1) === 1" → forAll { (x: A) =>
+      x.gcd(Ring[A].one) === Ring[A].one
+    },
+    "gcd(x, 0) === abs(x)" → forAll { (x: A) =>
+      inRange(x) { y => y.abs } ==>
+      (x.gcd(Ring[A].zero) === Signed[A].abs(x))
+    },
+    "lcm(x, 1) === x" → forAll { (x: A) =>
+      inRange(x) { y => y.abs } ==>
+      (x.lcm(Ring[A].one) === x)
+    }
+  )
+
+  def additiveCSemigroup(implicit A: AdditiveSemigroup[A]) = new DefaultRuleSet(
+    name = "additiveCSemigroup",
+    parent = None,
+    "associative +" → forAll((x: A, y: A, z: A) =>
+      inRange(x, y, z) { (x1, y1, z1) => (x1 + y1, y1 + z1, x1 + y1 + z1) } ==>
+        (((x + y) + z) === (x + (y + z)))
+    ),
+    "commutative +" → forAll((x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => x1 + y1 } ==>
+        ((x + y) === (y + x))
+    ),
+    "sumN(a, 1) === a" → forAll((a: A) =>
+      A.sumN(a, 1) === a
+    ),
+    "sumN(a, 2) === a + a" → forAll((a: A) =>
+      inRange(a) { a1 => a1 + a1 } ==>
+        (A.sumN(a, 2) === (a + a))
+    )
+  )
+
+  def additiveCMonoid(implicit A: AdditiveCMonoid[A]) = new DefaultRuleSet(
+    name = "additiveCMonoid",
+    parent = Some(additiveCSemigroup),
+    "left identity +" → forAll((x: A) =>
+      (A.zero + x) === x
+    ),
+    "right identity +" → forAll((x: A) =>
+      (x + A.zero) === x
+    ),
+    "sumN(a, 0) === 0" → forAll((a: A) =>
+      A.sumN(a, 0) === A.zero
+    ),
+    "sum(Nil) === 0" → forAll((a: A) =>
+      A.sum(Nil) === A.zero
+    ),
+    "isZero" → forAll((a: A) =>
+      a.isZero === (a === A.zero)
+    )
+  )
+
+  def additiveAbGroup(implicit A: AdditiveGroup[A]) = new DefaultRuleSet(
+    name = "additiveAbGroup",
+    parent = Some(additiveCMonoid),
+    "minus consistent" → forAll((x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => (x1 - y1, -y1) } ==>
+        ((x - y) === (x + (-y)))
+    ),
+    "left inverse +" → forAll((x: A) =>
+      inRange(x) { x1 => -x1 } ==>
+        (A.zero === ((-x) + x))
+    ),
+    "right inverse +" → forAll((x: A) =>
+      inRange(x) { x1 => -x1 } ==>
+        (A.zero === (x + (-x)))
+    )
+  )
+
+  def multiplicativeCSemigroup(implicit A: MultiplicativeSemigroup[A]) = new DefaultRuleSet(
+    name = "multiplicativeCSemigroup",
+    parent = None,
+    "associative *" → forAll((x: A, y: A, z: A) =>
+      inRange(x, y, z) { (x1, y1, z1) => (x1 * y1, y1 * z1, x1 * y1 * z1) } ==>
+        (((x * y) * z) === (x * (y * z)))
+    ),
+    "commutative *" → forAll((x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => x1 * y1 } ==>
+        ((x * y) === (y * x))
+    ),
+    "pow(a, 1) === a" → forAll((a: A) =>
+      A.pow(a, 1) === a
+    ),
+    "pow(a, 2) === a + a" → forAll((a: A) =>
+      inRange(a) { a1 => a1 * a1 } ==>
+        (A.pow(a, 2) === (a * a))
+    )
+  )
+
+  def multiplicativeCMonoid(implicit A: MultiplicativeCMonoid[A]) = new DefaultRuleSet(
+    name = "multiplicativeCMonoid",
+    parent = Some(multiplicativeCSemigroup),
+    "left identity *" → forAll((x: A) =>
+      (A.one * x) === x
+    ),
+    "right identity *" → forAll((x: A) =>
+      (x * A.one) === x
+    ),
+    "pow(a, 0) === 0" → forAll((a: A) =>
+      A.pow(a, 0) === A.one
+    ),
+    "product(Nil) === 0" → forAll((a: A) =>
+      A.product(Nil) === A.one
+    ),
+    "isOne" → forAll((a: A) =>
+      a.isOne === (a === A.one)
+    )
+  )
+
+  def cRig(implicit A: CRig[A]) = new RingProperties(
+    name = "commutative rig",
+    parents = Seq(additiveCMonoid, multiplicativeCMonoid),
+    "distributive" → forAll((x: A, y: A, z: A) =>
+      inRange(x, y, z) { (x1, y1, z1) => (x1 * (y1 + z1), x1 * y1, x1 * z1) } ==>
+        ((x * (y + z) === (x * y + x * z)) && (((x + y) * z) === (x * z + y * z)))
+    ),
+    "pow" → forAll((x: A) =>
+      inRange(x) { x1 => (x1 * x1, x1 * x1 * x1) } ==>
+        (((x pow 1) === x) && ((x pow 2) === x * x) && ((x pow 3) === x * x * x))
+    )
+  )
+
+  def cRing(implicit A: CRing[A]) = new RingProperties(
+    name = "commutative ring",
+    parents = Seq(cRig, additiveCMonoid, multiplicativeCMonoid)
+  )
+
+  def gcdRing(implicit A: GCDRing[A]) = new RingProperties(
+    name = "gcd domain",
+    parents = Seq(cRing),
+    "gcd/lcm" → forAll { (x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => x1 * y1 } ==> {
+        val d = x gcd y
+        val m = x lcm y
+        x * y === d * m
+      }
+    },
+    "gcd is commutative" → forAll { (x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => (x1 gcd y1) } ==>
+      ((x gcd y) === (y gcd x))
+    },
+    "lcm is commutative" → forAll { (x: A, y: A) =>
+      inRange(x, y) { (x1, y1) => (x1 lcm y1) } ==>
+      ((x lcm y) === (y lcm x))
+    },
+    "gcd(0, 0)" → ((A.zero gcd A.zero) === A.zero),
+    "lcm(0, 0) === 0" → ((A.zero lcm A.zero) === A.zero),
+    "lcm(x, 0) === 0" → forAll { (x: A) => (x lcm A.zero) === A.zero }
+  )
+
+  def euclideanRing(implicit A: EuclideanRing[A]) = new RingProperties(
+    name = "euclidean ring",
+    parents = Seq(gcdRing),
+    "euclidean division rule" → forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val (q, r) = x /% y
+        x === (y * q + r)
+      }
+    },
+    "equot" → forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        (x /% y)._1 === (x /~ y)
+      }
+    },
+    "emod" → forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        (x /% y)._2 === (x % y)
+      }
+    },
+    "euclidean function" → forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val (q, r) = x /% y
+        r.isZero || (r.euclideanFunction < y.euclideanFunction)
+      }
+    },
+    "submultiplicative function" → forAll { (x: A, y: A) =>
+      (pred(x) && pred(y) && inRange(x, y) { (x1, y1) => (x1 * y1) }) ==> {
+        x.euclideanFunction <= (x * y).euclideanFunction
+      }
+    }
+  )
+
+  class RingProperties(
+    val name: String,
+    val parents: Seq[RuleSet],
+    val props: (String, Prop)*
+  ) extends RuleSet {
+    def bases = Nil
+  }
+
+}

--- a/laws/src/main/scala/spire/laws/LimitedRangeLaws.scala
+++ b/laws/src/main/scala/spire/laws/LimitedRangeLaws.scala
@@ -11,7 +11,7 @@ import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop._
 
 object LimitedRangeLaws {
-  // Integral is 
+
   def apply[A:Eq:Arbitrary:Integral:NumberTag](implicit _pred: Predicate[A]) = new LimitedRangeLaws[A] {
     def Equ = Eq[A]
     def Arb = implicitly[Arbitrary[A]]
@@ -21,58 +21,110 @@ object LimitedRangeLaws {
   }
 }
 
-
-
 trait LimitedRangeSyntax[A] {
 
+  implicit def Arb: Arbitrary[A]
   implicit def Itg: Integral[A]
   implicit def Tag: NumberTag[A]
 
-  trait SeqAdapter[S] extends Function1[S, Seq[BigInt]]
-
-  object SeqAdapter {
-
-    def apply[S](implicit ev: SeqAdapter[S]): SeqAdapter[S] = ev
-
-    implicit object seq extends SeqAdapter[Seq[BigInt]] {
-      def apply(s: Seq[BigInt]) = s
-    }
-
-    implicit object bigInt extends SeqAdapter[BigInt] {
-      def apply(b: BigInt) = Seq(b)
-    }
-
-    implicit object tuple2 extends SeqAdapter[(BigInt, BigInt)] {
-      def apply(b: (BigInt, BigInt)) = Seq(b._1, b._2)
-    }
-
-    implicit object tuple3 extends SeqAdapter[(BigInt, BigInt, BigInt)] {
-      def apply(b: (BigInt, BigInt, BigInt)) = Seq(b._1, b._2, b._3)
-    }
-
-    implicit object tuple4 extends SeqAdapter[(BigInt, BigInt, BigInt, BigInt)] {
-      def apply(b: (BigInt, BigInt, BigInt, BigInt)) = Seq(b._1, b._2, b._3, b._4)
-    }
-
-  }
-
-  def isInRange[S:SeqAdapter](s: S) = SeqAdapter[S].apply(s).forall(isBigIntInRange)
-
-  def isBigIntInRange(y: BigInt): Boolean = {
+  def inRange(y: BigInt): Boolean = {
     Tag.hasMinValue.fold(true)(minVal => Itg.toBigInt(minVal) <= y) &&
     Tag.hasMaxValue.fold(true)(maxVal => y <= Itg.toBigInt(maxVal))
   }
 
-  def inRange[S:SeqAdapter](x1: A)(f: BigInt => S): Boolean =
-    isInRange(f(Itg.toBigInt(x1)))
+  trait RangeCheck[S] {
+    def check[B](b: B)(f: B => S): Boolean
+  }
 
-  def inRange[S:SeqAdapter](x1: A, x2: A)(f: (BigInt, BigInt) => S): Boolean =
-    isInRange(f(Itg.toBigInt(x1), Itg.toBigInt(x2)))
+  object RangeCheck {
 
-  def inRange[S:SeqAdapter](x1: A, x2: A, x3: A)(f: (BigInt, BigInt, BigInt) => S): Boolean =
-    isInRange(f(Itg.toBigInt(x1), Itg.toBigInt(x2), Itg.toBigInt(x3)))
+    def apply[S](implicit ev: RangeCheck[S]): RangeCheck[S] = ev
+
+    implicit object seq extends RangeCheck[Seq[BigInt]] {
+      def check[B](b: B)(f: B => Seq[BigInt]) = f(b).forall(inRange)
+    }
+
+    implicit object bigInt extends RangeCheck[BigInt] {
+      def check[B](b: B)(f: B => BigInt) = inRange(f(b))
+    }
+
+    implicit object tuple2 extends RangeCheck[(BigInt, BigInt)] {
+      def check[B](b: B)(f: B => (BigInt, BigInt)) = {
+        val (b1, b2) = f(b)
+        inRange(b1) && inRange(b2)
+      }
+    }
+
+    implicit object tuple3 extends RangeCheck[(BigInt, BigInt, BigInt)] {
+      def check[B](b: B)(f: B => (BigInt, BigInt, BigInt)) = {
+        val (b1, b2, b3) = f(b)
+        inRange(b1) && inRange(b2) && inRange(b3)
+      }
+    }
+
+    implicit object tuple4 extends RangeCheck[(BigInt, BigInt, BigInt, BigInt)] {
+      def check[B](b: B)(f: B => (BigInt, BigInt, BigInt, BigInt)) = {
+        val (b1, b2, b3, b4) = f(b)
+        inRange(b1) && inRange(b2) && inRange(b3) && inRange(b4)
+      }
+    }
+
+  }
+
+  def half(a: A): A = Itg.fromBigInt(Itg.toBigInt(a) / 2)
+
+  type ToProp[X] = X => Prop
+
+  def forAllLimitedRange[S:RangeCheck, P:ToProp](checks: BigInt => S)(f: A => P): Prop = {
+    lazy val safeGen = Arb.arbitrary.map { x =>
+      @tailrec def rec(x1: A): A =
+        if (RangeCheck[S].check(Itg.toBigInt(x1))(checks)) x1 else rec(half(x1))
+      rec(x)
+    }
+    forAll(safeGen)(f)
+  }
+
+  def forAllLimitedRange[S:RangeCheck, P:ToProp](checks: (BigInt, BigInt) => S)(f: (A, A) => P)(implicit d1: DummyImplicit): Prop = {
+    lazy val safeGen = for {
+      x <- Arb.arbitrary
+      y <- Arb.arbitrary
+    } yield {
+      @tailrec def rec(x1: A, y1: A): (A, A) =
+        if (RangeCheck[S].check((Itg.toBigInt(x1), Itg.toBigInt(y1)))(checks.tupled)) (x1, y1) else rec(half(x1), half(y1))
+      rec(x, y)
+    }
+    forAll(safeGen)(f.tupled)
+  }
+
+  def forAllLimitedRange[S:RangeCheck, P:ToProp](checks: (BigInt, BigInt, BigInt) => S)(f: (A, A, A) => P)(implicit d1: DummyImplicit, d2: DummyImplicit): Prop = {
+    lazy val safeGen = for {
+      x <- Arb.arbitrary
+      y <- Arb.arbitrary
+      z <- Arb.arbitrary
+    } yield {
+      @tailrec def rec(x1: A, y1: A, z1: A): (A, A, A) =
+        if (RangeCheck[S].check((Itg.toBigInt(x1), Itg.toBigInt(y1), Itg.toBigInt(z1)))(checks.tupled)) (x1, y1, z1) else rec(half(x1), half(y1), half(z1))
+      rec(x, y, z)
+    }
+    forAll(safeGen)(f.tupled)
+  }
+
+  def forAllLimitedRange[S:RangeCheck, P:ToProp](checks: (BigInt, BigInt, BigInt, BigInt) => S)(f: (A, A, A, A) => P)(implicit d1: DummyImplicit, d2: DummyImplicit, d3: DummyImplicit): Prop = {
+    lazy val safeGen = for {
+      x <- Arb.arbitrary
+      y <- Arb.arbitrary
+      z <- Arb.arbitrary
+      t <- Arb.arbitrary
+    } yield {
+      @tailrec def rec(x1: A, y1: A, z1: A, t1: A): (A, A, A, A) =
+        if (RangeCheck[S].check((Itg.toBigInt(x1), Itg.toBigInt(y1), Itg.toBigInt(z1), Itg.toBigInt(t1)))(checks.tupled)) (x1, y1, z1, t1) else rec(half(x1), half(y1), half(z1), half(t1))
+      rec(x, y, z, t)
+    }
+    forAll(safeGen)(f.tupled)
+  }
 
 }
+
 
 /** Shadows tests from other Laws traits by allowing the property test only when the
   * intermediate results are in the range of the tested type. 
@@ -81,7 +133,6 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
 
   implicit override def Itg: Integral[A]
   implicit def Equ: Eq[A]
-  implicit def Arb: Arbitrary[A]
 
   def pred: Predicate[A]
 
@@ -89,9 +140,8 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
 
   def signed(implicit A: Signed[A]) = new SimpleRuleSet(
     name = "signed",
-    "abs non-negative" → forAll((x: A) =>
-      inRange(x)(x1 => Seq(x1.abs)) ==>
-        (x.abs.sign != Sign.Negative)
+    "abs non-negative" → forAllLimitedRange(_.abs)( (x: A) =>
+      (x.abs.sign != Sign.Negative)
     ),
     "signum returns -1/0/1" → forAll((x: A) =>
       x.signum.abs <= 1
@@ -104,62 +154,53 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
   def signedAdditiveCMonoid(implicit signedA: Signed[A], additiveCMonoidA: AdditiveCMonoid[A]) = new DefaultRuleSet(
     name = "signedAdditiveCMonoid",
     parent = Some(signed),
-    "ordered group" → forAll { (x: A, y: A, z: A) =>
-      inRange(x, y, z) { (x1, y1, z1) => (x1 + z1, y1 + z1) } ==>
-      ((x <= y) ==> (x + z <= y + z))
-    },
-    "triangle inequality" → forAll { (x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => (x1.abs + y1.abs) } ==>
-      ((x + y).abs <= x.abs + y.abs)
-    }
+    "ordered group" → forAllLimitedRange( (x1, y1, z1) => (x1 + z1, y1 + z1) )( (x: A, y: A, z: A) =>
+      (x <= y) ==> (x + z <= y + z)
+    ),
+    "triangle inequality" → forAllLimitedRange( (x1, y1) => (x1.abs + y1.abs) )( (x: A, y: A) =>
+      (x + y).abs <= x.abs + y.abs
+    )
   )
 
   def signedAdditiveAbGroup(implicit signedA: Signed[A], additiveAbGroupA: AdditiveAbGroup[A]) = new DefaultRuleSet(
     name = "signedAdditiveAbGroup",
     parent = Some(signedAdditiveCMonoid),
-    "abs(x) equals abs(-x)" → forAll { (x: A) =>
-      inRange(x) { y => y.abs } ==>
-      (x.abs === (-x).abs)
-    }
+    "abs(x) equals abs(-x)" → forAllLimitedRange(_.abs)( (x: A) =>
+      x.abs === (-x).abs
+    )
   )
 
   def signedGCDRing(implicit signedA: Signed[A], gcdRingA: GCDRing[A]) = new DefaultRuleSet(
     name = "signedGCDRing",
     parent = Some(signedAdditiveAbGroup),
-    "gcd(x, y) >= 0" → forAll { (x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => x1.gcd(y1) } ==>
-      ((x gcd y).signum >= 0)
-    },
+    "gcd(x, y) >= 0" → forAllLimitedRange( (x1, y1) => x1.gcd(y1) )( (x: A, y: A) =>
+      (x gcd y).signum >= 0
+    ),
     "gcd(x, 1) === 1" → forAll { (x: A) =>
       x.gcd(Ring[A].one) === Ring[A].one
     },
-    "gcd(x, 0) === abs(x)" → forAll { (x: A) =>
-      inRange(x) { y => y.abs } ==>
-      (x.gcd(Ring[A].zero) === Signed[A].abs(x))
-    },
-    "lcm(x, 1) === x" → forAll { (x: A) =>
-      inRange(x) { y => y.abs } ==>
-      (x.lcm(Ring[A].one) === x)
-    }
+    "gcd(x, 0) === abs(x)" → forAllLimitedRange(_.abs)( (x: A) =>
+      x.gcd(Ring[A].zero) === Signed[A].abs(x)
+    ),
+    "lcm(x, 1) === x" → forAllLimitedRange(_.abs)( (x: A) =>
+      x.lcm(Ring[A].one) === x
+    )
   )
 
   def additiveCSemigroup(implicit A: AdditiveSemigroup[A]) = new DefaultRuleSet(
     name = "additiveCSemigroup",
     parent = None,
-    "associative +" → forAll((x: A, y: A, z: A) =>
-      inRange(x, y, z) { (x1, y1, z1) => (x1 + y1, y1 + z1, x1 + y1 + z1) } ==>
-        (((x + y) + z) === (x + (y + z)))
+    "associative +" → forAllLimitedRange( (x1, y1, z1) => (x1 + y1, y1 + z1, x1 + y1 + z1) )( (x: A, y: A, z: A) =>
+      ((x + y) + z) === (x + (y + z))
     ),
-    "commutative +" → forAll((x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => x1 + y1 } ==>
-        ((x + y) === (y + x))
+    "commutative +" → forAllLimitedRange( (x1, y1) => x1 + y1 )( (x: A, y: A) =>
+      (x + y) === (y + x)
     ),
-    "sumN(a, 1) === a" → forAll((a: A) =>
+    "sumN(a, 1) === a" → forAll( (a: A) =>
       A.sumN(a, 1) === a
     ),
-    "sumN(a, 2) === a + a" → forAll((a: A) =>
-      inRange(a) { a1 => a1 + a1 } ==>
-        (A.sumN(a, 2) === (a + a))
+    "sumN(a, 2) === a + a" → forAllLimitedRange( x1 => x1 + x1)( (a: A) =>
+      A.sumN(a, 2) === (a + a)
     )
   )
 
@@ -186,37 +227,31 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
   def additiveAbGroup(implicit A: AdditiveGroup[A]) = new DefaultRuleSet(
     name = "additiveAbGroup",
     parent = Some(additiveCMonoid),
-    "minus consistent" → forAll((x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => (x1 - y1, -y1) } ==>
-        ((x - y) === (x + (-y)))
+    "minus consistent" → forAllLimitedRange( (x1, y1) => (x1 - y1, -y1) )( (x: A, y: A) =>
+      (x - y) === (x + (-y))
     ),
-    "left inverse +" → forAll((x: A) =>
-      inRange(x) { x1 => -x1 } ==>
-        (A.zero === ((-x) + x))
+    "left inverse +" → forAllLimitedRange(x1 => -x1)( (x: A) =>
+      A.zero === ((-x) + x)
     ),
-    "right inverse +" → forAll((x: A) =>
-      inRange(x) { x1 => -x1 } ==>
-        (A.zero === (x + (-x)))
+    "right inverse +" → forAllLimitedRange(x1 => -x1)( (x: A) =>
+      A.zero === (x + (-x))
     )
   )
 
   def multiplicativeCSemigroup(implicit A: MultiplicativeSemigroup[A]) = new DefaultRuleSet(
     name = "multiplicativeCSemigroup",
     parent = None,
-    "associative *" → forAll((x: A, y: A, z: A) =>
-      inRange(x, y, z) { (x1, y1, z1) => (x1 * y1, y1 * z1, x1 * y1 * z1) } ==>
-        (((x * y) * z) === (x * (y * z)))
+    "associative *" → forAllLimitedRange( (x1, y1, z1) => (x1 * y1, y1 * z1, x1 * y1 * z1) )( (x: A, y: A, z: A) =>
+      ((x * y) * z) === (x * (y * z))
     ),
-    "commutative *" → forAll((x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => x1 * y1 } ==>
-        ((x * y) === (y * x))
+    "commutative *" → forAllLimitedRange( (x1, y1) => x1 * y1 )( (x: A, y: A) =>
+      (x * y) === (y * x)
     ),
     "pow(a, 1) === a" → forAll((a: A) =>
       A.pow(a, 1) === a
     ),
-    "pow(a, 2) === a + a" → forAll((a: A) =>
-      inRange(a) { a1 => a1 * a1 } ==>
-        (A.pow(a, 2) === (a * a))
+    "pow(a, 2) === a + a" → forAllLimitedRange( x1 => x1 * x1)( (x: A) =>
+      A.pow(x, 2) === (x * x)
     )
   )
 
@@ -243,13 +278,11 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
   def cRig(implicit A: CRig[A]) = new RingProperties(
     name = "commutative rig",
     parents = Seq(additiveCMonoid, multiplicativeCMonoid),
-    "distributive" → forAll((x: A, y: A, z: A) =>
-      inRange(x, y, z) { (x1, y1, z1) => (x1 * (y1 + z1), x1 * y1, x1 * z1) } ==>
-        ((x * (y + z) === (x * y + x * z)) && (((x + y) * z) === (x * z + y * z)))
+    "distributive" → forAllLimitedRange( (x1, y1, z1) => (x1 * (y1 + z1), x1 * y1, x1 * z1) )( (x: A, y: A, z: A) =>
+      (x * (y + z) === (x * y + x * z)) && (((x + y) * z) === (x * z + y * z))
     ),
-    "pow" → forAll((x: A) =>
-      inRange(x) { x1 => (x1 * x1, x1 * x1 * x1) } ==>
-        (((x pow 1) === x) && ((x pow 2) === x * x) && ((x pow 3) === x * x * x))
+    "pow" → forAllLimitedRange( x1 => (x1 * x1, x1 * x1 * x1) )( (x: A) =>
+      ((x pow 1) === x) && ((x pow 2) === x * x) && ((x pow 3) === x * x * x)
     )
   )
 
@@ -261,20 +294,16 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
   def gcdRing(implicit A: GCDRing[A]) = new RingProperties(
     name = "gcd domain",
     parents = Seq(cRing),
-    "gcd/lcm" → forAll { (x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => x1 * y1 } ==> {
-        val d = x gcd y
-        val m = x lcm y
-        x * y === d * m
-      }
+    "gcd/lcm" → forAllLimitedRange( (x1, y1) => x1 * y1 ) { (x: A, y: A) =>
+      val d = x gcd y
+      val m = x lcm y
+      x * y === d * m
     },
-    "gcd is commutative" → forAll { (x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => (x1 gcd y1) } ==>
-      ((x gcd y) === (y gcd x))
+    "gcd is commutative" → forAllLimitedRange( (x1, y1) => (x1 gcd y1) ) { (x: A, y: A) =>
+      (x gcd y) === (y gcd x)
     },
-    "lcm is commutative" → forAll { (x: A, y: A) =>
-      inRange(x, y) { (x1, y1) => (x1 lcm y1) } ==>
-      ((x lcm y) === (y lcm x))
+    "lcm is commutative" → forAllLimitedRange( (x1, y1) => (x1 lcm y1) ) { (x: A, y: A) =>
+      (x lcm y) === (y lcm x)
     },
     "gcd(0, 0)" → ((A.zero gcd A.zero) === A.zero),
     "lcm(0, 0) === 0" → ((A.zero lcm A.zero) === A.zero),
@@ -306,8 +335,8 @@ trait LimitedRangeLaws[A] extends LimitedRangeSyntax[A] with Laws {
         r.isZero || (r.euclideanFunction < y.euclideanFunction)
       }
     },
-    "submultiplicative function" → forAll { (x: A, y: A) =>
-      (pred(x) && pred(y) && inRange(x, y) { (x1, y1) => (x1 * y1) }) ==> {
+    "submultiplicative function" → forAllLimitedRange( (x1, y1) => (x1 * y1) ) { (x: A, y: A) =>
+      (pred(x) && pred(y)) ==> {
         x.euclideanFunction <= (x * y).euclideanFunction
       }
     }

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -37,6 +37,8 @@ trait RingLaws[A] extends GroupLaws[A] {
   implicit def Equ: Eq[A] = nonZeroLaws.Equ
 
 
+  // the laws below are shadowed in LimitedRangeLaws
+
   // multiplicative groups
 
   def multiplicativeSemigroup(implicit A: MultiplicativeSemigroup[A]) = new MultiplicativeProperties(

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -56,6 +56,8 @@ class LawTests extends FunSuite with Discipline {
   checkAll("UInt",       LimitedRangeLaws[UInt].signedAdditiveCMonoid)
   checkAll("ULong",      RingLaws[ULong].cRig)
   checkAll("ULong",      LimitedRangeLaws[ULong].signedAdditiveCMonoid)
+  checkAll("Natural",    RingLaws[Natural].cRig)
+  checkAll("Natural",    CombinationLaws[Natural].signedAdditiveCMonoid)
   checkAll("SafeLong",   RingLaws[SafeLong].euclideanRing)
   checkAll("SafeLong",   CombinationLaws[SafeLong].signedGCDRing)
 

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -33,8 +33,14 @@ class LawTests extends FunSuite with Discipline {
   }
 
   // Float and Double fail these tests
-  checkAll("Int",        RingLaws[Int].cRing)
-  checkAll("Long",       RingLaws[Long].cRing)
+  checkAll("Byte",       LimitedRangeLaws[Byte].cRing)
+  checkAll("Byte",       LimitedRangeLaws[Byte].signedGCDRing)
+  checkAll("Short",      LimitedRangeLaws[Short].cRing)
+  checkAll("Short",      LimitedRangeLaws[Short].signedGCDRing)
+  checkAll("Int",        LimitedRangeLaws[Int].euclideanRing)
+  checkAll("Int",        LimitedRangeLaws[Int].signedGCDRing)
+  checkAll("Long",       LimitedRangeLaws[Long].euclideanRing)
+  checkAll("Long",       LimitedRangeLaws[Long].signedGCDRing)
   checkAll("BigInt",     RingLaws[BigInt].euclideanRing)
   checkAll("BigInt",     CombinationLaws[BigInt].signedGCDRing)
   checkAll("BigInteger", RingLaws[BigInteger].euclideanRing)

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -49,14 +49,13 @@ class LawTests extends FunSuite with Discipline {
   checkAll("Rational",   CombinationLaws[BigInt].signedGCDRing)
   checkAll("Real",       RingLaws[Real].field)
   checkAll("UByte",      RingLaws[UByte].cRig)
-  // no Integral[A] for unsigned integers. TODO.
-  //  checkAll("UByte",      LimitedRangeLaws[UByte].signedAdditiveCMonoid)
+  checkAll("UByte",      LimitedRangeLaws[UByte].signedAdditiveCMonoid)
   checkAll("UShort",     RingLaws[UShort].cRig)
-  //  checkAll("UShort",     LimitedRangeLaws[UShort].signedAdditiveCMonoid)
+  checkAll("UShort",     LimitedRangeLaws[UShort].signedAdditiveCMonoid)
   checkAll("UInt",       RingLaws[UInt].cRig)
-  //  checkAll("UInt",       LimitedRangeLaws[UInt].signedAdditiveCMonoid)
+  checkAll("UInt",       LimitedRangeLaws[UInt].signedAdditiveCMonoid)
   checkAll("ULong",      RingLaws[ULong].cRig)
-  //  checkAll("ULong",      LimitedRangeLaws[ULong].signedAdditiveCMonoid)
+  checkAll("ULong",      LimitedRangeLaws[ULong].signedAdditiveCMonoid)
   checkAll("SafeLong",   RingLaws[SafeLong].euclideanRing)
   checkAll("SafeLong",   CombinationLaws[SafeLong].signedGCDRing)
 

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -49,9 +49,14 @@ class LawTests extends FunSuite with Discipline {
   checkAll("Rational",   CombinationLaws[BigInt].signedGCDRing)
   checkAll("Real",       RingLaws[Real].field)
   checkAll("UByte",      RingLaws[UByte].cRig)
+  // no Integral[A] for unsigned integers. TODO.
+  //  checkAll("UByte",      LimitedRangeLaws[UByte].signedAdditiveCMonoid)
   checkAll("UShort",     RingLaws[UShort].cRig)
+  //  checkAll("UShort",     LimitedRangeLaws[UShort].signedAdditiveCMonoid)
   checkAll("UInt",       RingLaws[UInt].cRig)
+  //  checkAll("UInt",       LimitedRangeLaws[UInt].signedAdditiveCMonoid)
   checkAll("ULong",      RingLaws[ULong].cRig)
+  //  checkAll("ULong",      LimitedRangeLaws[ULong].signedAdditiveCMonoid)
   checkAll("SafeLong",   RingLaws[SafeLong].euclideanRing)
   checkAll("SafeLong",   CombinationLaws[SafeLong].signedGCDRing)
 


### PR DESCRIPTION
Supercedes #634, based on new master (PR easier to read)

This implements law tests for types that approximate an arbitrary range type.

For example, Byte/Short/Int/Long approximate a BigInt, and their operations are defined as long as the range of the primitive type is not exceeded. This PR adds specialized versions of the law tests that verify that the randomized checking occurs within the range of the primitive type.