### PR TITLE
Tests for limited range types

### DIFF
--- a/laws/src/main/scala/spire/laws/CombinationLaws.scala
+++ b/laws/src/main/scala/spire/laws/CombinationLaws.scala
@@ -26,10 +26,10 @@ trait CombinationLaws[A] extends BaseLaws[A] {
     name = "signedAdditiveCMonoid",
     parent = None,
     "ordered group" → forAll { (x: A, y: A, z: A) =>
-      (x <= y) ==> (x + z <= y + z)
+      checkTrue(!(x <= y) || (x + z <= y + z)) // replaces ==>
     },
     "triangle inequality" → forAll { (x: A, y: A) =>
-      (x + y).abs <= x.abs + y.abs
+      checkTrue((x + y).abs <= x.abs + y.abs)
     }
   )
 
@@ -37,7 +37,7 @@ trait CombinationLaws[A] extends BaseLaws[A] {
     name = "signedAdditiveAbGroup",
     parent = Some(signedAdditiveCMonoid),
     "abs(x) equals abs(-x)" → forAll { (x: A) =>
-      x.abs === (-x).abs
+      x.abs <=> (-x).abs
     }
   )
 
@@ -48,10 +48,10 @@ trait CombinationLaws[A] extends BaseLaws[A] {
     name = "signedGCDRing",
     parent = Some(signedAdditiveAbGroup),
     "gcd(x, y) >= 0" → forAll { (x: A, y: A) =>
-      x.gcd(y).signum >= 0
+      checkTrue(x.gcd(y).signum >= 0)
     },
     "gcd(x, 0) === abs(x)" → forAll { (x: A) =>
-      x.gcd(Ring[A].zero) === Signed[A].abs(x)
+      x.gcd(Ring[A].zero) <=> Signed[A].abs(x)
     }
   )
 

--- a/laws/src/main/scala/spire/laws/GroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/GroupLaws.scala
@@ -27,13 +27,13 @@ trait GroupLaws[A] extends Laws {
     name = "semigroup",
     parent = None,
     "associative" → forAll((x: A, y: A, z: A) =>
-      ((x |+| y) |+| z) === (x |+| (y |+| z))
+      ((x |+| y) |+| z) <=> (x |+| (y |+| z))
     ),
     "combinen(a, 1) === a" → forAll((a: A) =>
-      A.combineN(a, 1) === a
+      A.combineN(a, 1) <=> a
     ),
     "combinen(a, 2) === a |+| a" → forAll((a: A) =>
-      A.combineN(a, 2) === (a |+| a)
+      A.combineN(a, 2) <=> (a |+| a)
     )
   )
 
@@ -41,19 +41,19 @@ trait GroupLaws[A] extends Laws {
     name = "monoid",
     parent = Some(semigroup),
     "left identity" → forAll((x: A) =>
-      (A.empty |+| x) === x
+      (A.empty |+| x) <=> x
     ),
     "right identity" → forAll((x: A) =>
-      (x |+| A.empty) === x
+      (x |+| A.empty) <=> x
     ),
     "combineN(a, 0) === id" → forAll((a: A) =>
-      A.combineN(a, 0) === A.empty
+      A.combineN(a, 0) <=> A.empty
     ),
     "combineAll(Nil) === id" → forAll((a: A) =>
-      A.combineAll(Nil) === A.empty
+      A.combineAll(Nil) <=> A.empty
     ),
     "isId" → forAll((x: A) =>
-      (x === A.empty) === (x.isEmpty)
+      (x === A.empty) <=> (x.isEmpty)
     )
   )
 
@@ -61,7 +61,7 @@ trait GroupLaws[A] extends Laws {
     name = "commutative monoid",
     parent = Some(monoid),
     "commutative" → forAll((x: A, y: A) =>
-      (x |+| y) === (y |+| x)
+      (x |+| y) <=> (y |+| x)
     )
   )
 
@@ -69,10 +69,10 @@ trait GroupLaws[A] extends Laws {
     name = "group",
     parent = Some(monoid),
     "left inverse" → forAll((x: A) =>
-      A.empty === (x.inverse |+| x)
+      A.empty <=> (x.inverse |+| x)
     ),
     "right inverse" → forAll((x: A) =>
-      A.empty === (x |+| x.inverse)
+      A.empty <=> (x |+| x.inverse)
     )
   )
 
@@ -80,7 +80,7 @@ trait GroupLaws[A] extends Laws {
     name = "abelian group",
     parent = Some(group),
     "commutative" → forAll((x: A, y: A) =>
-      (x |+| y) === (y |+| x)
+      (x |+| y) <=> (y |+| x)
     )
   )
 
@@ -91,10 +91,10 @@ trait GroupLaws[A] extends Laws {
     base = semigroup(A.additive),
     parent = None,
     "sumN(a, 1) === a" → forAll((a: A) =>
-      A.sumN(a, 1) === a
+      A.sumN(a, 1) <=> a
     ),
     "sumN(a, 2) === a + a" → forAll((a: A) =>
-      A.sumN(a, 2) === (a + a)
+      A.sumN(a, 2) <=> (a + a)
     )
   )
 
@@ -102,13 +102,13 @@ trait GroupLaws[A] extends Laws {
     base = monoid(A.additive),
     parent = Some(additiveSemigroup),
     "sumN(a, 0) === zero" → forAll((a: A) =>
-      A.sumN(a, 0) === A.zero
+      A.sumN(a, 0) <=> A.zero
     ),
     "sum(Nil) === zero" → forAll((a: A) =>
-      A.sum(Nil) === A.zero
+      A.sum(Nil) <=> A.zero
     ),
     "isZero" → forAll((a: A) =>
-      a.isZero === (a === A.zero)
+      a.isZero <=> (a === A.zero)
     )
   )
 
@@ -122,7 +122,7 @@ trait GroupLaws[A] extends Laws {
     base = group(A.additive),
     parent = Some(additiveMonoid),
     "minus consistent" → forAll((x: A, y: A) =>
-      (x - y) === (x + (-y))
+      (x - y) <=> (x + (-y))
     )
   )
 

--- a/laws/src/main/scala/spire/laws/OrderLaws.scala
+++ b/laws/src/main/scala/spire/laws/OrderLaws.scala
@@ -25,22 +25,22 @@ trait OrderLaws[A] extends Laws {
     name = "partialOrder",
     parent = None,
     "reflexitivity" → forAll((x: A) =>
-      x <= x
+      checkTrue(x <= x)
     ),
     "antisymmetry" → forAll((x: A, y: A) =>
-      (x <= y && y <= x) imp (x === y)
+      checkTrue((x <= y && y <= x) imp (x === y))
     ),
     "transitivity" → forAll((x: A, y: A, z: A) =>
-      (x <= y && y <= z) imp (x <= z)
+      checkTrue((x <= y && y <= z) imp (x <= z))
     ),
     "gteqv" → forAll((x: A, y: A) =>
-      (x <= y) === (y >= x)
+      (x <= y) <=> (y >= x)
     ),
     "lt" → forAll((x: A, y: A) =>
-      (x < y) === (x <= y && x =!= y)
+      (x < y) <=> (x <= y && x =!= y)
     ),
     "gt" → forAll((x: A, y: A) =>
-      (x < y) === (y > x)
+      (x < y) <=> (y > x)
     )
   )
 
@@ -48,7 +48,7 @@ trait OrderLaws[A] extends Laws {
     name = "order",
     parent = Some(partialOrder),
     "totality" → forAll((x: A, y: A) =>
-      x <= y || y <= x
+      checkTrue(x <= y || y <= x)
     )
   )
 
@@ -56,13 +56,13 @@ trait OrderLaws[A] extends Laws {
     name = "signed",
     parent = Some(order),
     "abs non-negative" → forAll((x: A) =>
-      x.abs.sign != Sign.Negative
+      checkTrue(x.abs.sign != Sign.Negative)
     ),
     "signum returns -1/0/1" → forAll((x: A) =>
-      x.signum.abs <= 1
+      checkTrue(x.signum.abs <= 1)
     ),
     "signum is sign.toInt" → forAll((x: A) =>
-      x.signum == x.sign.toInt
+      checkTrue(x.signum == x.sign.toInt)
     )
   )
 
@@ -70,67 +70,68 @@ trait OrderLaws[A] extends Laws {
     name = "truncatedDivision",
     parent = Some(signed),
     "division rule (tquotmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val (q, r) = x tquotmod y
         x === y * q + r
-      }
+      })
     },
     "division rule (fquotmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val (q, r) = x fquotmod y
-        x === y * q + r
-      }
+        x == y * q + r
+      })
     },
     "quotient is integer (tquot)" → forAll { (x: A, y: A) =>
-      y.isZero || (x tquot y).toBigIntOpt.nonEmpty
+      checkTrue(y.isZero || (x tquot y).toBigIntOpt.nonEmpty)
     },
     "quotient is integer (fquot)" → forAll { (x: A, y: A) =>
-      y.isZero || (x fquot y).toBigIntOpt.nonEmpty
+      checkTrue(y.isZero || (x fquot y).toBigIntOpt.nonEmpty)
     },
     "|r| < |y| (tmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val r = x tmod y
         r.abs < y.abs
-      }
+      })
     },
     "|r| < |y| (fmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val r = x fmod y
         r.abs < y.abs
-      }
+      })
     },
     "r = 0 or sign(r) = sign(x) (tmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val r = x tmod y
         r.isZero || (r.sign === x.sign)
-      }
+      })
     },
     "r = 0 or sign(r) = sign(y) (fmod)" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         val r = x fmod y
         r.isZero || (r.sign === y.sign)
-      }
+      })
     },
     "tquot" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         (x tquotmod y)._1 === (x tquot y)
-      }
+      })
     },
     "tmod" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         (x tquotmod y)._2 === (x tmod y)
-      }
+      })
     },
     "fquot" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         (x fquotmod y)._1 === (x fquot y)
-      }
+      })
     },
     "fmod" → forAll { (x: A, y: A) =>
-      y.isZero || {
+      checkTrue(y.isZero || {
         (x fquotmod y)._2 === (x fmod y)
-      }
+      })
     }
+    
   )
 
   class OrderProperties(

--- a/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -18,8 +18,8 @@ object VectorSpaceLaws {
 
 trait VectorSpaceLaws[V, A] extends Laws {
 
-  implicit def ringFromLeftModule[A](implicit V: LeftModule[_, A], ev: NoImplicit[CModule[_, A]]): Ring[A] = V.scalar
-  implicit def ringFromRightModule[A](implicit V: RightModule[_, A], ev: NoImplicit[CModule[_, A]]): Ring[A] = V.scalar
+  implicit def ringFromLeftModule(implicit V: LeftModule[V, A], ev: NoImplicit[CModule[V, A]]): Ring[A] = V.scalar
+  implicit def ringFromRightModule(implicit V: RightModule[V, A], ev: NoImplicit[CModule[V, A]]): Ring[A] = V.scalar
   implicit def cRingFromCModule(implicit V: CModule[V, A]): CRing[A] = V.scalar
 
   val scalarLaws: RingLaws[A]

--- a/laws/src/main/scala/spire/laws/package.scala
+++ b/laws/src/main/scala/spire/laws/package.scala
@@ -4,10 +4,38 @@ import spire.algebra._
 import spire.implicits._
 
 import org.scalacheck.{Prop, Properties}
+import org.scalacheck.util.Pretty
 
 import org.typelevel.discipline.Predicate
 
 package object laws {
+
+  /** Provides special syntax to use in laws catching invalid tests.
+    * 
+    * Invalid tests are those where the range of a primitive type is
+    * exceeded: in that case, the behavior is undecided with respect
+    * to the laws.
+    */
+  implicit final class EqArrow[A](lhs: => A) {
+    def <=>(rhs: => A)(implicit equ: Eq[A], pp: A => Pretty): Prop =
+      try {
+        if (Eq[A].eqv(lhs, rhs)) Prop.passed else Prop.falsified :| {
+          val lp = Pretty.pretty[A](lhs, Pretty.Params(0))
+          val rp = Pretty.pretty[A](rhs, Pretty.Params(0))
+          s"$lp is not === to $rp"
+        }
+      } catch {
+        case e: shadows.InvalidTestException => Prop.passed // TODO: or undecided?
+      }
+  }
+
+  def checkTrue(b: => Prop): Prop = {
+    try {
+      b
+    } catch {
+      case e: shadows.InvalidTestException => Prop.passed // TODO: or undecided?
+    }
+  }
 
   implicit def PredicateFromMonoid[A: Eq](implicit A: AdditiveMonoid[A]): Predicate[A] = new Predicate[A] {
     def apply(a: A) = a =!= A.zero

--- a/laws/src/main/scala/spire/laws/shadows/InvalidTestException.scala
+++ b/laws/src/main/scala/spire/laws/shadows/InvalidTestException.scala
@@ -1,0 +1,8 @@
+package spire.laws.shadows
+
+/** Exception thrown when the computation exceeds a type range.
+  * 
+  * For example, when shadowed, Byte(100) + Byte(100) will
+  * throw this.
+  */
+final class InvalidTestException extends Exception

--- a/laws/src/main/scala/spire/laws/shadows/Shadow.scala
+++ b/laws/src/main/scala/spire/laws/shadows/Shadow.scala
@@ -1,0 +1,161 @@
+package spire.laws.shadows
+
+import spire.algebra._
+import org.scalacheck.Arbitrary
+
+/** Represents a primitive value `a: A` along with its shadow `s: S`.
+  * 
+  * The shadow is a type S isomorphic to the primitive type A
+  * in the range where A is defined.
+  */
+case class Shadow[A, S](a: A, s: S)
+
+abstract class ShadowInstances0 {
+  
+  implicit def additiveCSemigroup[A:AdditiveCSemigroup,S:AdditiveCSemigroup](implicit ev: Shadowing[A, S]): AdditiveCSemigroup[Shadow[A, S]] =
+    new ShadowAdditiveCSemigroup[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+    }
+
+  implicit def multiplicativeCSemigroup[A:MultiplicativeCSemigroup,S:MultiplicativeCSemigroup](implicit ev: Shadowing[A, S]): MultiplicativeCSemigroup[Shadow[A, S]] =
+    new ShadowMultiplicativeCSemigroup[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+    }
+
+  implicit def eqInstance[A:Eq, S:Eq]: Eq[Shadow[A, S]] =
+    new ShadowEq[A, S] {
+      def A = implicitly
+      def S = implicitly
+    }
+}
+
+
+abstract class ShadowInstances1 extends ShadowInstances0 {
+
+  implicit def additiveCMonoid[A:Eq:AdditiveCMonoid,S:Eq:AdditiveCMonoid](implicit ev: Shadowing[A, S]): AdditiveCMonoid[Shadow[A, S]] =
+    new ShadowAdditiveCMonoid[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+
+  implicit def multiplicativeCMonoid[A:Eq:MultiplicativeCMonoid,S:Eq:MultiplicativeCMonoid](implicit ev: Shadowing[A, S]): MultiplicativeCMonoid[Shadow[A, S]] =
+    new ShadowMultiplicativeCMonoid[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+
+  implicit def partialOrderInstance[A:PartialOrder, S:PartialOrder]: PartialOrder[Shadow[A, S]] =
+    new ShadowPartialOrder[A, S] {
+      def A = implicitly
+      def S = implicitly
+    }
+}
+
+abstract class ShadowInstances2 extends ShadowInstances1 {
+
+  def additiveAbGroup[A:Eq:AdditiveAbGroup,S:Eq:AdditiveAbGroup](implicit ev: Shadowing[A, S]): AdditiveAbGroup[Shadow[A, S]] =
+    new ShadowAdditiveAbGroup[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+
+  implicit def orderInstance[A:Order, S:Order]: Order[Shadow[A, S]] =
+    new ShadowOrder[A, S] {
+      def A = implicitly
+      def S = implicitly
+    }
+}
+
+abstract class ShadowInstances3 extends ShadowInstances2 {
+
+  def cSemiring[A:Eq:CSemiring,S:Eq:CSemiring](implicit ev: Shadowing[A, S]): CSemiring[Shadow[A, S]] =
+    new ShadowCSemiring[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+  
+  implicit def signedInstance[A:Signed, S:Signed](implicit ev: Shadowing[A, S]): Signed[Shadow[A, S]] =
+    new ShadowSigned[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+    }
+}
+
+abstract class ShadowInstances4 extends ShadowInstances3 {
+
+  def cRig[A:Eq:CRig,S:Eq:CRig](implicit ev: Shadowing[A, S]): CRig[Shadow[A, S]] =
+    new ShadowCRig[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+
+  def cRng[A:Eq:CRng,S:Eq:CRng](implicit ev: Shadowing[A, S]): CRng[Shadow[A, S]] =
+    new ShadowCRng[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+}
+
+abstract class ShadowInstances5 extends ShadowInstances4 {
+
+  def cRing[A:Eq:CRing,S:Eq:CRing](implicit ev: Shadowing[A, S]): CRing[Shadow[A, S]] =
+    new ShadowCRing[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+}
+
+abstract class ShadowInstances6 extends ShadowInstances5 {
+
+  def gcdRing[A:Eq:GCDRing,S:Eq:GCDRing](implicit ev: Shadowing[A, S]): GCDRing[Shadow[A, S]] =
+    new ShadowGCDRing[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+}
+
+abstract class ShadowInstances7 extends ShadowInstances6 {
+  
+  def euclideanRing[A:Eq:EuclideanRing,S:Eq:EuclideanRing](implicit ev: Shadowing[A, S]): EuclideanRing[Shadow[A, S]] =
+    new ShadowEuclideanRing[A, S] {
+      val shadowing = ev
+      def A = implicitly
+      def S = implicitly
+      def eqA = implicitly
+      def eqS = implicitly
+    }
+}
+
+object Shadow extends ShadowInstances7 {
+  implicit def spireLawsArbitraryShadow[A, S](implicit A: Arbitrary[A], S: Shadowing[A, S]): Arbitrary[Shadow[A, S]] =
+    Arbitrary { A.arbitrary.map( a => Shadow(a, S.toShadow(a)) ) }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveAbGroup.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveAbGroup.scala
@@ -1,0 +1,14 @@
+package spire.laws.shadows
+
+import spire.algebra._
+
+trait ShadowAdditiveAbGroup[A, S] extends AdditiveAbGroup[Shadow[A, S]] with ShadowAdditiveCMonoid[A, S] {
+  import shadowing._
+  implicit def A: AdditiveAbGroup[A]
+  implicit def S: AdditiveAbGroup[S]
+
+  def negate(x: Shadow[A, S]): Shadow[A, S] = Shadow(A.negate(x.a), checked(S.negate(x.s)))
+
+  override def minus(x: Shadow[A, S], y: Shadow[A, S]) =
+    Shadow(A.minus(x.a, y.a), checked(S.minus(x.s, y.s)))
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveCMonoid.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveCMonoid.scala
@@ -1,0 +1,27 @@
+package spire.laws.shadows
+
+import spire.algebra.{AdditiveCMonoid, Eq}
+
+trait ShadowAdditiveCMonoid[A, S] extends AdditiveCMonoid[Shadow[A, S]] with ShadowAdditiveCSemigroup[A, S] {
+  import shadowing._
+  implicit def A: AdditiveCMonoid[A]
+  implicit def S: AdditiveCMonoid[S]
+  implicit def eqA: Eq[A]
+  implicit def eqS: Eq[S]
+
+  def zero: Shadow[A, S] = Shadow(A.zero, checked(S.zero))
+
+  override def isZero(x: Shadow[A, S])(implicit ev: Eq[Shadow[A, S]]) = {
+    val a = A.isZero(x.a)
+    val s = S.isZero(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def sum(xs: TraversableOnce[Shadow[A, S]]): Shadow[A, S] = {
+    val seq = xs.toSeq
+    val a = A.sum(seq.map(_.a))
+    val s = S.sum(seq.map(_.s))
+    Shadow(a, checked(s))
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveCSemigroup.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowAdditiveCSemigroup.scala
@@ -1,0 +1,27 @@
+package spire.laws.shadows
+
+import spire.algebra.{AdditiveCSemigroup, AdditiveSemigroup}
+
+trait ShadowAdditiveCSemigroup[A, S] extends AdditiveCSemigroup[Shadow[A, S]] {
+  implicit val shadowing: Shadowing[A, S]
+  import shadowing._
+  implicit def A: AdditiveSemigroup[A]
+  implicit def S: AdditiveSemigroup[S]
+
+  def plus(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.plus(x.a, y.a), checked(S.plus(x.s, y.s)))
+
+  override def sumN(x: Shadow[A, S], n: Int): Shadow[A, S] =
+    Shadow(A.sumN(x.a, n), checked(S.sumN(x.s, n)))
+
+  override def trySum(xs: TraversableOnce[Shadow[A, S]]): Option[Shadow[A, S]] = {
+    val seq = xs.toSeq
+    val aO = A.trySum( seq.map(_.a) )
+    val sO = S.trySum( seq.map(_.s) )
+    (aO, sO) match {
+      case (Some(a), Some(s)) => Some(Shadow(a, checked(s)))
+      case (None, None) => None
+      case _ => throw new IllegalArgumentException("Inconsistent results for trySum between primitive and shadow type")
+    }
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowCRig.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowCRig.scala
@@ -1,0 +1,9 @@
+package spire.laws.shadows
+
+import spire.algebra.CRig
+
+trait ShadowCRig[A, S] extends CRig[Shadow[A, S]]
+  with ShadowCSemiring[A, S] with ShadowMultiplicativeCMonoid[A, S] {
+  implicit def A: CRig[A]
+  implicit def S: CRig[S]
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowCRing.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowCRing.scala
@@ -1,0 +1,13 @@
+package spire.laws.shadows
+
+import spire.algebra.CRing
+
+trait ShadowCRing[A, S] extends CRing[Shadow[A, S]]
+  with ShadowCRig[A, S] with ShadowCRng[A, S] {
+  import shadowing._
+  implicit def A: CRing[A]
+  implicit def S: CRing[S]
+
+  override def fromInt(n: Int): Shadow[A, S] = Shadow(A.fromInt(n), checked(S.fromInt(n)))
+  override def fromBigInt(n: BigInt): Shadow[A, S] = Shadow(A.fromBigInt(n), checked(S.fromBigInt(n)))
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowCRng.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowCRng.scala
@@ -1,0 +1,9 @@
+package spire.laws.shadows
+
+import spire.algebra.CRng
+
+trait ShadowCRng[A, S] extends CRng[Shadow[A, S]]
+  with ShadowCSemiring[A, S] with ShadowAdditiveAbGroup[A, S] {
+  implicit def A: CRng[A]
+  implicit def S: CRng[S]
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowCSemiring.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowCSemiring.scala
@@ -1,0 +1,9 @@
+package spire.laws.shadows
+
+import spire.algebra.CSemiring
+
+trait ShadowCSemiring[A, S] extends CSemiring[Shadow[A, S]]
+  with ShadowAdditiveCMonoid[A, S] with ShadowMultiplicativeCSemigroup[A, S] {
+  implicit def A: CSemiring[A]
+  implicit def S: CSemiring[S]
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowEq.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowEq.scala
@@ -1,0 +1,22 @@
+package spire.laws.shadows
+
+import spire.algebra.Eq
+
+trait ShadowEq[A, S] extends Eq[Shadow[A, S]] {
+  implicit def A: Eq[A]
+  implicit def S: Eq[S]
+
+  override def neqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.neqv(x.a, y.a)
+    val s = S.neqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  def eqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.eqv(x.a, y.a)
+    val s = S.eqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowEuclideanRing.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowEuclideanRing.scala
@@ -1,0 +1,28 @@
+package spire.laws.shadows
+
+import spire.algebra.EuclideanRing
+
+trait ShadowEuclideanRing[A, S] extends EuclideanRing[Shadow[A, S]] with ShadowGCDRing[A, S] {
+  import shadowing._
+  implicit def A: EuclideanRing[A]
+  implicit def S: EuclideanRing[S]
+
+  def euclideanFunction(x: Shadow[A, S]): BigInt = {
+    val a = A.euclideanFunction(x.a)
+    val s = S.euclideanFunction(x.s)
+    assert(a == s)
+    a
+  }
+
+  def equot(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.equot(x.a, y.a), checked(S.equot(x.s, y.s)))
+
+  override def equotmod(x: Shadow[A, S], y: Shadow[A, S]): (Shadow[A, S], Shadow[A, S]) = {
+    val (a1, a2) = A.equotmod(x.a, y.a)
+    val (s1, s2) = S.equotmod(x.s, y.s)
+    (Shadow(a1, checked(s1)), Shadow(a2, checked(s2)))
+  }
+
+  def emod(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.emod(x.a, y.a), S.emod(x.s, y.s))
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowGCDRing.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowGCDRing.scala
@@ -1,0 +1,15 @@
+package spire.laws.shadows
+
+import spire.algebra.{Eq, GCDRing}
+
+trait ShadowGCDRing[A, S] extends GCDRing[Shadow[A, S]] with ShadowCRing[A, S] {
+  import shadowing._
+  implicit def A: GCDRing[A]
+  implicit def S: GCDRing[S]
+
+  def gcd(x: Shadow[A, S], y: Shadow[A, S])(implicit ev: Eq[Shadow[A, S]]): Shadow[A, S] =
+    Shadow(A.gcd(x.a, y.a), checked(S.gcd(x.s, y.s)))
+
+  def lcm(x: Shadow[A, S], y: Shadow[A, S])(implicit ev: Eq[Shadow[A, S]]): Shadow[A, S] =
+    Shadow(A.lcm(x.a, y.a), checked(S.lcm(x.s, y.s)))
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowMultiplicativeCMonoid.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowMultiplicativeCMonoid.scala
@@ -1,0 +1,27 @@
+package spire.laws.shadows
+
+import spire.algebra.{Eq, MultiplicativeCMonoid}
+
+trait ShadowMultiplicativeCMonoid[A, S] extends MultiplicativeCMonoid[Shadow[A, S]] with ShadowMultiplicativeCSemigroup[A, S] {
+  import shadowing._
+  implicit def A: MultiplicativeCMonoid[A]
+  implicit def S: MultiplicativeCMonoid[S]
+  implicit def eqA: Eq[A]
+  implicit def eqS: Eq[S]
+
+  def one: Shadow[A, S] = Shadow(A.one, checked(S.one))
+
+  override def isOne(x: Shadow[A, S])(implicit ev: Eq[Shadow[A, S]]) = {
+    val a = A.isOne(x.a)
+    val s = S.isOne(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def product(xs: TraversableOnce[Shadow[A, S]]): Shadow[A, S] = {
+    val seq = xs.toSeq
+    val a = A.product(seq.map(_.a))
+    val s = S.product(seq.map(_.s))
+    Shadow(a, checked(s))
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowMultiplicativeCSemigroup.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowMultiplicativeCSemigroup.scala
@@ -1,0 +1,27 @@
+package spire.laws.shadows
+
+import spire.algebra.MultiplicativeCSemigroup
+
+trait ShadowMultiplicativeCSemigroup[A, S] extends MultiplicativeCSemigroup[Shadow[A, S]] {
+  implicit def A: MultiplicativeCSemigroup[A]
+  implicit def S: MultiplicativeCSemigroup[S]
+  implicit val shadowing: Shadowing[A, S]
+  import shadowing._
+
+  def times(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.times(x.a, y.a), checked(S.times(x.s, y.s)))
+
+  override def pow(x: Shadow[A, S], n: Int): Shadow[A, S] =
+    Shadow(A.pow(x.a, n), checked(S.pow(x.s, n)))
+
+  override def tryProduct(xs: TraversableOnce[Shadow[A, S]]): Option[Shadow[A, S]] = {
+    val seq = xs.toSeq
+    val aO = A.tryProduct( seq.map(_.a) )
+    val sO = S.tryProduct( seq.map(_.s) )
+    (aO, sO) match {
+      case (Some(a), Some(s)) => Some(Shadow(a, checked(s)))
+      case (None, None) => None
+      case _ => throw new IllegalArgumentException("Inconsistent results for trySum between primitive and shadow type")
+    }
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowOrder.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowOrder.scala
@@ -1,0 +1,68 @@
+package spire.laws.shadows
+
+import cats.kernel.Comparison
+import spire.algebra.Order
+
+trait ShadowOrder[A, S] extends ShadowPartialOrder[A, S] with Order[Shadow[A, S]] {
+  implicit def A: Order[A]
+  implicit def S: Order[S]
+
+  override def eqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = super[ShadowPartialOrder].eqv(x, y)
+
+  override def partialCompare(x: Shadow[A, S], y: Shadow[A, S]): Double = super[ShadowPartialOrder].partialCompare(x, y)
+
+  def compare(x: Shadow[A, S], y: Shadow[A, S]): Int = {
+    val a = A.compare(x.a, y.a)
+    val s = S.compare(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def comparison(x: Shadow[A, S], y: Shadow[A, S]): Comparison = {
+    val a = A.comparison(x.a, y.a)
+    val s = S.comparison(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def min(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.min(x.a, y.a), S.min(x.s, y.s))
+
+  override def max(x: Shadow[A, S], y: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.max(x.a, y.a), S.max(x.s, y.s))
+
+  override def neqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.neqv(x.a, y.a)
+    val s = S.neqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def lteqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.lteqv(x.a, y.a)
+    val s = S.lteqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def lt(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.lt(x.a, y.a)
+    val s = S.lt(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def gteqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.gteqv(x.a, y.a)
+    val s = S.gteqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def gt(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.gt(x.a, y.a)
+    val s = S.gt(x.s, y.s)
+    assert(a == s)
+    a
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowPartialOrder.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowPartialOrder.scala
@@ -1,0 +1,81 @@
+package spire.laws.shadows
+
+import cats.kernel.Comparison
+import spire.algebra.PartialOrder
+
+trait ShadowPartialOrder[A, S] extends ShadowEq[A, S] with PartialOrder[Shadow[A, S]] {
+  implicit def A: PartialOrder[A]
+  implicit def S: PartialOrder[S]
+
+  override def eqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = super[ShadowEq].eqv(x, y)
+  override def neqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = super[ShadowEq].neqv(x, y)
+
+  def partialCompare(x: Shadow[A, S], y: Shadow[A, S]): Double = {
+    val a = A.partialCompare(x.a, y.a)
+    val s = S.partialCompare(x.s, y.s)
+    if (a.isNaN) assert(s.isNaN) else assert(a == s)
+    a
+  }
+
+  override def partialComparison(x: Shadow[A, S], y: Shadow[A, S]): Option[Comparison] = {
+    val a = A.partialComparison(x.a, y.a)
+    val s = S.partialComparison(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def tryCompare(x: Shadow[A, S], y: Shadow[A, S]): Option[Int] = {
+    val a = A.tryCompare(x.a, y.a)
+    val s = S.tryCompare(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def pmin(x: Shadow[A, S], y: Shadow[A, S]): Option[Shadow[A, S]] = {
+    val a = A.pmin(x.a, y.a)
+    val s = S.pmin(x.s, y.s)
+    (a, s) match {
+      case (Some(a1), Some(s1)) => Some(Shadow(a1, s1))
+      case (None, None) => None
+      case _ => throw new IllegalArgumentException("Inconsistent shadowing")
+    }
+  }
+
+  override def pmax(x: Shadow[A, S], y: Shadow[A, S]): Option[Shadow[A, S]] = {
+    val a = A.pmax(x.a, y.a)
+    val s = S.pmax(x.s, y.s)
+    (a, s) match {
+      case (Some(a1), Some(s1)) => Some(Shadow(a1, s1))
+      case (None, None) => None
+      case _ => throw new IllegalArgumentException("Inconsistent shadowing")
+    }
+  }
+
+  override def lteqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.lteqv(x.a, y.a)
+    val s = S.lteqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def lt(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.lt(x.a, y.a)
+    val s = S.lt(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def gteqv(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.gteqv(x.a, y.a)
+    val s = S.gteqv(x.s, y.s)
+    assert(a == s)
+    a
+  }
+
+  override def gt(x: Shadow[A, S], y: Shadow[A, S]): Boolean = {
+    val a = A.gt(x.a, y.a)
+    val s = S.gt(x.s, y.s)
+    assert(a == s)
+    a
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/ShadowSigned.scala
+++ b/laws/src/main/scala/spire/laws/shadows/ShadowSigned.scala
@@ -1,0 +1,69 @@
+package spire.laws.shadows
+
+import spire.algebra.{Sign, Signed}
+
+trait ShadowSigned[A, S] extends ShadowOrder[A, S] with Signed[Shadow[A, S]] {
+  implicit val shadowing: Shadowing[A, S]
+  import shadowing._
+  implicit def A: Signed[A]
+  implicit def S: Signed[S]
+
+  def signum(x: Shadow[A, S]): Int = {
+    val a = A.signum(x.a)
+    val s = S.signum(x.s)
+    assert(a == s)
+    a
+  }
+
+  def abs(x: Shadow[A, S]): Shadow[A, S] =
+    Shadow(A.abs(x.a), checked(S.abs(x.s)))
+
+  override def sign(x: Shadow[A, S]): Sign = {
+    val a = A.sign(x.a)
+    val s = S.sign(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignZero(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignZero(x.a)
+    val s = S.isSignZero(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignPositive(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignPositive(x.a)
+    val s = S.isSignPositive(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignNegative(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignNegative(x.a)
+    val s = S.isSignNegative(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignNonZero(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignNonZero(x.a)
+    val s = S.isSignNonZero(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignNonPositive(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignNonPositive(x.a)
+    val s = S.isSignNonPositive(x.s)
+    assert(a == s)
+    a
+  }
+
+  override def isSignNonNegative(x: Shadow[A, S]): Boolean = {
+    val a = A.isSignNonNegative(x.a)
+    val s = S.isSignNonNegative(x.s)
+    assert(a == s)
+    a
+  }
+}

--- a/laws/src/main/scala/spire/laws/shadows/Shadowing.scala
+++ b/laws/src/main/scala/spire/laws/shadows/Shadowing.scala
@@ -1,0 +1,35 @@
+package spire.laws.shadows
+
+import spire.algebra.IsIntegral
+import spire.math.NumberTag
+
+object Shadowing {
+  def apply[A, S](f: A => S, g: S => Option[A]): Shadowing[A, S] = new Shadowing[A, S] {
+    def toShadow(a: A): S = f(a)
+    def fromShadow(s: S): Option[A] = g(s)
+  }
+
+  def bigInt[A:IsIntegral:NumberTag](fromBigInt: BigInt => A): Shadowing[A, BigInt] =
+    new Shadowing[A, BigInt] {
+      def toShadow(a: A): BigInt = IsIntegral[A].toBigInt(a)
+      def fromShadow(s: BigInt): Option[A] = {
+        NumberTag[A].hasMinValue match {
+          case Some(m) if s < IsIntegral[A].toBigInt(m) => return None
+          case _ =>
+        }
+        NumberTag[A].hasMaxValue match {
+          case Some(m) if s > IsIntegral[A].toBigInt(m) => return None
+          case _ =>
+        }
+        Some(fromBigInt(s))
+      }
+    }
+}
+
+trait Shadowing[A, S] {
+  def toShadow(a: A): S
+  def fromShadow(s: S): Option[A]
+  def isValid(s: S): Boolean = fromShadow(s).nonEmpty
+  def checked(s: S): S =
+    if (!isValid(s)) throw new InvalidTestException else s
+}

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -6,6 +6,7 @@ import spire.algebra._
 import spire.algebra.free._
 import spire.algebra.lattice._
 import spire.laws.arb._
+import spire.laws.shadows.{Shadow, Shadowing}
 import spire.math._
 import spire.optional.partialIterable._
 import spire.optional.mapIntIntPermutation._
@@ -32,6 +33,26 @@ class LawTests extends FunSuite with Discipline {
     }
   }
 
+  // shadowed types with limited range
+
+  implicit val shadowingUByte: Shadowing[UByte, BigInt] = Shadowing.bigInt[UByte](s => UByte(s.toInt))
+  implicit val shadowingUShort: Shadowing[UShort, BigInt] = Shadowing.bigInt[UShort](s => UShort(s.toInt))
+  implicit val shadowingUInt: Shadowing[UInt, BigInt] = Shadowing.bigInt[UInt](s => UInt(s.toLong))
+  implicit val shadowingULong: Shadowing[ULong, BigInt] = Shadowing.bigInt[ULong](s => ULong.fromBigInt(s))
+  checkAll("UByte",      RingLaws[UByte].cRig)
+  checkAll("UByte",      CombinationLaws[Shadow[UByte, BigInt]].signedAdditiveCMonoid)
+  checkAll("UByte",      OrderLaws[Shadow[UByte, BigInt]].signed)
+  checkAll("UShort",     RingLaws[UShort].cRig)
+  checkAll("UShort",     CombinationLaws[Shadow[UShort, BigInt]].signedAdditiveCMonoid)
+  checkAll("UShort",     OrderLaws[Shadow[UShort, BigInt]].signed)
+  checkAll("UInt",       RingLaws[UInt].cRig)
+  checkAll("UInt",       CombinationLaws[Shadow[UInt, BigInt]].signedAdditiveCMonoid)
+  checkAll("UInt",       OrderLaws[Shadow[UInt, BigInt]].signed)
+  checkAll("ULong",      RingLaws[ULong].cRig)
+  checkAll("ULong",      CombinationLaws[Shadow[ULong, BigInt]].signedAdditiveCMonoid)
+  checkAll("ULong",      OrderLaws[Shadow[ULong, BigInt]].signed)
+
+
   // Float and Double fail these tests
   checkAll("Int",        RingLaws[Int].cRing)
   checkAll("Int",        BaseLaws[Int].uniqueFactorizationDomain)
@@ -49,10 +70,6 @@ class LawTests extends FunSuite with Discipline {
   checkAll("Rational",   CombinationLaws[Rational].signedGCDRing)
   checkAll("Rational",   OrderLaws[Rational].truncatedDivision)
   checkAll("Real",       RingLaws[Real].field)
-  checkAll("UByte",      RingLaws[UByte].cRig)
-  checkAll("UShort",     RingLaws[UShort].cRig)
-  checkAll("UInt",       RingLaws[UInt].cRig)
-  checkAll("ULong",      RingLaws[ULong].cRig)
   checkAll("Natural",    RingLaws[Natural].cRig)
   checkAll("Natural",    CombinationLaws[Natural].signedAdditiveCMonoid)
   checkAll("SafeLong",   RingLaws[SafeLong].euclideanRing)


### PR DESCRIPTION
We add shadows to the tests: during testing, a primitive type is shadowed by a unlimited range type. When any intermediate computation exceeds the range of the primitive type, an exception is thrown such that the property evaluation is discarded (for now, we force it to pass to avoid failing on too many discards).

Changes:

- Introduces `spire.laws.shadows` which provides a `Shadow[A, S]` type containing a value `a: A` and its unlimited range `s: S`. `S` will usually be `SafeLong` or `BigInt`.
- Introduces wrappers for Spire typeclasses in `spire.laws.shadows`.
- Introduces `InvalidTestException`, thrown when 
- Introduces a wrapper for the laws, such that this exception leads to properties passing or being undecided.

The design is not final. In particular, I'm looking at:

- Improving the syntax of the wrappers that catch the `InvalidTestException`. I will probably replace the scalacheck `forAll` method, as this would have the minimal impact on the law syntax.

- Should we force the property to pass when the range is exceeded, or send `undecided`? `undecided` has the unfortunate effect to make some properties very difficult to pass, especially for `Byte`-sized types.

- Grouping the files in `spire.laws.shadows` which currently follow cats testing style.

- Add range-proof tests for all primitive types and all laws (as is done currently in the experimental branch).

This would improve a lot the coverage for primitive types (I get +10% on the unsigned primitive types).