### PR TITLE
Disabled benchmarks depending on Caliper.

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -4,7 +4,7 @@ package benchmark
 import spire.algebra._
 import spire.math._
 import spire.implicits._
-
+/*
 object AddBenchmarks extends MyRunner(classOf[AddBenchmarks])
 
 class AddBenchmarks extends MyBenchmark with BenchmarkData {
@@ -80,3 +80,4 @@ class AddBenchmarks extends MyBenchmark with BenchmarkData {
   def timeAddComplexesGeneric(reps:Int) = run(reps)(addGeneric(complexes))
   def timeAddFastComplexes(reps:Int) = run(reps)(addFastComplexes(fcomplexes))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValAddBenchmarks.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -101,3 +101,4 @@ class AnyValAddBenchmarks extends MyBenchmark {
   def timeAddDoublesDirect(reps:Int) = run(reps)(addDoublesDirect(doubles))
   def timeAddDoublesGeneric(reps:Int) = run(reps)(addGeneric(doubles))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AnyValSubtractBenchmarks.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -100,3 +100,4 @@ class AnyValSubtractBenchmarks extends MyBenchmark {
   def timeSubtractDoublesDirect(reps:Int) = run(reps)(subtractDoublesDirect(doubles))
   def timeSubtractDoublesGeneric(reps:Int) = run(reps)(subtractGeneric(doubles))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ArrayOrderBenchmark.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -74,3 +74,4 @@ class ArrayOrderBenchmarks extends MyBenchmark {
   def timeAddIndirect(reps: Int) = run(reps) { indirectAdd(a, b) }
   def timeAddDirect(reps: Int) = run(reps) { directAdd(a, b) }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Benchmark.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -47,3 +47,4 @@ trait BenchmarkData extends MyBenchmark {
   lazy val complexes = init(size)(nextComplex)
   lazy val fcomplexes = init(size)(FastComplex(nextFloat(), nextFloat()))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/BigIntRational.scala
+++ b/benchmark/src/main/scala/spire/benchmark/BigIntRational.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 object BigIntRational {
   val Zero = new BigIntRational(0, 1)
   val One = new BigIntRational(1, 1)
@@ -89,3 +89,4 @@ final class BigIntRational private (val n: BigInt, val d: BigInt) {
 
   def signum: Int = n.signum
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CForBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -320,3 +320,4 @@ class CForBenchmarks extends MyBenchmark {
     }
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/CheckedBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.macros.Checked
 import com.google.caliper.Param
 
@@ -59,3 +59,4 @@ class CheckedBenchmarks extends MyBenchmark {
     sum
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ComplexAddBenchmarks.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -73,3 +73,4 @@ class ComplexAddBenchmarks extends MyBenchmark {
   def timeAddFloatComplexesBoxed(reps:Int) = run(reps)(addFloatComplexesBoxed(fcs))
   def timeAddFloatComplexesUnboxed(reps:Int) = run(reps)(addFloatComplexesUnboxed(longs))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FibBenchmark.scala
@@ -6,7 +6,7 @@ import spire.math._
 import spire.implicits._
 
 import java.math.BigInteger
-
+/*
 object BigIntegerIsRig extends Rig[BigInteger] {
   def zero: BigInteger = new BigInteger("0")
   def one: BigInteger = new BigInteger("1")
@@ -134,3 +134,4 @@ class FibBenchmarks extends MyBenchmark {
     loop(n, BigInt(0), BigInt(1))
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FixtureSupport.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.math.Complex
 
 
@@ -38,3 +38,4 @@ trait FixtureSupport {
   def nextComplex = Complex(nextDouble, nextDouble)
 
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/FpFilterBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import com.google.caliper.Param
 
 import java.math.MathContext.UNLIMITED
@@ -77,3 +77,4 @@ class FpFilterBenchmark extends MyBenchmark {
   def timeBigDecimal(reps: Int) = run(reps)(findSign(Orient2.slow))
   def timeFpFilter(reps: Int) = run(reps)(findSign(Orient2.fast))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/GcdBenchmarks.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -91,3 +91,4 @@ class GcdBenchmarks extends MyBenchmark {
   }
 }
 
+*/

--- a/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/JuliaBenchmarks.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.implicits._
 import spire.math._
 
@@ -94,3 +94,4 @@ class JuliaBenchmarks extends MyBenchmark {
     total
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/LongRational.scala
+++ b/benchmark/src/main/scala/spire/benchmark/LongRational.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.implicits._
 
 object LongRational {
@@ -97,3 +97,4 @@ final class LongRational private (val n: Long, val d: Long) {
 }
 
 
+*/

--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.algebra._
 import spire.implicits._
 
@@ -123,3 +123,4 @@ class MapSemigroupBenchmarks extends MyBenchmark with BenchmarkData {
     }
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MergeBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.implicits._
 import spire.math.Rational
 import spire.math.BinaryMerge
@@ -21,3 +21,4 @@ object MergeBenchmark extends App {
   val bi = (1000 until 1001).toArray
   th.pbenchOffWarm("binary merge vs. linear merge (Int)")(th.Warm(LinearMerge.merge(ai,bi)))(th.Warm(BinaryMerge.merge(ai,bi)))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Mo5Benchmarks.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -42,3 +42,4 @@ class Mo5Benchmarks extends MyBenchmark {
     a.length
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/NaturalBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 
 import scala.util.Random
 
@@ -58,3 +58,4 @@ class NaturalBenchmarks extends MyBenchmark {
   def timeBigIntMin(reps: Int) = run(reps)(bigints.qmin)
   def timeSafeLongMin(reps: Int) = run(reps)(safes.qmin)
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PolynomialBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -185,3 +185,4 @@ class PolynomialBenchmarks extends MyBenchmark {
   def timeQuotModSpireDoublePolysDense(reps: Int) = run(reps)(quotModSpireDoublePolynomials(spireDenseDoublePolys))
 
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/PowBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 
 import scala.util.Random
 import Random._
@@ -75,3 +75,4 @@ class PowBenchmarks extends MyBenchmark {
     t
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RandomBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.implicits._
 
 object RandomBenchmarks extends MyRunner(classOf[RandomBenchmarks])
@@ -650,3 +650,4 @@ class RandomBenchmarks extends MyBenchmark with BenchmarkData {
     cfor(0)(_ < nextLen, _ + 1)(_ => rng.fillBytes(bytes))
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RatComparisonBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import scala.util.Random
 import Random._
 
@@ -153,3 +153,4 @@ class RatComparisonBenchmarks extends MyBenchmark {
     total
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 
 import spire.math._
@@ -119,3 +119,4 @@ class RationalBenchmarks extends MyBenchmark with BenchmarkData {
   def timeLongRationalSum(reps: Int) = run(reps)(longSum(longRats))
   def timeLongRationalProd(reps: Int) = run(reps)(longProd(longRats))
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RexBenchmark.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import spire.implicits._
 import spire.math._
 
@@ -100,3 +100,4 @@ class RexBenchmarks extends MyBenchmark with BenchmarkData {
     ai(k)
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -8,7 +8,7 @@ import spire.algebra._
 import spire.std.any._
 
 import scala.math.{Numeric => ScalaN}
-
+/*
 import com.google.caliper.Param
 
 object ScalaVsSpireBenchmarks extends MyRunner(classOf[ScalaVsSpireBenchmarks])
@@ -229,3 +229,4 @@ class ScalaVsSpireBenchmarks extends MyBenchmark {
 //  @tailrec final def gcd[A: Integral](a: A, b: A): A =
 //    if (a % b == implicitly[Integra[A]].zero) b else gcd(b, a % b)
 //}
+*/

--- a/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SelectionBenchmarks.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -90,3 +90,4 @@ class SelectionBenchmarks extends MyBenchmark {
     }
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SieveBenchmark.scala
@@ -1,6 +1,6 @@
 package spire
 package benchmark
-
+/*
 import spire.math.prime._
 import scala.util.{Success, Try}
 
@@ -47,3 +47,4 @@ object SieveBenchmark {
     ns.foreach(n => timer("  sieve.nth (%s)" format n)(nth(n)))
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SortingBenchmarks.scala
@@ -1,7 +1,7 @@
 package spire
 package benchmark
 
-
+/*
 import scala.util.Random
 import Random._
 
@@ -141,3 +141,4 @@ class SortingBenchmarks extends MyBenchmark with BenchmarkData {
     }
   }
 }
+*/

--- a/benchmark/src/main/scala/spire/benchmark/ZigguratBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ZigguratBenchmarks.scala
@@ -16,7 +16,7 @@ package spire
 package benchmark
 
 import spire.implicits._
-
+/*
 /**
  * This is a benchmark comparing Marsaglias Polar Method implementation with the implementation of his Ziggurat algorithm.
  *
@@ -63,3 +63,4 @@ class ZigguratBenchmarks extends MyBenchmark with BenchmarkData {
     cfor(0)(_ < nextLen, _ + 1)(_ => t += spire.random.Ziggurat.rexp(rng))
   }
 }
+*/

--- a/build.sbt
+++ b/build.sbt
@@ -347,15 +347,6 @@ lazy val benchmarkSettings = Seq(
     "org.apfloat" % "apfloat" % apfloatVersion,
     "org.jscience" % "jscience" % jscienceVersion,
     "org.apache.commons" % "commons-math3" % apacheCommonsMath3Version,
-
-    // thyme
-    "ichi.bench" % "thyme" %  "0.1.0" from "http://plastic-idolatry.com/jars/thyme-0.1.0.jar",
-
-    // caliper stuff
-    "com.google.guava" % "guava" %  "18.0",
-    "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" %  "2.1",
-    "com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT" from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar",
-    "com.google.code.gson" % "gson" % "1.7.2"
   ),
 
   // enable forking in run


### PR DESCRIPTION
The Spire project cannot be imported into IntelliJ because the Caliper jars are missing for 1.0-SNAPSHOT. This PR comments out the benchmarks based on Caliper.