### PR TITLE
fix Complex.{abs,norm} for negative reals

### DIFF
--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -404,10 +404,11 @@ package object math {
     (implicit f: Field[A], n: NRoot[A], s: Signed[A]): A = {
     import spire.implicits._
     def abs(n: A): A = if (n < f.zero) -n else n
-    if (x == f.zero) abs(y)
-    else if (y == f.zero) abs(x)
-    else if (x > y) abs(x) * (1 + (y/x)**2).sqrt
-    else abs(y) * (1 + (x/y)**2).sqrt
+    val (ax, ay) = (abs(x), abs(y))
+    if (x == f.zero) ay
+    else if (y == f.zero) ax
+    else if (ax > ay) ax * (1 + (y/x)**2).sqrt
+    else ay * (1 + (x/y)**2).sqrt
   }
 
   // BigInt

--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -404,7 +404,8 @@ package object math {
     (implicit f: Field[A], n: NRoot[A], s: Signed[A]): A = {
     import spire.implicits._
     def abs(n: A): A = if (n < f.zero) -n else n
-    val (ax, ay) = (abs(x), abs(y))
+    val ax = abs(x)
+    val ay = abs(y)
     if (x == f.zero) ay
     else if (y == f.zero) ax
     else if (ax > ay) ax * (1 + (y/x)**2).sqrt

--- a/core/shared/src/main/scala/spire/math/package.scala
+++ b/core/shared/src/main/scala/spire/math/package.scala
@@ -404,8 +404,8 @@ package object math {
     (implicit f: Field[A], n: NRoot[A], s: Signed[A]): A = {
     import spire.implicits._
     def abs(n: A): A = if (n < f.zero) -n else n
-    if (x == f.zero) y
-    else if (y == f.zero) x
+    if (x == f.zero) abs(y)
+    else if (y == f.zero) abs(x)
     else if (x > y) abs(x) * (1 + (y/x)**2).sqrt
     else abs(y) * (1 + (x/y)**2).sqrt
   }

--- a/tests/src/test/scala/spire/math/PackageTest.scala
+++ b/tests/src/test/scala/spire/math/PackageTest.scala
@@ -45,5 +45,11 @@ class PackageTest extends FunSuite {
     assert(hypot(4.0, 0.0) == 4.0)
     assert(hypot(0.0, 4.0) == 4.0)
     assert(hypot(0.0, 0.0) == 0.0)
+    // verify least-surprising behavior for negative inputs (relied on by Complex.abs!)
+    assert(hypot(-3.0,  4.0) == 5.0)
+    assert(hypot(-3.0, -4.0) == 5.0)
+    assert(hypot( 3.0, -4.0) == 5.0)
+    assert(hypot( 0.0, -4.0) == 4.0)
+    assert(hypot(-4.0,  0.0) == 4.0)
   }
 }


### PR DESCRIPTION
fix a bug introduced by #666: `abs` and `norm` returned negative values when one of {real,imag} was zero and the other was negative

there was discussion on #661 around whether `hypot` should assume non-negative arguments and `Complex.{norm,abs}` should correct for them before calling `hypot`, but this felt simpler and relatively downside-free