### PR TITLE
Topic/sorting 721

### DIFF
--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -136,32 +136,32 @@ object MergeSort extends Sort {
 object QuickSort {
   @inline final def limit: Int = 16
 
-  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length - 1)
+  final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length)
 
-  final def qsort[@sp A](data:Array[A], left: Int, right: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
-
-    if (right - left < limit) {
-      InsertionSort.sort(data, left, right + 1)
+  final def qsort[@sp A](data:Array[A], start: Int, end: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
+    require(start >= 0 && end <= data.length)
+    if (end - start < limit) {
+      InsertionSort.sort(data, start, end)
       return
     }
 
-    val pivot = left + (right - left) / 2
-    val next = partition(data, left, right, pivot)
-    qsort(data, left, next - 1)
-    qsort(data, next + 1, right)
+    val pivot = start + (end - start) / 2
+    val next = partition(data, start, end, pivot)
+    qsort(data, start, next)
+    qsort(data, next + 1, end)
   }
 
-  final def partition[@sp A](data:Array[A], left:Int, right:Int, pivot:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
+  final def partition[@sp A](data:Array[A], left:Int, right:Int, pivotIndex:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
 
-    val value = data(pivot)
+    val pivotValue = data(pivotIndex)
 
     //swap(pivot, right)
-    var tmp = data(pivot); data(pivot) = data(right); data(right) = tmp
+    var tmp = data(pivotIndex); data(pivotIndex) = data(right - 1); data(right - 1) = tmp
 
     var store = left
     var i = left
-    while (i < right) {
-      if (o.lt(data(i), value)) {
+    while (i < right - 1) {
+      if (o.lt(data(i), pivotValue)) {
         //swap(i, store)
         tmp = data(i); data(i) = data(store); data(store) = tmp
         store += 1
@@ -169,7 +169,7 @@ object QuickSort {
       i += 1
     }
     //swap(store, right)
-    tmp = data(store); data(store) = data(right); data(right) = tmp
+    tmp = data(store); data(store) = data(right - 1); data(right - 1) = tmp
     store
   }
 }

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -26,7 +26,7 @@ object InsertionSort extends Sort {
     * @param data the data to be sorted
     * @param start the index of the first element, inclusive, to be sorted
     * @param end the index of the last element, exclusive, to be sorted
-    * @tparam A a type belonging to the type class Order
+    * @tparam A a type belonging to the type class `Order`
     */
   final def sort[@sp A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
     require(start <= end && start >= 0 && end <= data.length)
@@ -110,7 +110,7 @@ object MergeSort extends Sort {
     * @param start the start of the first input section (inclusive) as well as the start of the merged output
     * @param mid the end of the first input section (exclusive) and the beginning of the second input section (inclusive)
     * @param end the end of the second input section (exclusive)
-    * @tparam A a member of the type class Order
+    * @tparam A a member of the type class `Order`
     */
   @inline final def merge[@sp A](in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)(implicit o:Order[A]): Unit = {
     require(start >= 0 && start <= mid && mid <= end && end <= in.length && end <= out.length)
@@ -138,6 +138,15 @@ object QuickSort {
 
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length)
 
+  /**
+    * Uses quick sort on `data` to sort the entries from the index `start`
+    * up to, but not including, the index `end`. Operates in place.
+    *
+    * @param data the input data
+    * @param start the index from which to start sorting (inclusive)
+    * @param end the index at which to stop sorting (exclusive)
+    * @tparam A a member of the type class `Order`
+    */
   final def qsort[@sp A](data:Array[A], start: Int, end: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
     require(start >= 0 && end <= data.length)
     if (end - start < limit) {
@@ -155,21 +164,22 @@ object QuickSort {
 
     val pivotValue = data(pivotIndex)
 
-    //swap(pivot, right)
-    var tmp = data(pivotIndex); data(pivotIndex) = data(right - 1); data(right - 1) = tmp
+    data(pivotIndex) = data(right - 1)
 
+    var temp = pivotValue
     var store = left
     var i = left
     while (i < right - 1) {
       if (o.lt(data(i), pivotValue)) {
         //swap(i, store)
-        tmp = data(i); data(i) = data(store); data(store) = tmp
+        temp = data(i); data(i) = data(store); data(store) = temp
         store += 1
       }
       i += 1
     }
-    //swap(store, right)
-    tmp = data(store); data(store) = data(right - 1); data(right - 1) = tmp
+
+    data(right - 1) = data(store)
+    data(store) = pivotValue
     store
   }
 }

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -162,5 +162,5 @@ object Sorting {
 
   final def insertionSort[@sp A:Order:ClassTag](data:Array[A]): Unit = InsertionSort.sort(data)
   final def mergeSort[@sp A:Order:ClassTag](data:Array[A]): Unit = MergeSort.sort(data)
-  final def quickSort[@sp K:Order:ClassTag](data:Array[K]): Unit = QuickSort.sort(data)
+  final def quickSort[@sp A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
 }

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -14,14 +14,22 @@ trait Sort extends Any {
 /**
  * Simple implementation of insertion sort.
  *
- * Works for small arrays but due to O(n^2) complexity is not generally good.
+ * Works for small arrays but due to quadratic complexity is not generally good.
  */
 object InsertionSort extends Sort {
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit =
     sort(data, 0, data.length)
 
+  /**
+    * Uses insertion sort on `data` to sort the entries from the index `start`
+    * up to, but not including, the index `end`. Operates in place.
+    * @param data the data to be sorted
+    * @param start the index of the first element, inclusive, to be sorted
+    * @param end the index of the last element, exclusive, to be sorted
+    * @tparam A a type belonging to the type class Order
+    */
   final def sort[@sp A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
-
+    require(start <= end && start >= 0 && end <= data.length)
     var i = start + 1
     while (i < end) {
       val item = data(i)
@@ -49,7 +57,10 @@ object MergeSort extends Sort {
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = {
     val len = data.length
 
-    if (len <= startStep) return InsertionSort.sort(data)
+    if (len <= startStep) {
+      InsertionSort.sort(data)
+      return
+    }
 
     var buf1:Array[A] = data
     var buf2:Array[A] = new Array[A](len)
@@ -115,7 +126,10 @@ object QuickSort {
 
   final def qsort[@sp A](data:Array[A], left: Int, right: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
 
-    if (right - left < limit) return InsertionSort.sort(data, left, right + 1)
+    if (right - left < limit) {
+      InsertionSort.sort(data, left, right + 1)
+      return
+    }
 
     val pivot = left + (right - left) / 2
     val next = partition(data, left, right, pivot)
@@ -153,7 +167,7 @@ object QuickSort {
  * Object providing in-place sorting capability for arrays.
  *
  * Sorting.sort() uses quickSort() by default (in-place, not stable, generally
- * fastest but might hit bad cases where it's O(n^2)). Also provides
+ * fastest but might hit bad cases where it is quadratic. Also provides
  * mergeSort() (in-place, stable, uses extra memory, still pretty fast) and
  * insertionSort(), which is slow except for small arrays.
  */

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -89,17 +89,31 @@ object MergeSort extends Sort {
       step *= 2
     }
 
-    if (buf1 != data) System.arraycopy(buf1, 0, data, 0, len)
+    if (!buf1.eq(data)) System.arraycopy(buf1, 0, data, 0, len)
   }
 
   /**
-   * Helper method for mergeSort, used to do a single "merge" between two
-   * sections of the input array. The start, mid and end parameters denote the
-   * left and right ranges of the input to merge, as well as the area of the
-   * ouput to write to.
-   */
+    * Helper method for mergeSort, used to do a single "merge" between two
+    * sections of the input array, and write the result to the output array.
+    *
+    * The first input section starts at `start` (inclusive) and ends at `mid` (exclusive).
+    * The second input section starts at `mid` (inclusive) and ends at `end` (exclusive).
+    *
+    * Writing to the output begins at `start` (inclusive).
+    *
+    * The start, mid and end parameters denote the
+    * left and right ranges of the input to merge, as well as the area of the
+    * output to write to.
+    *
+    * @param in the input array
+    * @param out the output array
+    * @param start the start of the first input section (inclusive) as well as the start of the merged output
+    * @param mid the end of the first input section (exclusive) and the beginning of the second input section (inclusive)
+    * @param end the end of the second input section (exclusive)
+    * @tparam A a member of the type class Order
+    */
   @inline final def merge[@sp A](in:Array[A], out:Array[A], start:Int, mid:Int, end:Int)(implicit o:Order[A]): Unit = {
-
+    require(start >= 0 && start <= mid && mid <= end && end <= in.length && end <= out.length)
     var ii = start
     var jj = mid
     var kk = start

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -12,9 +12,9 @@ trait Sort extends Any {
 }
 
 /**
- * Simple implementation of insertion sort.
+ * An implementation of insertion sort.
  *
- * Works for small arrays but due to quadratic complexity is not generally good.
+ * Works well for small arrays but due to quadratic complexity is not generally optimal.
  */
 object InsertionSort extends Sort {
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit =
@@ -23,6 +23,7 @@ object InsertionSort extends Sort {
   /**
     * Uses insertion sort on `data` to sort the entries from the index `start`
     * up to, but not including, the index `end`. Operates in place.
+    *
     * @param data the data to be sorted
     * @param start the index of the first element, inclusive, to be sorted
     * @param end the index of the last element, exclusive, to be sorted
@@ -54,6 +55,15 @@ object MergeSort extends Sort {
   @inline final def startWidth: Int = 8
   @inline final def startStep: Int = 16
 
+  /**
+    * Uses merge sort to sort the input array in place.
+    *
+    * If the size of the input array does not exceed the threshold `startStep`
+    * uses insertion sort instead.
+    *
+    * @param data the input array
+    * @tparam A a member of the type class `Order`
+    */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = {
     val len = data.length
 
@@ -101,10 +111,6 @@ object MergeSort extends Sort {
     *
     * Writing to the output begins at `start` (inclusive).
     *
-    * The start, mid and end parameters denote the
-    * left and right ranges of the input to merge, as well as the area of the
-    * output to write to.
-    *
     * @param in the input array
     * @param out the output array
     * @param start the start of the first input section (inclusive) as well as the start of the merged output
@@ -136,11 +142,24 @@ object MergeSort extends Sort {
 object QuickSort {
   @inline final def limit: Int = 16
 
+  /**
+    * Uses quicksort on `data` to sort the entries from the index `start`
+    * up to, but not including, the index `end`. Operates in place.
+    *
+    * If the size of the input array is less than the threshold `limit`
+    * uses insertion sort instead.
+    *
+    * @param data the input data
+    * @tparam A a member of the type class `Order`
+    */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length)
 
   /**
-    * Uses quick sort on `data` to sort the entries from the index `start`
+    * Uses quicksort on `data` to sort the entries from the index `start`
     * up to, but not including, the index `end`. Operates in place.
+    *
+    * If the size of the segment to be sorted is less than the threshold `limit`
+    * uses insertion sort instead.
     *
     * @param data the input data
     * @param start the index from which to start sorting (inclusive)
@@ -163,7 +182,7 @@ object QuickSort {
   /**
     * Helper method for the quick sort implementation. Partitions the segment of the input array from `start` to `end`
     * according to the value at the given `pivotIndex`. Values less in the segment less than the pivot value will end up
-    * to the left of the pivot value, and values greater on the right.
+    * to the left of the pivot value, and values greater on the right. Operates in place.
     *
     * @param data the input array
     * @param start the left endpoint (inclusive) of the interval to be partitioned

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -154,22 +154,34 @@ object QuickSort {
       return
     }
 
-    val pivot = start + (end - start) / 2
-    val next = partition(data, start, end, pivot)
-    qsort(data, start, next)
-    qsort(data, next + 1, end)
+    val pivotIndex = start + (end - start) / 2
+    val nextPivotIndex = partition(data, start, end, pivotIndex)
+    qsort(data, start, nextPivotIndex)
+    qsort(data, nextPivotIndex + 1, end)
   }
 
-  final def partition[@sp A](data:Array[A], left:Int, right:Int, pivotIndex:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
-
+  /**
+    * Helper method for the quick sort implementation. Partitions the segment of the input array from `start` to `end`
+    * according to the value at the given `pivotIndex`. Values less in the segment less than the pivot value will end up
+    * to the left of the pivot value, and values greater on the right.
+    *
+    * @param data the input array
+    * @param start the left endpoint (inclusive) of the interval to be partitioned
+    * @param end the right endpoint (exclusive) of the interval to be partitioned
+    * @param pivotIndex the index of the current pivot
+    * @tparam A a member of the type class Order
+    * @return the next pivot value
+    */
+  final def partition[@sp A](data:Array[A], start:Int, end:Int, pivotIndex:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
+    require(start >= 0 && pivotIndex >= start && end > pivotIndex && end <= data.length)
     val pivotValue = data(pivotIndex)
 
-    data(pivotIndex) = data(right - 1)
+    data(pivotIndex) = data(end - 1)
 
     var temp = pivotValue
-    var store = left
-    var i = left
-    while (i < right - 1) {
+    var store = start
+    var i = start
+    while (i < end - 1) {
       if (o.lt(data(i), pivotValue)) {
         //swap(i, store)
         temp = data(i); data(i) = data(store); data(store) = temp
@@ -178,7 +190,7 @@ object QuickSort {
       i += 1
     }
 
-    data(right - 1) = data(store)
+    data(end - 1) = data(store)
     data(store) = pivotValue
     store
   }

--- a/core/src/main/scala/spire/math/Sorting.scala
+++ b/core/src/main/scala/spire/math/Sorting.scala
@@ -17,6 +17,13 @@ trait Sort extends Any {
  * Works well for small arrays but due to quadratic complexity is not generally optimal.
  */
 object InsertionSort extends Sort {
+
+  /**
+    * Sorts `data` in place using insertion sort.
+    *
+    * @param data the array to be sorted
+    * @tparam A a member of the type class `Order`
+    */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit =
     sort(data, 0, data.length)
 
@@ -24,10 +31,10 @@ object InsertionSort extends Sort {
     * Uses insertion sort on `data` to sort the entries from the index `start`
     * up to, but not including, the index `end`. Operates in place.
     *
-    * @param data the data to be sorted
+    * @param data the array to be sorted
     * @param start the index of the first element, inclusive, to be sorted
     * @param end the index of the last element, exclusive, to be sorted
-    * @tparam A a type belonging to the type class `Order`
+    * @tparam A a member of the type class `Order`
     */
   final def sort[@sp A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
     require(start <= end && start >= 0 && end <= data.length)
@@ -56,12 +63,12 @@ object MergeSort extends Sort {
   @inline final def startStep: Int = 16
 
   /**
-    * Uses merge sort to sort the input array in place.
+    * Uses merge sort to sort the array `data` in place.
     *
-    * If the size of the input array does not exceed the threshold `startStep`
+    * If the size of the input array does not exceed the threshold `startStep`,
     * uses insertion sort instead.
     *
-    * @param data the input array
+    * @param data the array to be sorted
     * @tparam A a member of the type class `Order`
     */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = {
@@ -143,13 +150,12 @@ object QuickSort {
   @inline final def limit: Int = 16
 
   /**
-    * Uses quicksort on `data` to sort the entries from the index `start`
-    * up to, but not including, the index `end`. Operates in place.
+    * Uses quicksort on `data` to sort the entries. Operates in place.
     *
-    * If the size of the input array is less than the threshold `limit`
+    * If the size of the input array is less than the threshold `limit`,
     * uses insertion sort instead.
     *
-    * @param data the input data
+    * @param data the array to be sorted
     * @tparam A a member of the type class `Order`
     */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length)
@@ -161,7 +167,7 @@ object QuickSort {
     * If the size of the segment to be sorted is less than the threshold `limit`
     * uses insertion sort instead.
     *
-    * @param data the input data
+    * @param data the array to be sorted
     * @param start the index from which to start sorting (inclusive)
     * @param end the index at which to stop sorting (exclusive)
     * @tparam A a member of the type class `Order`
@@ -180,11 +186,11 @@ object QuickSort {
   }
 
   /**
-    * Helper method for the quick sort implementation. Partitions the segment of the input array from `start` to `end`
-    * according to the value at the given `pivotIndex`. Values less in the segment less than the pivot value will end up
+    * Helper method for the quick sort implementation. Partitions the segment of the array `data` from `start` to `end`
+    * according to the value at the given `pivotIndex`. Values in the segment less than the pivot value will end up
     * to the left of the pivot value, and values greater on the right. Operates in place.
     *
-    * @param data the input array
+    * @param data the array to be partitioned
     * @param start the left endpoint (inclusive) of the interval to be partitioned
     * @param end the right endpoint (exclusive) of the interval to be partitioned
     * @param pivotIndex the index of the current pivot
@@ -227,9 +233,15 @@ object QuickSort {
  * insertionSort(), which is slow except for small arrays.
  */
 object Sorting {
+  /** Delegates to [[spire.math.QuickSort.sort]] */
   final def sort[@sp A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
 
+  /** Delegates to [[spire.math.InsertionSort.sort]] */
   final def insertionSort[@sp A:Order:ClassTag](data:Array[A]): Unit = InsertionSort.sort(data)
+
+  /** Delegates to [[spire.math.MergeSort.sort]] */
   final def mergeSort[@sp A:Order:ClassTag](data:Array[A]): Unit = MergeSort.sort(data)
+
+  /** Delegates to [[spire.math.QuickSort.sort]] */
   final def quickSort[@sp A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
 }

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -9,11 +9,11 @@ import spire.std.int._
 class SortingTest extends FunSuite with Matchers {
 
   test("The sort methods can handle empty arrays") {
-    checkAllSortMethods(Array[Int]()){sorted => sorted should contain theSameElementsInOrderAs Array[Int]()}
+    checkAllSortMethods(Array[Int]()){_ should contain theSameElementsInOrderAs Array[Int]()}
   }
 
   test("The sort methods can handle singleton arrays") {
-    checkAllSortMethods(Array("lonely")){sorted => sorted should contain theSameElementsInOrderAs Array("lonely")}
+    checkAllSortMethods(Array("lonely")){_ should contain theSameElementsInOrderAs Array("lonely")}
   }
 
   test("Sort randomly generated arrays of various sizes") {
@@ -27,16 +27,16 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Sort a decreasing sequence") {
-    checkAllSortMethods(Array(5, 4, 3, 2, 1)){sorted => sorted should contain theSameElementsInOrderAs Array(1, 2, 3, 4, 5)}
+    checkAllSortMethods(Array.range(0, forceStrategySize).reverse){ _ should contain theSameElementsInOrderAs Array.range(0, forceStrategySize) }
   }
 
   test("Sort a constant sequence") {
-    checkAllSortMethods(Array.fill(20){7}) {sorted => sorted should contain theSameElementsInOrderAs Array.fill(20){7}}
+    checkAllSortMethods(Array.fill(20){7}) { _ should contain theSameElementsInOrderAs Array.fill(20){7}}
   }
 
   test("Sort a list of strings") {
     checkAllSortMethods(Array("There", "is", "a", "light", "that", "never", "goes", "out")){
-      sorted => sorted should contain theSameElementsInOrderAs Array("There", "a", "goes", "is", "light", "never", "out", "that")
+      _ should contain theSameElementsInOrderAs Array("There", "a", "goes", "is", "light", "never", "out", "that")
     }
   }
 
@@ -47,14 +47,14 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use InsertionSort to sort a specific range") {
-    checkSortMethod[Int](input => InsertionSort.sort(input, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
-      sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 4, 6, 7, 1, -1, 3)
+    checkSortMethod[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
+      _ should contain theSameElementsInOrderAs Array(5, 8, 4, 6, 7, 1, -1, 3)
     }
   }
 
   test("Use InsertionSort to sort an empty range") {
-    checkSortMethod[Int](input => InsertionSort.sort(input, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
-      sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3)
+    checkSortMethod[Int](InsertionSort.sort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
+      _ should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3)
     }
   }
 
@@ -106,6 +106,35 @@ class SortingTest extends FunSuite with Matchers {
     an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 1, 5, 3)
 
   }
+
+  test("Use QuickSort to sort a specific range: start is inclusive, end is exclusive") {
+    checkSortMethod[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding) {
+      _ should contain theSameElementsInOrderAs Array(5, -1, 1, 4, 6, 7, 8, 3) ++ forceQuickSortPadding
+    }
+  }
+
+  test("Use QuickSort to sort an empty range") {
+    checkSortMethod[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding) {
+      _ should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding
+    }
+  }
+
+  test("QuickSort: start must be less than or equal to end") {
+    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding, 4, 3)
+  }
+
+  test("QuickSort: start must be nonnegative") {
+    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding, -1, 16)
+  }
+
+  test("QuickSort: end cannot exceed the length of the input array") {
+    val input = Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding
+    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(input, 2, input.length + 1)
+  }
+
+  private val forceStrategySize = max(QuickSort.limit, MergeSort.startStep) * 2
+
+  private val forceQuickSortPadding = new Array[Int](forceStrategySize)
 
   private def isSorted(input: Array[Int]): Assertion = {
     assert(input.zip(input.tail).forall({case (p, q) => p <= q}))

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -17,12 +17,19 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Sort randomly generated arrays of various sizes") {
-    val sizes = Seq.range(1, 65) ++ Seq(256, 1024, 9121, 65539)
+    val smallSizes = Seq.range(1, 65)
     val randomGen = new scala.util.Random()
 
-    sizes.foreach { size =>
-      val input: Array[Int] = Array.tabulate(size) { _ => randomGen.nextInt(Int.MaxValue) }
+    smallSizes.foreach { size =>
+      val input: Array[Int] = Array.tabulate(size) { _ => randomGen.nextInt(10000) }
       checkAllSortMethods(input)(isSorted)
+    }
+
+    val largeSizes = Seq(256, 1024, 9121)
+    largeSizes.foreach { size =>
+      val input: Array[Int] = Array.tabulate(size) { _ => randomGen.nextInt(10000) }
+      checkMutation(mergeSort[Int], input)(isSorted)
+      checkMutation(quickSort[Int], input)(isSorted)
     }
   }
 

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -38,11 +38,7 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Sort a constant sequence") {
-    matchAgainstExpectedForEachSortMethod(Array.fill(20) {
-      7
-    }, Array.fill(20) {
-      7
-    })
+    matchAgainstExpectedForEachSortMethod(Array.fill(20){7}, Array.fill(20){7})
   }
 
   test("Sort a list of strings") {
@@ -57,8 +53,12 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use InsertionSort to sort a specific range") {
-    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3),
-      Array(5, 8, 4, 6, 7, 1, -1, 3))
+    val rangeToSort = Array(7, 6, 4)
+    val expectedAfter = Array(4, 6, 7)
+
+    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 5),
+      Array(5, 8) ++ rangeToSort ++ Array(1, -1, 3),
+      Array(5, 8) ++ expectedAfter ++ Array(1, -1, 3))
   }
 
   test("Use InsertionSort to sort an empty range") {
@@ -79,8 +79,12 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("MergeSort.merge merges segments of the input and writes to the output") {
-    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7),
-      new Array[Int](9), Array(0, 2, 4, 3, 5, 13, 19, 0, 0))
+    val segment1 = Array(2, 5, 13)
+    val segment2 = Array(4, 3, 19)
+    val expectedAfterMerging = Array(2, 4, 3, 5, 13, 19)
+
+    matchAgainstExpected[Int](MergeSort.merge(Array(1) ++ segment1 ++ segment2 ++ Array(-2, 9), _, 1, 4, 7),
+      new Array[Int](9), Array(0) ++ expectedAfterMerging ++ Array(0, 0))
   }
 
   test("MergeSort.merge succeeds when start and end are the extreme allowed values") {
@@ -118,31 +122,42 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use QuickSort to sort a specific range: start is inclusive, end is exclusive") {
-    matchAgainstExpected[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING,
-      Array(5, -1, 1, 4, 6, 7, 8, 3) ++ BIG_PADDING)
+    val rangeToSort = Array(8, 7, 6, 4, 1, -1)
+    val expectedAfter = Array(-1, 1, 4, 6, 7, 8)
+
+    matchAgainstExpected[Int](QuickSort.qsort(_, 1, 7),
+      Array(5) ++ rangeToSort ++ Array(3) ++ ENOUGH_ZEROS,
+      Array(5) ++ expectedAfter ++ Array(3) ++ ENOUGH_ZEROS)
   }
 
   test("Use QuickSort to sort an empty range") {
-    matchAgainstExpected[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING,
-      Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING)
+    matchAgainstExpected[Int](QuickSort.qsort(_, 2, 2),
+      Array(5, 8, 7, 6, 4, 1, -1, 3) ++ ENOUGH_ZEROS,
+      Array(5, 8, 7, 6, 4, 1, -1, 3) ++ ENOUGH_ZEROS)
   }
 
   test("QuickSort: start must be less than or equal to end") {
-    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ BIG_PADDING, 4, 3)
+    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ ENOUGH_ZEROS, 4, 3)
   }
 
   test("QuickSort: start must be nonnegative") {
-    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ BIG_PADDING, -1, 16)
+    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ ENOUGH_ZEROS, -1, 16)
   }
 
   test("QuickSort: end cannot exceed the length of the input array") {
-    val input = Array(7, 6, 4, 2, 1) ++ BIG_PADDING
+    val input = Array(7, 6, 4, 2, 1) ++ ENOUGH_ZEROS
     an[IllegalArgumentException] should be thrownBy QuickSort.qsort(input, 2, input.length + 1)
   }
 
   test("QuickSort: Partitioning an array") {
-    matchAgainstExpected[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10),
-      Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10))
+    val leftSegment = Array(5, 11, 2)
+    val rightSegment = Array(8, 1, 9)
+    val pivotValue = 7
+    val expectedAfterPartition = Array(5, 2, 1, 7, 8, 11, 9)
+
+    matchAgainstExpected[Int](QuickSort.partition(_, 2, 9, 5),
+      Array(6, -1) ++ leftSegment ++ Array(pivotValue) ++ rightSegment ++ Array(2, 10),
+      Array(6, -1) ++ expectedAfterPartition ++ Array(2, 10))
   }
 
   test("QuickSort.partition: 0 <= start <= pivot < end <= length of input") {
@@ -154,7 +169,7 @@ class SortingTest extends FunSuite with Matchers {
 
   private val BIG = max(QuickSort.limit, MergeSort.startStep) * 2
 
-  private val BIG_PADDING = new Array[Int](BIG)
+  private val ENOUGH_ZEROS = new Array[Int](BIG) // For forcing the quick sort and merge sort implementations to kick in
 
   private def isSorted(input: Array[Int]): Assertion = {
     assert(input.zip(input.tail).forall({ case (p, q) => p <= q }))

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -7,55 +7,47 @@ import spire.math.Sorting.{insertionSort, mergeSort, quickSort}
 import spire.std.int._
 
 class SortingTest extends FunSuite with Matchers {
-  private def testSort(before: Array[Int]) = {
-
-    val goal = before.clone()
-    scala.util.Sorting.quickSort(goal)
-
-    val merged = before.clone()
-    mergeSort(merged)
-
-    val quicked = before.clone()
-    quickSort(quicked)
-
-    // make sure our result is ok
-    for (i <- 0 until before.length) assert(merged(i) === goal(i))
-    for (i <- 0 until before.length) assert(quicked(i) === goal(i))
-  }
 
   test("The sort methods can handle empty arrays") {
-    checkAllSortMethods(Array[Int](), Array[Int]())
+    checkAllSortMethods(Array[Int]()){sorted => sorted should contain theSameElementsInOrderAs Array[Int]()}
   }
 
   test("The sort methods can handle singleton arrays") {
-    checkAllSortMethods(Array("lonely"), Array("lonely"))
+    checkAllSortMethods(Array("lonely")){sorted => sorted should contain theSameElementsInOrderAs Array("lonely")}
   }
 
-  test("trivial sort") {
-    testSort(Array(2, 1))
+  test("Sort randomly generated arrays of various sizes") {
+    val sizes = Seq.range(1, 65) ++ Seq(256, 1024, 9121, 65539)
+    val randomGen = new scala.util.Random()
+
+    sizes.foreach { size =>
+      val input: Array[Int] = Array.tabulate(size){_ => randomGen.nextInt(Int.MaxValue)}
+      checkAllSortMethods(input)(isSorted)
+    }
   }
 
-  test("sort 3 decreasing") {
-    testSort(Array(3, 2, 1))
+  test("Sort a decreasing sequence") {
+    checkAllSortMethods(Array(5, 4, 3, 2, 1)){sorted => sorted should contain theSameElementsInOrderAs Array(1, 2, 3, 4, 5)}
   }
 
-  test("sort()") {
-    testSort(Array(23, 1, 52, 64, 234, 623, 124, 421, 421))
-  }
-
-  test("sort 5 decreasing") {
-    testSort(Array(5, 4, 3, 2, 1))
+  test("Sort a constant sequence") {
+    checkAllSortMethods(Array.fill(20){7}) {sorted => sorted should contain theSameElementsInOrderAs Array.fill(20){7}}
   }
 
   test("Sort a list of strings") {
-    checkAllSortMethods(Array("There", "is", "a", "light", "that", "never", "goes", "out"),
-      Array("There", "a", "goes", "is", "light", "never", "out", "that"))
+    checkAllSortMethods(Array("There", "is", "a", "light", "that", "never", "goes", "out")){
+      sorted => sorted should contain theSameElementsInOrderAs Array("There", "a", "goes", "is", "light", "never", "out", "that")
+    }
   }
 
   test("Merge and insertion sorts are stable") {
     // This will fail for quickSort
     checkStability(mergeSort)
     checkStability(insertionSort)
+  }
+
+  private def isSorted(input: Array[Int]): Assertion = {
+    assert(input.zip(input.tail).forall({case (p, q) => p <= q}))
   }
 
   private case class Point(x: Int, y: Int) {
@@ -68,6 +60,12 @@ class SortingTest extends FunSuite with Matchers {
 
   private def arrayOfPoints(coordinates: (Int, Int)*) = (coordinates map { case (x, y) => Point(x, y) }).toArray
 
+
+  private implicit object StringOrder extends Order[String] {
+    override def compare(x: String, y: String): Int = x.compareTo(y)
+  }
+
+
   private def checkStability(sortMethod: Array[Point] => Unit) = {
     val toSort = arrayOfPoints((1, 2), (-1, 4), (1, -20), (3, 5), (1, -10), (4, 1),
       (4, 3), (5, 2), (-6, 3), (10, 10), (4, -5), (23, -23), (0, 0),
@@ -77,24 +75,19 @@ class SortingTest extends FunSuite with Matchers {
       (1, -10), (1, -1), (2, 2), (3, 5), (3, 3), (4, 1), (4, 3), (4, -5),
       (4, 4), (5, 2), (6, 7), (7, 6), (10, 10), (23, -23))
 
-    sortAndCheck(sortMethod, toSort, expectedAfter)
+    checkSortMethod(sortMethod, toSort){_ should contain theSameElementsInOrderAs expectedAfter}
+  }
+  private def checkAllSortMethods[A: Order : ClassTag](toSort: => Array[A])(check: Array[A] => Assertion) = {
+    checkSortMethod(mergeSort[A], toSort)(check)
+    checkSortMethod(quickSort[A], toSort)(check)
+    checkSortMethod(insertionSort[A], toSort)(check)
   }
 
-  private implicit object StringOrder extends Order[String] {
-    override def compare(x: String, y: String): Int = x.compareTo(y)
-  }
-
-  private def checkAllSortMethods[A: Order : ClassTag](toSort: => Array[A], expectedAfter: => Array[A]) = {
-    sortAndCheck(mergeSort[A], toSort, expectedAfter)
-    sortAndCheck(quickSort[A], toSort, expectedAfter)
-    sortAndCheck(insertionSort[A], toSort, expectedAfter)
-  }
-
-  private def sortAndCheck[A: Order : ClassTag](sortMethod: Array[A] => Unit, toSort: Array[A], expectedAfter: Array[A]) = {
+  private def checkSortMethod[A: Order : ClassTag](sortMethod: Array[A] => Unit, toSort: Array[A])(check: Array[A] => Assertion) = {
     val copyForSorting = toSort.clone() // To avoid interdependence between tests, it's important that we clone the input array.
 
     sortMethod(copyForSorting)
 
-    copyForSorting should contain theSameElementsInOrderAs expectedAfter
+    check(copyForSorting)
   }
 }

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -46,6 +46,31 @@ class SortingTest extends FunSuite with Matchers {
     checkStability(insertionSort)
   }
 
+  test("Use insertionSort to sort a specific range") {
+    checkSortMethod[Int](input => InsertionSort.sort(input, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
+      sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 4, 6, 7, 1, -1, 3)
+    }
+  }
+
+  test("Use insertionSort to sort an empty range") {
+    checkSortMethod[Int](input => InsertionSort.sort(input, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
+      sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3)
+    }
+  }
+
+  test("insertionSort: start must be less than or equal to end") {
+    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 4, 3)
+  }
+
+  test("insertionSort: start must be nonnegative") {
+    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), -1, 3)
+  }
+
+  test("insertionSort: end cannot exceed the length of the input array") {
+    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 2, 6)
+  }
+
+
   private def isSorted(input: Array[Int]): Assertion = {
     assert(input.zip(input.tail).forall({case (p, q) => p <= q}))
   }
@@ -64,7 +89,6 @@ class SortingTest extends FunSuite with Matchers {
   private implicit object StringOrder extends Order[String] {
     override def compare(x: String, y: String): Int = x.compareTo(y)
   }
-
 
   private def checkStability(sortMethod: Array[Point] => Unit) = {
     val toSort = arrayOfPoints((1, 2), (-1, 4), (1, -20), (3, 5), (1, -10), (4, 1),

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -46,30 +46,66 @@ class SortingTest extends FunSuite with Matchers {
     checkStability(insertionSort)
   }
 
-  test("Use insertionSort to sort a specific range") {
+  test("Use InsertionSort to sort a specific range") {
     checkSortMethod[Int](input => InsertionSort.sort(input, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
       sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 4, 6, 7, 1, -1, 3)
     }
   }
 
-  test("Use insertionSort to sort an empty range") {
+  test("Use InsertionSort to sort an empty range") {
     checkSortMethod[Int](input => InsertionSort.sort(input, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
       sorted => sorted should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3)
     }
   }
 
-  test("insertionSort: start must be less than or equal to end") {
+  test("InsertionSort: start must be less than or equal to end") {
     an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 4, 3)
   }
 
-  test("insertionSort: start must be nonnegative") {
+  test("InsertionSort: start must be nonnegative") {
     an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), -1, 3)
   }
 
-  test("insertionSort: end cannot exceed the length of the input array") {
+  test("InsertionSort: end cannot exceed the length of the input array") {
     an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 2, 6)
   }
 
+  test("MergeSort.merge merges segments of the input and writes to the output") {
+    val outputArray = new Array[Int](9)
+    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 1, 4, 7)
+    outputArray should contain theSameElementsInOrderAs Array(0, 2, 4, 3, 5, 13, 19, 0, 0)
+  }
+
+  test("MergeSort.merge succeeds when start and end are the extreme allowed values") {
+    val outputArray = new Array[Int](9)
+    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 0, 4, 9)
+    outputArray should contain theSameElementsInOrderAs Array(1, 2, 4, 3, 5, 13, 19, -2, 9)
+  }
+
+  test("MergeSort.merge does nothing when start = mid = end") {
+    val outputArray = new Array[Int](9)
+    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 4, 4, 4)
+    outputArray should contain theSameElementsInOrderAs Array(0, 0, 0, 0, 0, 0, 0, 0, 0)
+  }
+
+
+  test("MergeSort.merge: end cannot exceed the size of the output array") {
+    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](4), 3, 7, 8)
+  }
+
+  test("MergeSort.merge: end cannot exceed the size of the input array") {
+    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 3, 7, 12)
+  }
+
+  test("MergeSort.merge: start must be nonnegative") {
+    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), -1, 2, 4)
+  }
+
+  test("MergeSort.merge: start <= mid <= end") {
+    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 3, 1, 5)
+    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 1, 5, 3)
+
+  }
 
   private def isSorted(input: Array[Int]): Assertion = {
     assert(input.zip(input.tail).forall({case (p, q) => p <= q}))

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -9,11 +9,11 @@ import spire.std.int._
 class SortingTest extends FunSuite with Matchers {
 
   test("The sort methods can handle empty arrays") {
-    checkAllSortMethods(Array[Int]()){_ should contain theSameElementsInOrderAs Array[Int]()}
+    matchAgainstExpectedForEachSortMethod(Array[Int](), Array[Int]())
   }
 
   test("The sort methods can handle singleton arrays") {
-    checkAllSortMethods(Array("lonely")){_ should contain theSameElementsInOrderAs Array("lonely")}
+    matchAgainstExpectedForEachSortMethod(Array("lonely"), Array("lonely"))
   }
 
   test("Sort randomly generated arrays of various sizes") {
@@ -27,17 +27,15 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Sort a decreasing sequence") {
-    checkAllSortMethods(Array.range(0, forceStrategySize).reverse){ _ should contain theSameElementsInOrderAs Array.range(0, forceStrategySize) }
+    matchAgainstExpectedForEachSortMethod(Array.range(0, forceStrategySize).reverse, Array.range(0, forceStrategySize))
   }
 
   test("Sort a constant sequence") {
-    checkAllSortMethods(Array.fill(20){7}) { _ should contain theSameElementsInOrderAs Array.fill(20){7}}
+    matchAgainstExpectedForEachSortMethod(Array.fill(20){7}, Array.fill(20){7})
   }
 
   test("Sort a list of strings") {
-    checkAllSortMethods(Array("There", "is", "a", "light", "that", "never", "goes", "out")){
-      _ should contain theSameElementsInOrderAs Array("There", "a", "goes", "is", "light", "never", "out", "that")
-    }
+    matchAgainstExpectedForEachSortMethod(Array("There", "is", "a", "light", "that", "never", "goes", "out"), Array("There", "a", "goes", "is", "light", "never", "out", "that"))
   }
 
   test("Merge and insertion sorts are stable") {
@@ -47,15 +45,11 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use InsertionSort to sort a specific range") {
-    checkSortMethod[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
-      _ should contain theSameElementsInOrderAs Array(5, 8, 4, 6, 7, 1, -1, 3)
-    }
+    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3), Array(5, 8, 4, 6, 7, 1, -1, 3))
   }
 
   test("Use InsertionSort to sort an empty range") {
-    checkSortMethod[Int](InsertionSort.sort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3)) {
-      _ should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3)
-    }
+    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3), Array(5, 8, 7, 6, 4, 1, -1, 3))
   }
 
   test("InsertionSort: start must be less than or equal to end") {
@@ -71,22 +65,16 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("MergeSort.merge merges segments of the input and writes to the output") {
-    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7), new Array[Int](9)) {
-      _ should contain theSameElementsInOrderAs Array(0, 2, 4, 3, 5, 13, 19, 0, 0)
-    }
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7), new Array[Int](9), Array(0, 2, 4, 3, 5, 13, 19, 0, 0))
   }
 
   test("MergeSort.merge succeeds when start and end are the extreme allowed values") {
-    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 0, 4, 9), new Array[Int](9)) {
-      _ should contain theSameElementsInOrderAs Array(1, 2, 4, 3, 5, 13, 19, -2, 9)
-    }
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 0, 4, 9), new Array[Int](9), Array(1, 2, 4, 3, 5, 13, 19, -2, 9))
   }
 
   test("MergeSort.merge does nothing when start = mid = end") {
-    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 4, 4, 4), new Array[Int](9)) {
-      _ should contain theSameElementsInOrderAs Array(0, 0, 0, 0, 0, 0, 0, 0, 0)
-    }
-  }
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 4, 4, 4), new Array[Int](9), Array(0, 0, 0, 0, 0, 0, 0, 0, 0))
+   }
 
 
   test("MergeSort.merge: end cannot exceed the size of the output array") {
@@ -108,15 +96,11 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use QuickSort to sort a specific range: start is inclusive, end is exclusive") {
-    checkSortMethod[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding) {
-      _ should contain theSameElementsInOrderAs Array(5, -1, 1, 4, 6, 7, 8, 3) ++ forceQuickSortPadding
-    }
+    matchAgainstExpected[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding, Array(5, -1, 1, 4, 6, 7, 8, 3) ++ forceQuickSortPadding)
   }
 
   test("Use QuickSort to sort an empty range") {
-    checkSortMethod[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding) {
-      _ should contain theSameElementsInOrderAs Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding
-    }
+    matchAgainstExpected[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding, Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding)
   }
 
   test("QuickSort: start must be less than or equal to end") {
@@ -133,9 +117,7 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("QuickSort: Partitioning an array") {
-    checkSortMethod[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10)) {
-      _ should contain theSameElementsInOrderAs Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10)
-    }
+    matchAgainstExpected[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10), Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10))
   }
 
   private val forceStrategySize = max(QuickSort.limit, MergeSort.startStep) * 2
@@ -170,19 +152,32 @@ class SortingTest extends FunSuite with Matchers {
       (1, -10), (1, -1), (2, 2), (3, 5), (3, 3), (4, 1), (4, 3), (4, -5),
       (4, 4), (5, 2), (6, 7), (7, 6), (10, 10), (23, -23))
 
-    checkSortMethod(sortMethod, toSort){_ should contain theSameElementsInOrderAs expectedAfter}
+    matchAgainstExpected(sortMethod, toSort, expectedAfter)
   }
+
+  private def matchAgainstExpected[A: Order : ClassTag](mutation: Array[A] => Unit, toMutate: Array[A], expectedAfter: Array[A]) = {
+    checkMutation(mutation, toMutate) {
+      _ should contain theSameElementsInOrderAs expectedAfter
+    }
+  }
+
+  private def matchAgainstExpectedForEachSortMethod[A: Order : ClassTag](toMutate: Array[A], expected: Array[A]) = {
+    checkAllSortMethods(toMutate) {
+      _ should contain theSameElementsInOrderAs expected
+    }
+  }
+
   private def checkAllSortMethods[A: Order : ClassTag](toSort: => Array[A])(check: Array[A] => Assertion) = {
-    checkSortMethod(mergeSort[A], toSort)(check)
-    checkSortMethod(quickSort[A], toSort)(check)
-    checkSortMethod(insertionSort[A], toSort)(check)
+    checkMutation(mergeSort[A], toSort)(check)
+    checkMutation(quickSort[A], toSort)(check)
+    checkMutation(insertionSort[A], toSort)(check)
   }
 
-  private def checkSortMethod[A: Order : ClassTag](sortMethod: Array[A] => Unit, toSort: Array[A])(check: Array[A] => Assertion) = {
-    val copyForSorting = toSort.clone() // To avoid interdependence between tests, it's important that we clone the input array.
+  private def checkMutation[A: Order : ClassTag](mutation: Array[A] => Unit, toMutate: Array[A])(check: Array[A] => Assertion) = {
+    val copyForMutation = toMutate.clone() // To avoid interdependence between tests, it's important that we clone the input array.
 
-    sortMethod(copyForSorting)
+    mutation(copyForMutation)
 
-    check(copyForSorting)
+    check(copyForMutation)
   }
 }

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -71,21 +71,21 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("MergeSort.merge merges segments of the input and writes to the output") {
-    val outputArray = new Array[Int](9)
-    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 1, 4, 7)
-    outputArray should contain theSameElementsInOrderAs Array(0, 2, 4, 3, 5, 13, 19, 0, 0)
+    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7), new Array[Int](9)) {
+      _ should contain theSameElementsInOrderAs Array(0, 2, 4, 3, 5, 13, 19, 0, 0)
+    }
   }
 
   test("MergeSort.merge succeeds when start and end are the extreme allowed values") {
-    val outputArray = new Array[Int](9)
-    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 0, 4, 9)
-    outputArray should contain theSameElementsInOrderAs Array(1, 2, 4, 3, 5, 13, 19, -2, 9)
+    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 0, 4, 9), new Array[Int](9)) {
+      _ should contain theSameElementsInOrderAs Array(1, 2, 4, 3, 5, 13, 19, -2, 9)
+    }
   }
 
   test("MergeSort.merge does nothing when start = mid = end") {
-    val outputArray = new Array[Int](9)
-    MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), outputArray, 4, 4, 4)
-    outputArray should contain theSameElementsInOrderAs Array(0, 0, 0, 0, 0, 0, 0, 0, 0)
+    checkSortMethod[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 4, 4, 4), new Array[Int](9)) {
+      _ should contain theSameElementsInOrderAs Array(0, 0, 0, 0, 0, 0, 0, 0, 0)
+    }
   }
 
 
@@ -130,6 +130,12 @@ class SortingTest extends FunSuite with Matchers {
   test("QuickSort: end cannot exceed the length of the input array") {
     val input = Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding
     an [IllegalArgumentException] should be thrownBy QuickSort.qsort(input, 2, input.length + 1)
+  }
+
+  test("QuickSort: Partitioning an array") {
+    checkSortMethod[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10)) {
+      _ should contain theSameElementsInOrderAs Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10)
+    }
   }
 
   private val forceStrategySize = max(QuickSort.limit, MergeSort.startStep) * 2

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -21,21 +21,26 @@ class SortingTest extends FunSuite with Matchers {
     val randomGen = new scala.util.Random()
 
     sizes.foreach { size =>
-      val input: Array[Int] = Array.tabulate(size){_ => randomGen.nextInt(Int.MaxValue)}
+      val input: Array[Int] = Array.tabulate(size) { _ => randomGen.nextInt(Int.MaxValue) }
       checkAllSortMethods(input)(isSorted)
     }
   }
 
   test("Sort a decreasing sequence") {
-    matchAgainstExpectedForEachSortMethod(Array.range(0, forceStrategySize).reverse, Array.range(0, forceStrategySize))
+    matchAgainstExpectedForEachSortMethod(Array.range(0, BIG).reverse, Array.range(0, BIG))
   }
 
   test("Sort a constant sequence") {
-    matchAgainstExpectedForEachSortMethod(Array.fill(20){7}, Array.fill(20){7})
+    matchAgainstExpectedForEachSortMethod(Array.fill(20) {
+      7
+    }, Array.fill(20) {
+      7
+    })
   }
 
   test("Sort a list of strings") {
-    matchAgainstExpectedForEachSortMethod(Array("There", "is", "a", "light", "that", "never", "goes", "out"), Array("There", "a", "goes", "is", "light", "never", "out", "that"))
+    matchAgainstExpectedForEachSortMethod(Array("There", "is", "a", "light", "that", "never", "goes", "out"),
+      Array("There", "a", "goes", "is", "light", "never", "out", "that"))
   }
 
   test("Merge and insertion sorts are stable") {
@@ -45,87 +50,107 @@ class SortingTest extends FunSuite with Matchers {
   }
 
   test("Use InsertionSort to sort a specific range") {
-    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3), Array(5, 8, 4, 6, 7, 1, -1, 3))
+    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 5), Array(5, 8, 7, 6, 4, 1, -1, 3),
+      Array(5, 8, 4, 6, 7, 1, -1, 3))
   }
 
   test("Use InsertionSort to sort an empty range") {
-    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3), Array(5, 8, 7, 6, 4, 1, -1, 3))
+    matchAgainstExpected[Int](InsertionSort.sort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3),
+      Array(5, 8, 7, 6, 4, 1, -1, 3))
   }
 
   test("InsertionSort: start must be less than or equal to end") {
-    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 4, 3)
+    an[IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 4, 3)
   }
 
   test("InsertionSort: start must be nonnegative") {
-    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), -1, 3)
+    an[IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), -1, 3)
   }
 
   test("InsertionSort: end cannot exceed the length of the input array") {
-    an [IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 2, 6)
+    an[IllegalArgumentException] should be thrownBy InsertionSort.sort(Array(7, 6, 4, 2, 1), 2, 6)
   }
 
   test("MergeSort.merge merges segments of the input and writes to the output") {
-    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7), new Array[Int](9), Array(0, 2, 4, 3, 5, 13, 19, 0, 0))
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 1, 4, 7),
+      new Array[Int](9), Array(0, 2, 4, 3, 5, 13, 19, 0, 0))
   }
 
   test("MergeSort.merge succeeds when start and end are the extreme allowed values") {
-    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 0, 4, 9), new Array[Int](9), Array(1, 2, 4, 3, 5, 13, 19, -2, 9))
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 0, 4, 9),
+      new Array[Int](9), Array(1, 2, 4, 3, 5, 13, 19, -2, 9))
   }
 
   test("MergeSort.merge does nothing when start = mid = end") {
-    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 4, 4, 4), new Array[Int](9), Array(0, 0, 0, 0, 0, 0, 0, 0, 0))
-   }
+    matchAgainstExpected[Int](MergeSort.merge(Array(1, 2, 5, 13, 4, 3, 19, -2, 9), _, 4, 4, 4),
+      new Array[Int](9), Array(0, 0, 0, 0, 0, 0, 0, 0, 0))
+  }
 
 
   test("MergeSort.merge: end cannot exceed the size of the output array") {
-    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](4), 3, 7, 8)
+    an[IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9),
+      new Array[Int](4), 3, 7, 8)
   }
 
   test("MergeSort.merge: end cannot exceed the size of the input array") {
-    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 3, 7, 12)
+    an[IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9),
+      new Array[Int](20), 3, 7, 12)
   }
 
   test("MergeSort.merge: start must be nonnegative") {
-    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), -1, 2, 4)
+    an[IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9),
+      new Array[Int](20), -1, 2, 4)
   }
 
   test("MergeSort.merge: start <= mid <= end") {
-    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 3, 1, 5)
-    an [IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9), new Array[Int](20), 1, 5, 3)
+    an[IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9),
+      new Array[Int](20), 3, 1, 5)
+    an[IllegalArgumentException] should be thrownBy MergeSort.merge(Array(5, 3, 4, 7, 5, 8, 9),
+      new Array[Int](20), 1, 5, 3)
 
   }
 
   test("Use QuickSort to sort a specific range: start is inclusive, end is exclusive") {
-    matchAgainstExpected[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding, Array(5, -1, 1, 4, 6, 7, 8, 3) ++ forceQuickSortPadding)
+    matchAgainstExpected[Int](QuickSort.qsort(_, 1, 7), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING,
+      Array(5, -1, 1, 4, 6, 7, 8, 3) ++ BIG_PADDING)
   }
 
   test("Use QuickSort to sort an empty range") {
-    matchAgainstExpected[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding, Array(5, 8, 7, 6, 4, 1, -1, 3) ++ forceQuickSortPadding)
+    matchAgainstExpected[Int](QuickSort.qsort(_, 2, 2), Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING,
+      Array(5, 8, 7, 6, 4, 1, -1, 3) ++ BIG_PADDING)
   }
 
   test("QuickSort: start must be less than or equal to end") {
-    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding, 4, 3)
+    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ BIG_PADDING, 4, 3)
   }
 
   test("QuickSort: start must be nonnegative") {
-    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding, -1, 16)
+    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(Array(7, 6, 4, 2, 1) ++ BIG_PADDING, -1, 16)
   }
 
   test("QuickSort: end cannot exceed the length of the input array") {
-    val input = Array(7, 6, 4, 2, 1) ++ forceQuickSortPadding
-    an [IllegalArgumentException] should be thrownBy QuickSort.qsort(input, 2, input.length + 1)
+    val input = Array(7, 6, 4, 2, 1) ++ BIG_PADDING
+    an[IllegalArgumentException] should be thrownBy QuickSort.qsort(input, 2, input.length + 1)
   }
 
   test("QuickSort: Partitioning an array") {
-    matchAgainstExpected[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10), Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10))
+    matchAgainstExpected[Int](QuickSort.partition(_, 2, 9, 5), Array(6, -1, 5, 11, 2, 7, 8, 1, 9, 2, 10),
+      Array(6, -1, 5, 2, 1, 7, 8, 11, 9, 2, 10))
   }
 
-  private val forceStrategySize = max(QuickSort.limit, MergeSort.startStep) * 2
+  test("QuickSort.partition: 0 <= start <= pivot < end <= length of input") {
+    val input = Array(2, 3, 4, 6)
+    Array((-1, 2, 1), (0, 5, 2), (0, 4, 4), (2, 4, 1), (1, 3, 4)).foreach {
+      case (start, end, pivotIndex) => an [IllegalArgumentException] should be thrownBy QuickSort.partition(input, start, end, pivotIndex)
+    }
+  }
 
-  private val forceQuickSortPadding = new Array[Int](forceStrategySize)
+  private val BIG = max(QuickSort.limit, MergeSort.startStep) * 2
+
+  private val BIG_PADDING = new Array[Int](BIG)
 
   private def isSorted(input: Array[Int]): Assertion = {
-    assert(input.zip(input.tail).forall({case (p, q) => p <= q}))
+    assert(input.zip(input.tail).forall({ case (p, q) => p <= q }))
   }
 
   private case class Point(x: Int, y: Int) {

--- a/tests/src/test/scala/spire/math/SortingTest.scala
+++ b/tests/src/test/scala/spire/math/SortingTest.scala
@@ -1,12 +1,12 @@
 package spire
 package math
 
-import org.scalatest.FunSuite
-
+import org.scalatest._
+import spire.algebra.Order
 import spire.std.int._
 
-class SortingTest extends FunSuite {
-  def testSort(before: Array[Int]) = {
+class SortingTest extends FunSuite with Matchers {
+  private def testSort(before: Array[Int]) = {
 
     val goal = before.clone()
     scala.util.Sorting.quickSort(goal)
@@ -14,13 +14,14 @@ class SortingTest extends FunSuite {
     val merged = before.clone()
     Sorting.mergeSort(merged)
 
-     val quicked = before.clone()
-     Sorting.quickSort(quicked)
+    val quicked = before.clone()
+    Sorting.quickSort(quicked)
 
     // make sure our result is ok
     for (i <- 0 until before.length) assert(merged(i) === goal(i))
-     for (i <- 0 until before.length) assert(quicked(i) === goal(i))
+    for (i <- 0 until before.length) assert(quicked(i) === goal(i))
   }
+
 
   test("sort empty array") {
     testSort(Array[Int]())
@@ -44,5 +45,35 @@ class SortingTest extends FunSuite {
 
   test("sort 5 decreasing") {
     testSort(Array(5, 4, 3, 2, 1))
+  }
+
+  case class Point(x: Int, y: Int) {
+    override def toString: String = s"($x, $y)"
+  }
+
+  implicit object PointOrder extends Order[Point] {
+    override def compare(a: Point, b: Point): Int = a.x.compareTo(b.x)
+  }
+
+  private def arrayOfPoints(coordinates: (Int, Int)*) = (coordinates map {case (x, y) => Point(x, y)}).toArray
+
+  test("Merge and insertion sorts are stable") {
+    checkStability(Sorting.mergeSort[Point])
+    checkStability(Sorting.insertionSort[Point])
+  }
+
+
+  private def checkStability(sortMethod: Array[Point] => Unit) = {
+    val toSort = arrayOfPoints((1, 2), (-1, 4), (1, -20), (3, 5), (1, -10), (4, 1),
+      (4, 3), (5, 2), (-6, 3), (10, 10), (4, -5), (23, -23), (0, 0),
+      (6, 7), (7, 6), (1, -1), (-1, 8), (4, 4), (3, 3), (2, 2))
+
+    val expectedAfter = arrayOfPoints((-6, 3), (-1, 4), (-1, 8), (0, 0), (1, 2), (1, -20),
+      (1, -10), (1, -1), (2, 2), (3, 5), (3, 3), (4, 1), (4, 3), (4, -5),
+      (4, 4), (5, 2), (6, 7), (7, 6), (10, 10), (23, -23))
+
+    sortMethod(toSort)
+
+    toSort should contain theSameElementsInOrderAs expectedAfter
   }
 }


### PR DESCRIPTION
This is intended to resolve Issue #721, which relates to inconsistencies across the implementations of MergeSort, InsertionSort, and QuickSort. 

1) All these strategies operate in place on segments of arrays that start and end at specified indices. In the QuickSort implementation, the end index was inclusive, while it was exclusive in MergeSort and InsertionSort. This has been fixed in this changeset to make the end index exclusive in all three implementations, following the convention in the Java Collections library. Validity and boundary checks have been introduced for the various parameters. Unit tests have been written to document and test the new behavior. 

2) The naming of the start and end indices has been made consistent.

3) Unit tests have been added for checking correctness, stability, edge cases, etc. 

4) Scaladocs have been added for all the utility methods in the Sorting package. 