### PR TITLE
Get rid of Order context bound in Interval constructors

### DIFF
--- a/core/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/src/main/scala/spire/math/interval/Overlap.scala
@@ -28,7 +28,7 @@ object Overlap {
       * An interval that joins [[lower]] and [[upper]] in a continuous interval without intersecting any of them.
       * For example for (-5, 1] and (4, 6), a join is (1,4]
       */
-    def join: Interval[A] = (~lower).last.intersect((~upper).head)
+    def join(implicit o: Order[A]): Interval[A] = (~lower).last.intersect((~upper).head)
   }
 
   /**


### PR DESCRIPTION
Pushes `Order` requirements down to individual methods of `Interval`.

I didn't touch `IntervalSet`s though. @rklaehn do you have anything in mind that can be improved now?