### PR TITLE
[READY] Identification and correction of the (transient) bug in sparse polynomial handling.

### DIFF
--- a/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/shared/src/main/scala/spire/math/poly/PolySparse.scala
@@ -263,8 +263,10 @@ object PolySparse {
         val e0 = exp(j0)
         val c0 = coeff(j0)
         if (e != e0) {
-          expBldr += e
-          coeffBldr += c
+          if (!c.isZero) {
+            expBldr += e
+            coeffBldr += c
+          }
           c = c0
         } else {
           c += c0
@@ -273,8 +275,10 @@ object PolySparse {
         j = j0
         i += 1
       }
-      expBldr += e
-      coeffBldr += c
+      if (!c.isZero) {
+        expBldr += e
+        coeffBldr += c
+      }
       val poly = PolySparse(expBldr.result(), coeffBldr.result())
       poly
     }

--- a/tests/src/test/scala/spire/math/PolynomialTest.scala
+++ b/tests/src/test/scala/spire/math/PolynomialTest.scala
@@ -274,6 +274,11 @@ class PolynomialCheck extends PropSpec with Matchers with GeneratorDrivenPropert
 
 class PolynomialTest extends FunSuite {
 
+  test("Polynomial(List(Term(-1, 4), List(1, 4))).toSparse should be equal to Polynomial.zero") {
+    val ts = Term(r"-1", 4) :: Term(r"1", 4) :: Nil
+    assert(Polynomial(ts).toSparse == Polynomial.zero[Rational])
+  }
+
   test("Polynomial(List(Term(0, 0), Term(0, 0))) should not throw") {
     val ts = Term(r"0", 0) :: Term(r"0", 0) :: Nil
     assert(Polynomial(ts) == Polynomial.zero[Rational])


### PR DESCRIPTION
The bug appeared when constructing a sparse polynomial from a list of Term, and a pair of terms of the form `(-a, n)` and `(a, n)` was present, corresponding to -a x^n + a x^n = 0. The resulting coefficient = 0 was not filtered out and led to bugs elsewhere, as an invariant of both sparse and dense polynomial is that no coefficient present should be equal to 0.

Note: I had to pump ScalaCheck `minSucessful` to 5000 for the bug to be reproducible.