### PR TITLE
Fix limitToInt to work around commonly-occuring case. (take 2)

### DIFF
--- a/tests/src/test/scala/spire/math/RationalCheck.scala
+++ b/tests/src/test/scala/spire/math/RationalCheck.scala
@@ -87,6 +87,19 @@ class RationalCheck extends PropSpec with Matchers with GeneratorDrivenPropertyC
     }
   }
 
+  property("limitToInt does not change small Rationals") {
+    forAll { (n: Int, d: Int) =>
+      val r = Rational(n, if (d < 1) 1 else d)
+      r.limitToInt shouldBe r
+    }
+  }
+
+  property("limitToInt regression") {
+    val n = Int.MinValue
+    val r = Rational(n, 1)
+    r.limitToInt shouldBe r
+  }
+
   property("Rational.numeratorIsValidLong") { (x: Q) =>
     x.numeratorIsValidLong shouldBe x.numerator.isValidLong
   }

--- a/tests/src/test/scala/spire/math/RealCheck.scala
+++ b/tests/src/test/scala/spire/math/RealCheck.scala
@@ -240,4 +240,10 @@ class RealCheck extends PropSpec with Matchers with GeneratorDrivenPropertyCheck
   //     }
   //   }
   // }
+
+  property("x.pow(k) = x.fpow(k)") {
+    forAll { (x: Real, k: Byte) =>
+      x.pow(k & 0xff) shouldBe x.fpow(Rational(k & 0xff))
+    }
+  }
 }


### PR DESCRIPTION
Previously, calling Rational(3).limitToInt would invoke the
general .limitTo code which is already implicated in at
least one other bug (#393). So, this change does a very
simple check to see if limiting is even necessary before
calling into that code.

This fixes the repoted issue, namely the situation where
Rational(3).limitToInt seems to hang.

Tests are added both for the .limitToInt behavior and
also simple tests of Real#fpow.