### PR TITLE
chore: migrate context bounds ahead of 3.8.0

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/Arrays.scala
+++ b/benchmark/src/main/scala/spire/benchmark/Arrays.scala
@@ -50,8 +50,8 @@ object Arrays {
     val order = Order[A]
     layout match {
       case ArrayOrder.Random   =>
-      case ArrayOrder.Sorted   => spire.math.Sorting.sort(data)(order, ct)
-      case ArrayOrder.Reversed => spire.math.Sorting.sort(data)(Order.reverse(order), ct)
+      case ArrayOrder.Sorted   => spire.math.Sorting.sort(data)(using order, ct)
+      case ArrayOrder.Reversed => spire.math.Sorting.sort(data)(using Order.reverse(order), ct)
     }
     data
   }

--- a/benchmark/src/main/scala/spire/benchmark/SizedArrays.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SizedArrays.scala
@@ -43,8 +43,8 @@ object SizedArrays {
     val order = Order[A]
     layout match {
       case ArrayOrder.Random   =>
-      case ArrayOrder.Sorted   => spire.math.Sorting.sort(data)(order, ct)
-      case ArrayOrder.Reversed => spire.math.Sorting.sort(data)(Order.reverse(order), ct)
+      case ArrayOrder.Sorted   => spire.math.Sorting.sort(data)(using order, ct)
+      case ArrayOrder.Reversed => spire.math.Sorting.sort(data)(using Order.reverse(order), ct)
     }
     data
   }

--- a/core/src/main/scala/spire/algebra/UniqueFactorizationDomain.scala
+++ b/core/src/main/scala/spire/algebra/UniqueFactorizationDomain.scala
@@ -64,6 +64,6 @@ object UniqueFactorizationDomain {
   implicit def uniqueFactorizationDomainFromIntegral[A](implicit A: Integral[A]): UniqueFactorizationDomain[A] =
     new UniqueFactorizationDomain[A] {
       def isPrime(a: A): Boolean = SafeLong(A.toBigInt(a)).isPrime
-      def factor(a: A): Decomposition[A] = WrapDecomposition[A](SafeLong(A.toBigInt(a)).factor)(A)
+      def factor(a: A): Decomposition[A] = WrapDecomposition[A](SafeLong(A.toBigInt(a)).factor)(using A)
     }
 }

--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -507,7 +507,7 @@ trait Polynomial[@sp(Double) C] { lhs =>
       foreach { (e, c) => bldr += Term(c, e) }
 
       val ts = bldr.result()
-      QuickSort.sort(ts)(Order.reverse(Order[Term[C]]), implicitly[ClassTag[Term[C]]])
+      QuickSort.sort(ts)(using Order.reverse(Order[Term[C]]), implicitly[ClassTag[Term[C]]])
       val s = ts.mkString
       "(" + (if (s.take(3) == " - ") "-" + s.drop(3) else s.drop(3)) + ")"
     }

--- a/core/src/main/scala/spire/optional/vectorOrder.scala
+++ b/core/src/main/scala/spire/optional/vectorOrder.scala
@@ -27,13 +27,13 @@ trait VectorOrderLow {
   implicit def seqEq[A, CC[A] <: SeqOps[A, Seq, CC[A]]](implicit
     A0: Eq[A],
     module: CModule[CC[A], A]
-  ): SeqVectorEq[A, CC[A]] = new SeqVectorEq[A, CC[A]]()(A0, module.scalar)
+  ): SeqVectorEq[A, CC[A]] = new SeqVectorEq[A, CC[A]](using A0, module.scalar)
 
   implicit def arrayEq[@sp(Int, Long, Float, Double) A](implicit
     ev: Eq[A],
     module: CModule[Array[A], A]
   ): ArrayVectorEq[A] =
-    new ArrayVectorEq[A]()(ev, module.scalar)
+    new ArrayVectorEq[A](using ev, module.scalar)
 
   implicit def mapEq[K, V](implicit V0: Eq[V], module: CModule[Map[K, V], V]): MapVectorEq[K, V] =
     new MapVectorEq[K, V]()(V0, module.scalar)
@@ -48,11 +48,11 @@ object vectorOrder extends VectorOrderLow {
   implicit def seqOrder[A, CC[A] <: SeqOps[A, Seq, CC[A]]](implicit
     A0: Order[A],
     module: CModule[CC[A], A]
-  ): SeqVectorOrder[A, CC[A]] = new SeqVectorOrder[A, CC[A]]()(A0, module.scalar)
+  ): SeqVectorOrder[A, CC[A]] = new SeqVectorOrder[A, CC[A]](using A0, module.scalar)
 
   implicit def arrayOrder[@sp(Int, Long, Float, Double) A](implicit
     ev: Order[A],
     module: CModule[Array[A], A]
   ): ArrayVectorOrder[A] =
-    new ArrayVectorOrder[A]()(ev, module.scalar)
+    new ArrayVectorOrder[A](using ev, module.scalar)
 }

--- a/extras/src/main/scala/spire/math/extras/interval/IntervalSeq.scala
+++ b/extras/src/main/scala/spire/math/extras/interval/IntervalSeq.scala
@@ -235,12 +235,13 @@ object IntervalSeq {
 
   def hole[T: Order](value: T): IntervalSeq[T] = singleton(true, value, K01)
 
-  def empty[T: Order]: IntervalSeq[T] = new IntervalSeq[T](false, Array()(classTag), Array(), implicitly[Order[T]])
+  def empty[T: Order]: IntervalSeq[T] =
+    new IntervalSeq[T](false, Array()(using classTag), Array(), implicitly[Order[T]])
 
-  def all[T: Order]: IntervalSeq[T] = new IntervalSeq[T](true, Array()(classTag), Array(), implicitly[Order[T]])
+  def all[T: Order]: IntervalSeq[T] = new IntervalSeq[T](true, Array()(using classTag), Array(), implicitly[Order[T]])
 
   implicit def apply[T: Order](value: Boolean): IntervalSeq[T] =
-    new IntervalSeq[T](value, Array()(classTag), Array(), implicitly[Order[T]])
+    new IntervalSeq[T](value, Array()(using classTag), Array(), implicitly[Order[T]])
 
   implicit def apply[T: Order](interval: Interval[T]): IntervalSeq[T] = interval.fold {
     case (Closed(a), Closed(b)) if a == b => point(a)
@@ -265,12 +266,12 @@ object IntervalSeq {
   }
 
   private def fromTo[T: Order](a: T, ak: Byte, b: T, bk: Byte) =
-    new IntervalSeq[T](false, Array(a, b)(classTag), Array(ak, bk), implicitly[Order[T]])
+    new IntervalSeq[T](false, Array(a, b)(using classTag), Array(ak, bk), implicitly[Order[T]])
 
   private def wrong: Nothing = throw new IllegalStateException("")
 
   private def singleton[T: Order](belowAll: Boolean, value: T, kind: Byte): IntervalSeq[T] =
-    new IntervalSeq(belowAll, Array(value)(classTag), Array(kind), implicitly[Order[T]])
+    new IntervalSeq(belowAll, Array(value)(using classTag), Array(kind), implicitly[Order[T]])
 
   final private val K00 = 0
 
@@ -320,7 +321,7 @@ object IntervalSeq {
 
     private[this] val order = lhs.order
 
-    private[this] val r = Array.ofDim[T](a.length + b.length)(classTag)
+    private[this] val r = Array.ofDim[T](a.length + b.length)(using classTag)
 
     private[this] val rk = new Array[Byte](a.length + b.length)
 
@@ -391,7 +392,7 @@ object IntervalSeq {
         fromA(a0, a1, bBelow(b0))
       } else {
         val am = (a0 + a1) / 2
-        val res = Searching.search(b, a(am), b0, b1 - 1)(order)
+        val res = Searching.search(b, a(am), b0, b1 - 1)(using order)
         if (res >= 0) {
           // same elements
           val bm = res
@@ -518,7 +519,7 @@ object IntervalSeq {
         fromA(a0, a1, bBelow(b0))
       } else {
         val am = (a0 + a1) / 2
-        val res = Searching.search(b, a(am), b0, b1 - 1)(order)
+        val res = Searching.search(b, a(am), b0, b1 - 1)(using order)
         if (res >= 0) {
           // same elements
           val bm = res

--- a/extras/src/main/scala/spire/math/extras/interval/IntervalTrie.scala
+++ b/extras/src/main/scala/spire/math/extras/interval/IntervalTrie.scala
@@ -258,7 +258,7 @@ object IntervalTrie {
         r.toLong
     }
     def intervalToIntervalSet(i: Interval[Long]): IntervalTrie[Long] = apply(i)
-    val intervals = text.split(';').map(Interval.apply).map(_.mapBounds(rationalToLong)(la))
+    val intervals = text.split(';').map(Interval.apply).map(_.mapBounds(rationalToLong)(using la))
     val simpleSets = intervals.map(intervalToIntervalSet)
     simpleSets.foldLeft(empty[Long])(_ | _)
   }

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -45,11 +45,8 @@ trait RingLaws[A] extends GroupLaws[A] {
   val nonZeroLaws: GroupLaws[A]
   def pred: Predicate[A]
 
-  def withPred(_pred: Predicate[A], replace: Boolean = true): RingLaws[A] = RingLaws[A](
-    Equ,
-    Arb,
-    if (replace) _pred else pred && _pred
-  )
+  def withPred(_pred: Predicate[A], replace: Boolean = true): RingLaws[A] =
+    RingLaws[A](using Equ, Arb, if (replace) _pred else pred && _pred)
 
   implicit def Arb: Arbitrary[A]
   implicit def Equ: Eq[A] = nonZeroLaws.Equ

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.11.6

--- a/tests/shared/src/test/scala/spire/SyntaxScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/SyntaxScalaCheckSuite.scala
@@ -73,7 +73,7 @@ class SyntaxScalaCheckSuite extends munit.ScalaCheckSuite with BaseSyntaxSuite {
   property("Semigroup syntax")(forAll { (a: String, b: String) => testSemigroupSyntax(a, b) })
   property("Monoid syntax")(forAll { (a: String, b: String) => testMonoidSyntax(a, b) })
   property("Group syntax")(forAll { (a: Int, b: Int) =>
-    testMonoidSyntax(a, b)(AdditiveGroup[Int].additive, implicitly)
+    testMonoidSyntax(a, b)(using AdditiveGroup[Int].additive, implicitly)
   })
   property("AdditiveSemigroup syntax")(forAll { (a: Int, b: Int) => testAdditiveSemigroupSyntax(a, b) })
   property("AdditiveMonoid syntax")(forAll { (a: Int, b: Int) => testAdditiveMonoidSyntax(a, b) })
@@ -89,7 +89,7 @@ class SyntaxScalaCheckSuite extends munit.ScalaCheckSuite with BaseSyntaxSuite {
   property("Ring syntax")(forAll { (a: Int, b: Int) => testRingSyntax(a, b) })
   property("EuclideanRing syntax")(forAll { (a: Int, b: NonZero[Int]) => testEuclideanRingSyntax(a, b.x) })
   property("Field syntax")(forAll { (a: Double, b: NonZero[Double]) =>
-    testFieldSyntax(a, b.x)(implicitly, spire.optional.totalfloat.TotalDoubleOrder)
+    testFieldSyntax(a, b.x)(using implicitly, spire.optional.totalfloat.TotalDoubleOrder)
   })
   property("NRoot syntax")(forAll { (a: Positive[Double]) => testNRootSyntax(a.x) })
   property("LeftModule syntax")(forAll { (v: Vector[Int], w: Vector[Int], a: Int) => testLeftModuleSyntax(v, w, a) })

--- a/tests/shared/src/test/scala/spire/laws/LawSuite.scala
+++ b/tests/shared/src/test/scala/spire/laws/LawSuite.scala
@@ -184,11 +184,13 @@ class LawSuite extends munit.DisciplineSuite {
 
   checkAll("List[Int]", GroupLaws[List[Int]].monoid)
   checkAll("Vector[Int]", GroupLaws[Vector[Int]].monoid)
-  checkAll("Set[Int]", GroupLaws[Set[Int]](spire.optional.genericEq.generic, implicitly).monoid)
+  checkAll("Set[Int]", GroupLaws[Set[Int]](using spire.optional.genericEq.generic, implicitly).monoid)
   checkAll("String[Int]", GroupLaws[String].monoid)
   checkAll("Array[Int]", GroupLaws[Array[Int]].monoid)
 
-  checkAll("Seq[String]", PartialGroupLaws[Seq[String]](spire.optional.genericEq.generic, implicitly).semigroupoid)
+  checkAll("Seq[String]",
+           PartialGroupLaws[Seq[String]](using spire.optional.genericEq.generic, implicitly).semigroupoid
+  )
   checkAll("Seq[Int]", PartialGroupLaws[Seq[Int]].groupoid)
 
   checkAll("String", VectorSpaceLaws[String, Int].metricSpace)

--- a/tests/shared/src/test/scala/spire/math/BinaryMergeScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/BinaryMergeScalaCheckSuite.scala
@@ -30,7 +30,7 @@ class BinaryMergeScalaCheckSuite extends munit.ScalaCheckSuite {
       Arrays.sort(b)
       Arrays.sort(r)
       val order = new CountingOrder[Int]
-      val r1 = BinaryMerge.merge(a, b)(order, ClassTag.Int)
+      val r1 = BinaryMerge.merge(a, b)(using order, ClassTag.Int)
       r1.corresponds(r)(_ == _)
     }
   }
@@ -42,9 +42,9 @@ class BinaryMergeScalaCheckSuite extends munit.ScalaCheckSuite {
       Arrays.sort(b)
       Arrays.sort(r)
       val o1 = new CountingOrder[Int]
-      val r1 = BinaryMerge.merge(a, b)(o1, ClassTag.Int)
+      val r1 = BinaryMerge.merge(a, b)(using o1, ClassTag.Int)
       val o2 = new CountingOrder[Int]
-      val r2 = BinaryMerge.merge(b, a)(o2, ClassTag.Int)
+      val r2 = BinaryMerge.merge(b, a)(using o2, ClassTag.Int)
       r1.corresponds(r2)(_ == _)
     }
   }

--- a/tests/shared/src/test/scala/spire/math/MergingSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/MergingSuite.scala
@@ -35,7 +35,7 @@ class MergingSuite extends munit.FunSuite {
     val a = Array.range(0, 100).map(_ * 2)
     val b = Array.range(1, 100).map(_ * 2)
     val o = new CountingOrder[Int]
-    val r = BinaryMerge.merge(a, b)(o, ClassTag.Int)
+    val r = BinaryMerge.merge(a, b)(using o, ClassTag.Int)
     assert(r.sorted.corresponds(r)(_ == _))
     assert(o.count < 200)
   }
@@ -44,8 +44,8 @@ class MergingSuite extends munit.FunSuite {
     val a = Array.range(0, 100).map(_ * 2)
     val b = Array.range(1, 100).map(_ * 3)
     val o = new CountingOrder[Int]
-    val r1 = LinearMerge.merge(a, b)(o, ClassTag.Int)
-    val r2 = LinearMerge.merge(b, a)(o, ClassTag.Int)
+    val r1 = LinearMerge.merge(a, b)(using o, ClassTag.Int)
+    val r2 = LinearMerge.merge(b, a)(using o, ClassTag.Int)
     assert(r1.sorted.corresponds(r1)(_ == _))
     assert(r2.sorted.corresponds(r2)(_ == _))
   }

--- a/tests/shared/src/test/scala/spire/math/RealScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/RealScalaCheckSuite.scala
@@ -133,7 +133,7 @@ class RealScalaCheckSuite extends munit.ScalaCheckSuite {
   }
 
   property("x.nroot(-k).pow(-k) = x") {
-    forAll(nonZeroSpireImplicit[Real](implicitly, implicitly, Arbitrary(realFromLongs)).arbitrary,
+    forAll(nonZeroSpireImplicit[Real](using implicitly, implicitly, Arbitrary(realFromLongs)).arbitrary,
            Arbitrary.arbitrary[Sized[Int, _1, _10]]
     ) { (x0: NonZero[Real], k: Sized[Int, _1, _10]) =>
       val x = x0.num.abs


### PR DESCRIPTION
For the Scala 3 CB, I've migrated this project to take into account all the changes to context bounds. From Scala 3.5.0, context bounds will desugar to `using` parameters and from 3.8.0, the stdlib will migrate too.