### PR TITLE
Return BigDecimal values with better math contexts.

### DIFF
--- a/core/src/main/scala/spire/math/Algebraic.scala
+++ b/core/src/main/scala/spire/math/Algebraic.scala
@@ -275,7 +275,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    * mode. Rounding is always exact.
    */
   def toBigDecimal(scale: Int, roundingMode: RoundingMode): BigDecimal =
-    BigDecimal(roundExact(this, expr.toBigDecimal(scale + 2), scale, roundingMode))
+    new BigDecimal(roundExact(this, expr.toBigDecimal(scale + 2), scale, roundingMode), MathContext.UNLIMITED)
 
   /**
    * Relative approximation to the precision specified in `mc` with the given
@@ -344,8 +344,9 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     val adjustedApprox =
       if (newScale <= approx.scale) approx.setScale(newScale + 1, RoundingMode.DOWN)
       else approx
-    roundExact(this, adjustedApprox, newScale, roundingMode)
+    val finalApprox = roundExact(this, adjustedApprox, newScale, roundingMode)
       .round(mc) // We perform a final round, since roundExact uses scales.
+    new BigDecimal(finalApprox, mc)
   }
 
   /**
@@ -865,7 +866,6 @@ object Algebraic extends AlgebraicInstances {
 
       lazy val signum: Int = {
         val maxDigits = separationBound.decimalDigits + 1
-        val approxOnly = maxDigits > Int.MaxValue
 
         // An adaptive algorithm to find the sign. Rather than just compute
         // this number to `maxDigits` precision, we start with a smaller


### PR DESCRIPTION
This is a port of #584. On that PR, Tom said:

> Since we weren't explicitly setting the MathContext, it was using
> the default. However, by default, BigDecimal won't round the input,
> so it looked OK. However, any operations performed with this number
> as the receiver of the method would've truncated the
> result. Probably unexpectedly. Ugh... Scala's BigDecimal is such a
> mess.

This replaces https://github.com/non/spire/pull/584.